### PR TITLE
Add conversion primitives and basic tests

### DIFF
--- a/quasar_convert/CMakeLists.txt
+++ b/quasar_convert/CMakeLists.txt
@@ -1,0 +1,65 @@
+cmake_minimum_required(VERSION 3.20)
+project(quasar_convert LANGUAGES CXX)
+
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+
+option(QUASAR_USE_STIM "Enable Stim support" OFF)
+option(QUASAR_USE_MQT "Enable MQT DD support" OFF)
+
+include(FetchContent)
+
+find_package(Python3 COMPONENTS Interpreter Development.Module REQUIRED)
+
+if(QUASAR_USE_STIM)
+FetchContent_Declare(
+    stim
+    GIT_REPOSITORY https://github.com/quantumlib/Stim.git
+    GIT_TAG v1.15.0
+)
+FetchContent_Populate(stim)
+add_subdirectory(${stim_SOURCE_DIR} ${stim_BINARY_DIR} EXCLUDE_FROM_ALL)
+endif()
+
+if(QUASAR_USE_MQT)
+FetchContent_Declare(
+    mqtcore
+    GIT_REPOSITORY https://github.com/munich-quantum-toolkit/core.git
+    GIT_TAG v1.11.1
+    GIT_SHALLOW OFF
+    GIT_SUBMODULES "extern/dd_package"
+)
+FetchContent_Populate(mqtcore)
+add_subdirectory(${mqtcore_SOURCE_DIR}/extern/dd_package ${mqtcore_BINARY_DIR}/dd_package EXCLUDE_FROM_ALL)
+endif()
+
+FetchContent_Declare(
+    pybind11
+    GIT_REPOSITORY https://github.com/pybind/pybind11.git
+    GIT_TAG v2.11.1
+)
+FetchContent_MakeAvailable(pybind11)
+
+pybind11_add_module(quasar_convert MODULE conversion_engine.cpp binding.cpp)
+
+if(QUASAR_USE_STIM)
+target_link_libraries(quasar_convert PRIVATE libstim)
+target_compile_definitions(quasar_convert PRIVATE QUASAR_USE_STIM)
+endif()
+
+if(QUASAR_USE_MQT)
+target_link_libraries(quasar_convert PRIVATE MQT::DDPackage)
+target_include_directories(quasar_convert PRIVATE ${mqtcore_SOURCE_DIR}/extern/dd_package/include)
+target_compile_definitions(quasar_convert PRIVATE QUASAR_USE_MQT)
+endif()
+
+enable_testing()
+add_test(NAME conversion_engine_tests
+    COMMAND Python3::Interpreter ${CMAKE_CURRENT_SOURCE_DIR}/tests/test_engine.py)
+set_tests_properties(conversion_engine_tests PROPERTIES
+    ENVIRONMENT "PYTHONPATH=${CMAKE_CURRENT_BINARY_DIR}")
+
+add_test(NAME stim_mqt_tests
+    COMMAND Python3::Interpreter ${CMAKE_CURRENT_SOURCE_DIR}/tests/test_stim_mqt.py)
+set_tests_properties(stim_mqt_tests PROPERTIES
+    ENVIRONMENT "PYTHONPATH=${CMAKE_CURRENT_BINARY_DIR}")

--- a/quasar_convert/binding.cpp
+++ b/quasar_convert/binding.cpp
@@ -1,0 +1,43 @@
+#include <pybind11/pybind11.h>
+#include <pybind11/stl.h>
+#include <pybind11/complex.h>
+
+#include "conversion_engine.hpp"
+
+namespace py = pybind11;
+
+PYBIND11_MODULE(quasar_convert, m) {
+    py::class_<quasar::SSD>(m, "SSD")
+        .def(py::init<>())
+        .def_readwrite("boundary_qubits", &quasar::SSD::boundary_qubits)
+        .def_readwrite("top_s", &quasar::SSD::top_s);
+
+    py::enum_<quasar::Backend>(m, "Backend")
+        .value("StimTableau", quasar::Backend::StimTableau)
+        .value("DecisionDiagram", quasar::Backend::DecisionDiagram);
+
+    py::enum_<quasar::Primitive>(m, "Primitive")
+        .value("B2B", quasar::Primitive::B2B)
+        .value("LW", quasar::Primitive::LW)
+        .value("ST", quasar::Primitive::ST)
+        .value("Full", quasar::Primitive::Full);
+
+    py::class_<quasar::ConversionResult>(m, "ConversionResult")
+        .def_readonly("primitive", &quasar::ConversionResult::primitive)
+        .def_readonly("cost", &quasar::ConversionResult::cost);
+
+    py::class_<quasar::ConversionEngine>(m, "ConversionEngine")
+        .def(py::init<>())
+        .def("estimate_cost", &quasar::ConversionEngine::estimate_cost)
+        .def("extract_ssd", &quasar::ConversionEngine::extract_ssd)
+        .def("convert", &quasar::ConversionEngine::convert)
+#ifdef QUASAR_USE_STIM
+        .def("convert_boundary_to_tableau", &quasar::ConversionEngine::convert_boundary_to_tableau)
+        .def("try_build_tableau", &quasar::ConversionEngine::try_build_tableau)
+#endif
+#ifdef QUASAR_USE_MQT
+        .def("convert_boundary_to_dd", &quasar::ConversionEngine::convert_boundary_to_dd)
+#endif
+        ;
+}
+

--- a/quasar_convert/conversion_engine.cpp
+++ b/quasar_convert/conversion_engine.cpp
@@ -1,0 +1,120 @@
+#include "conversion_engine.hpp"
+
+#include <cmath>
+#include <algorithm>
+#include <complex>
+#include <vector>
+
+namespace quasar {
+
+ConversionEngine::ConversionEngine() {
+#ifdef QUASAR_USE_MQT
+    dd_pkg = std::make_unique<dd::Package<>>();
+#endif
+}
+
+std::pair<double, double> ConversionEngine::estimate_cost(std::size_t fragment_size, Backend backend) const {
+    // Simple placeholder model: cost grows linearly with fragment size.
+    double time_cost = static_cast<double>(fragment_size);
+    double memory_cost = static_cast<double>(fragment_size) * 0.1;
+    if (backend == Backend::DecisionDiagram) {
+        time_cost *= 1.5;  // assume DD conversion is slightly more expensive
+    }
+    return {time_cost, memory_cost};
+}
+
+SSD ConversionEngine::extract_ssd(const std::vector<uint32_t>& qubits, std::size_t s) const {
+    SSD ssd;
+    ssd.boundary_qubits = qubits;
+    ssd.top_s = s;
+    return ssd;
+}
+
+ConversionResult ConversionEngine::convert(const SSD& ssd) const {
+    const std::size_t boundary = ssd.boundary_qubits.size();
+    const std::size_t rank = ssd.top_s;
+
+    Primitive chosen;
+    double cost = 0.0;
+
+    // Heuristics inspired by the draft:
+    // - B2B for small rank and small boundary.
+    // - LW for larger boundaries but still within a manageable window.
+    // - ST for moderate/large rank where approximation is attempted.
+    // - Full as a last resort.
+    if (rank <= 4 && boundary <= 6) {
+        chosen = Primitive::B2B;
+        // Simulate cubic cost with nested loops.
+        for (std::size_t i = 0; i < rank; ++i) {
+            for (std::size_t j = 0; j < rank; ++j) {
+                for (std::size_t k = 0; k < rank; ++k) {
+                    cost += static_cast<double>((i + j + k) % 5);
+                }
+            }
+        }
+    } else if (boundary <= 10) {
+        chosen = Primitive::LW;
+        const std::size_t w = std::min<std::size_t>(boundary, 4);
+        const std::size_t dim = 1ULL << w;
+        std::vector<std::complex<double>> window(dim);
+        for (std::size_t i = 0; i < dim; ++i) {
+            window[i] = std::complex<double>(0.0, 0.0);
+        }
+        cost = static_cast<double>(dim);
+    } else if (rank <= 16) {
+        chosen = Primitive::ST;
+        const std::size_t chi = std::min<std::size_t>(rank, 8);
+        for (std::size_t i = 0; i < chi; ++i) {
+            for (std::size_t j = 0; j < chi; ++j) {
+                for (std::size_t k = 0; k < chi; ++k) {
+                    cost += static_cast<double>((i * j + k) % 7);
+                }
+            }
+        }
+    } else {
+        chosen = Primitive::Full;
+        const std::size_t dim = 1ULL << std::min<std::size_t>(boundary, 16);
+        std::vector<std::complex<double>> state(dim);
+        for (std::size_t i = 0; i < dim; ++i) {
+            state[i] = std::complex<double>(0.0, 0.0);
+        }
+        cost = static_cast<double>(dim);
+    }
+
+    return {chosen, cost};
+}
+
+#ifdef QUASAR_USE_MQT
+dd::Package<>::vEdge ConversionEngine::convert_boundary_to_dd(const SSD& ssd) const {
+    // Produce a zero-state decision diagram for the boundary qubits.
+    return dd_pkg->makeZeroState(static_cast<dd::QubitCount>(ssd.boundary_qubits.size()));
+}
+#endif
+
+#ifdef QUASAR_USE_STIM
+stim::Tableau ConversionEngine::convert_boundary_to_tableau(const SSD& ssd) const {
+    // Return an identity tableau of the requested size.
+    return stim::Tableau::identity(ssd.boundary_qubits.size());
+}
+
+std::optional<stim::Tableau> ConversionEngine::try_build_tableau(const std::vector<std::complex<double>>& state) const {
+    if (state.empty()) {
+        return std::nullopt;
+    }
+    // Check whether the state is |0...0>.
+    bool zero_state = std::abs(state[0] - std::complex<double>(1.0, 0.0)) < 1e-9;
+    for (std::size_t i = 1; i < state.size() && zero_state; ++i) {
+        if (std::abs(state[i]) > 1e-9) {
+            zero_state = false;
+        }
+    }
+    if (zero_state) {
+        std::size_t n = static_cast<std::size_t>(std::log2(state.size()));
+        return stim::Tableau::identity(n);
+    }
+    return std::nullopt;
+}
+#endif
+
+} // namespace quasar
+

--- a/quasar_convert/conversion_engine.hpp
+++ b/quasar_convert/conversion_engine.hpp
@@ -1,0 +1,74 @@
+#pragma once
+
+#include <optional>
+#include <utility>
+#include <vector>
+#include <complex>
+#include <memory>
+#include <cstddef>
+#include <cstdint>
+
+#ifdef QUASAR_USE_STIM
+#include <stim.h>
+#endif
+#ifdef QUASAR_USE_MQT
+#include <dd/Package.hpp>
+#endif
+
+namespace quasar {
+
+struct SSD {
+    std::vector<uint32_t> boundary_qubits;  // indices of qubits on the boundary
+    std::size_t top_s;                      // number of Schmidt vectors kept
+};
+
+enum class Backend {
+    StimTableau,
+    DecisionDiagram
+};
+
+// Conversion primitive selected by the engine. These correspond to the
+// strategies described in Table 2 of the QuASAr draft: boundary-to-boundary
+// (B2B), local-window (LW), staged (ST) and full extraction (Full).
+enum class Primitive {
+    B2B,
+    LW,
+    ST,
+    Full
+};
+
+struct ConversionResult {
+    Primitive primitive;   // primitive that was chosen
+    double cost;           // simplistic cost measure
+};
+
+class ConversionEngine {
+  public:
+    ConversionEngine();
+
+    std::pair<double, double> estimate_cost(std::size_t fragment_size, Backend backend) const;
+
+    SSD extract_ssd(const std::vector<uint32_t>& qubits, std::size_t s) const;
+
+    // Choose a conversion primitive for the given SSD and simulate the
+    // associated cost. The implementation uses simple heuristics based on the
+    // boundary size and Schmidt rank to select between B2B, LW, ST and Full.
+    ConversionResult convert(const SSD& ssd) const;
+
+#ifdef QUASAR_USE_MQT
+    dd::Package<>::vEdge convert_boundary_to_dd(const SSD& ssd) const;
+#endif
+
+#ifdef QUASAR_USE_STIM
+    stim::Tableau convert_boundary_to_tableau(const SSD& ssd) const;
+    std::optional<stim::Tableau> try_build_tableau(const std::vector<std::complex<double>>& state) const;
+#endif
+
+  private:
+#ifdef QUASAR_USE_MQT
+    std::unique_ptr<dd::Package<>> dd_pkg;
+#endif
+};
+
+} // namespace quasar
+

--- a/quasar_convert/tests/test_engine.py
+++ b/quasar_convert/tests/test_engine.py
@@ -1,0 +1,38 @@
+import unittest
+import quasar_convert as qc
+
+class ConversionPrimitiveTests(unittest.TestCase):
+    def setUp(self):
+        self.eng = qc.ConversionEngine()
+
+    def test_b2b_selected(self):
+        ssd = qc.SSD()
+        ssd.boundary_qubits = [0, 1]
+        ssd.top_s = 2
+        res = self.eng.convert(ssd)
+        self.assertEqual(res.primitive, qc.Primitive.B2B)
+        self.assertGreater(res.cost, 0)
+
+    def test_lw_selected(self):
+        ssd = qc.SSD()
+        ssd.boundary_qubits = list(range(8))
+        ssd.top_s = 2
+        res = self.eng.convert(ssd)
+        self.assertEqual(res.primitive, qc.Primitive.LW)
+
+    def test_st_selected(self):
+        ssd = qc.SSD()
+        ssd.boundary_qubits = list(range(20))
+        ssd.top_s = 8
+        res = self.eng.convert(ssd)
+        self.assertEqual(res.primitive, qc.Primitive.ST)
+
+    def test_full_selected(self):
+        ssd = qc.SSD()
+        ssd.boundary_qubits = list(range(20))
+        ssd.top_s = 32
+        res = self.eng.convert(ssd)
+        self.assertEqual(res.primitive, qc.Primitive.Full)
+
+if __name__ == '__main__':
+    unittest.main()

--- a/quasar_convert/tests/test_stim_mqt.py
+++ b/quasar_convert/tests/test_stim_mqt.py
@@ -1,0 +1,28 @@
+import unittest
+import quasar_convert as qc
+
+class OptionalBackendTests(unittest.TestCase):
+    def test_stim_conversion(self):
+        eng = qc.ConversionEngine()
+        if hasattr(eng, 'convert_boundary_to_tableau'):
+            ssd = qc.SSD()
+            ssd.boundary_qubits = [0, 1]
+            ssd.top_s = 2
+            tab = eng.convert_boundary_to_tableau(ssd)
+            self.assertEqual(tab.num_qubits, 2)
+        else:
+            self.skipTest('Stim support not built')
+
+    def test_dd_conversion(self):
+        eng = qc.ConversionEngine()
+        if hasattr(eng, 'convert_boundary_to_dd'):
+            ssd = qc.SSD()
+            ssd.boundary_qubits = [0, 1]
+            ssd.top_s = 2
+            edge = eng.convert_boundary_to_dd(ssd)
+            self.assertIsNotNone(edge)
+        else:
+            self.skipTest('MQT DD support not built')
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary
- implement B2B, LW, ST and full conversion heuristics in C++ `ConversionEngine`
- expose conversion primitives and results in Python bindings
- integrate Python-based unit tests and wire them into CMake

## Testing
- `cmake -S quasar_convert -B quasar_convert/build`
- `cmake --build quasar_convert/build -j2`
- `ctest --test-dir quasar_convert/build`


------
https://chatgpt.com/codex/tasks/task_e_68a86df9252883218bc71bb3a7e023b2