### PR TITLE
Implement method-based partitioning

### DIFF
--- a/quasar/partitioner.py
+++ b/quasar/partitioner.py
@@ -3,13 +3,34 @@ from __future__ import annotations
 from typing import Dict, List, Tuple, TYPE_CHECKING
 
 from .ssd import SSD, SSDPartition
+from .cost import Backend, CostEstimator, Cost
 
 if TYPE_CHECKING:  # pragma: no cover
-    from .circuit import Circuit
+    from .circuit import Circuit, Gate
+
+
+CLIFFORD_GATES = {
+    "I",
+    "ID",
+    "X",
+    "Y",
+    "Z",
+    "H",
+    "S",
+    "SDG",
+    "CX",
+    "CY",
+    "CZ",
+    "SWAP",
+    "CSWAP",
+}
 
 
 class Partitioner:
-    """Partition circuits into independent and equal-state subsystems."""
+    """Partition circuits and assign simulation methods."""
+
+    def __init__(self, estimator: CostEstimator | None = None):
+        self.estimator = estimator or CostEstimator()
 
     def partition(self, circuit: 'Circuit') -> SSD:
         if not circuit.gates:
@@ -22,7 +43,7 @@ class Partitioner:
         n = len(all_qubits)
 
         parent = list(range(n))
-        history: Dict[int, List[str]] = {i: [] for i in range(n)}
+        history: Dict[int, List['Gate']] = {i: [] for i in range(n)}
 
         def find(x: int) -> int:
             while parent[x] != x:
@@ -39,26 +60,65 @@ class Partitioner:
 
         for gate in gates:
             qubits = [q_to_idx[q] for q in gate.qubits]
-            name = gate.gate
             if len(qubits) > 1:
                 base = qubits[0]
                 for other in qubits[1:]:
                     union(base, other)
                 root = find(base)
-                history[root].append(name)
+                history[root].append(gate)
             else:
                 root = find(qubits[0])
-                history[root].append(name)
+                history[root].append(gate)
 
         subsystems: Dict[int, List[int]] = {find(i): [] for i in range(n)}
         for idx in range(n):
             subsystems[find(idx)].append(idx_to_q[idx])
 
-        root_info = [(tuple(sorted(qs)), tuple(history[r])) for r, qs in subsystems.items()]
+        root_info = [(tuple(sorted(qs)), history[r]) for r, qs in subsystems.items()]
 
-        hist_map: Dict[Tuple[str, ...], List[Tuple[int, ...]]] = {}
-        for qs, hist in root_info:
-            hist_map.setdefault(hist, []).append(qs)
+        hist_map: Dict[Tuple[str, ...], List[Tuple[Tuple[int, ...], List['Gate']]]] = {}
+        for qs, gate_list in root_info:
+            names = tuple(g.gate for g in gate_list)
+            hist_map.setdefault(names, []).append((qs, gate_list))
 
-        partitions = [SSDPartition(subsystems=tuple(groups), history=hist) for hist, groups in hist_map.items()]
+        partitions = []
+        for hist, group_list in hist_map.items():
+            qubit_groups = [qs for qs, _ in group_list]
+            sample_gates = group_list[0][1]
+            backend, cost = self._choose_backend(sample_gates, len(qubit_groups[0]))
+            partitions.append(
+                SSDPartition(
+                    subsystems=tuple(qubit_groups),
+                    history=hist,
+                    backend=backend,
+                    cost=cost,
+                )
+            )
         return SSD(partitions)
+
+    # ------------------------------------------------------------------
+    def _choose_backend(self, gates: List['Gate'], num_qubits: int) -> Tuple[Backend, 'Cost']:
+        """Select the best simulation backend for a partition."""
+
+        names = [g.gate.upper() for g in gates]
+        num_gates = len(gates)
+        if all(name in CLIFFORD_GATES for name in names):
+            backend = Backend.TABLEAU
+            cost = self.estimator.tableau(num_qubits, num_gates)
+            return backend, cost
+
+        multi = [g for g in gates if len(g.qubits) > 1]
+        local = all(len(g.qubits) == 2 and abs(g.qubits[0] - g.qubits[1]) == 1 for g in multi)
+        if local:
+            backend = Backend.MPS
+            cost = self.estimator.mps(num_qubits, num_gates, chi=4)
+            return backend, cost
+
+        if num_gates <= 2 ** num_qubits:
+            backend = Backend.DECISION_DIAGRAM
+            cost = self.estimator.decision_diagram(num_gates=num_gates, frontier=num_qubits)
+            return backend, cost
+
+        backend = Backend.STATEVECTOR
+        cost = self.estimator.statevector(num_qubits, num_gates)
+        return backend, cost

--- a/quasar/ssd.py
+++ b/quasar/ssd.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass, field
-from typing import Tuple, List
+from typing import Tuple, List, Dict
 
 from .cost import Backend, Cost
 
@@ -41,3 +41,10 @@ class SSD:
 
     def total_qubits(self) -> int:
         return sum(len(p.qubits) for p in self.partitions)
+
+    def by_backend(self) -> Dict[Backend, List[SSDPartition]]:
+        """Group partitions by their assigned simulation backend."""
+        groups: Dict[Backend, List[SSDPartition]] = {}
+        for part in self.partitions:
+            groups.setdefault(part.backend, []).append(part)
+        return groups

--- a/quasar/ssd.py
+++ b/quasar/ssd.py
@@ -1,19 +1,26 @@
 from __future__ import annotations
 
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import Tuple, List
+
+from .cost import Backend, Cost
 
 
 @dataclass(frozen=True)
 class SSDPartition:
-    """Represents a set of identical subsystems.
+    """Represents a set of identical subsystems along with metadata.
 
     Each entry in :attr:`subsystems` holds the qubits belonging to one
-    independent subsystem that is in the same state as the others.
+    independent subsystem that is in the same state as the others.  The
+    partition also records the execution history, the chosen simulation
+    backend and an estimated cost for simulating one representative
+    subsystem.
     """
 
     subsystems: Tuple[Tuple[int, ...], ...]
     history: Tuple[str, ...] = ()
+    backend: Backend = Backend.STATEVECTOR
+    cost: Cost = field(default_factory=lambda: Cost(time=0.0, memory=0.0))
 
     @property
     def multiplicity(self) -> int:

--- a/tests/test_method_selection.py
+++ b/tests/test_method_selection.py
@@ -44,3 +44,63 @@ def test_dense_statevector_selection():
     circ = Circuit.from_dict(gates)
     part = circ.ssd.partitions[0]
     assert part.backend == Backend.STATEVECTOR
+
+
+def test_partition_multiple_backends():
+    # Two identical Clifford subcircuits on qubits (0,1) and (2,3)
+    gates = []
+    for base in (0, 2):
+        gates.extend(
+            [
+                {"gate": "H", "qubits": [base]},
+                {"gate": "CX", "qubits": [base, base + 1]},
+                {"gate": "S", "qubits": [base + 1]},
+            ]
+        )
+    # Local non-Clifford chain on qubits (4,5,6) -> MPS
+    gates.extend(
+        [
+            {"gate": "T", "qubits": [4]},
+            {"gate": "CX", "qubits": [4, 5]},
+            {"gate": "T", "qubits": [5]},
+            {"gate": "CX", "qubits": [5, 6]},
+            {"gate": "T", "qubits": [6]},
+        ]
+    )
+    # Sparse non-local gates on qubits (7,9) -> decision diagram
+    gates.extend(
+        [
+            {"gate": "T", "qubits": [7]},
+            {"gate": "CX", "qubits": [7, 9]},
+            {"gate": "T", "qubits": [9]},
+        ]
+    )
+    # Dense, non-local two-qubit pattern on (10,12) -> statevector
+    base = [
+        {"gate": "T", "qubits": [10]},
+        {"gate": "CX", "qubits": [10, 12]},
+    ]
+    gates.extend(base * 5)  # 10 gates > 2**2
+
+    circ = Circuit.from_dict(gates)
+    groups = circ.ssd.by_backend()
+
+    assert set(groups.keys()) == {
+        Backend.TABLEAU,
+        Backend.MPS,
+        Backend.DECISION_DIAGRAM,
+        Backend.STATEVECTOR,
+    }
+
+    tableau = groups[Backend.TABLEAU][0]
+    assert tableau.multiplicity == 2
+    assert set(tableau.qubits) == {0, 1, 2, 3}
+
+    mps = groups[Backend.MPS][0]
+    assert set(mps.qubits) == {4, 5, 6}
+
+    dd = groups[Backend.DECISION_DIAGRAM][0]
+    assert set(dd.qubits) == {7, 9}
+
+    sv = groups[Backend.STATEVECTOR][0]
+    assert set(sv.qubits) == {10, 12}

--- a/tests/test_method_selection.py
+++ b/tests/test_method_selection.py
@@ -1,0 +1,46 @@
+from quasar import Circuit, Backend
+
+
+def test_clifford_tableau_selection():
+    gates = [
+        {"gate": "H", "qubits": [0]},
+        {"gate": "CX", "qubits": [0, 1]},
+        {"gate": "S", "qubits": [1]},
+    ]
+    circ = Circuit.from_dict(gates)
+    part = circ.ssd.partitions[0]
+    assert part.backend == Backend.TABLEAU
+
+
+def test_local_mps_selection():
+    gates = [
+        {"gate": "T", "qubits": [0]},
+        {"gate": "CX", "qubits": [0, 1]},
+        {"gate": "T", "qubits": [1]},
+        {"gate": "CX", "qubits": [1, 2]},
+    ]
+    circ = Circuit.from_dict(gates)
+    part = circ.ssd.partitions[0]
+    assert part.backend == Backend.MPS
+
+
+def test_sparse_dd_selection():
+    gates = [
+        {"gate": "T", "qubits": [0]},
+        {"gate": "CX", "qubits": [0, 2]},
+        {"gate": "T", "qubits": [2]},
+    ]
+    circ = Circuit.from_dict(gates)
+    part = circ.ssd.partitions[0]
+    assert part.backend == Backend.DECISION_DIAGRAM
+
+
+def test_dense_statevector_selection():
+    base = [
+        {"gate": "T", "qubits": [0]},
+        {"gate": "CX", "qubits": [0, 2]},
+    ]
+    gates = base * 5  # 10 gates > 2**3
+    circ = Circuit.from_dict(gates)
+    part = circ.ssd.partitions[0]
+    assert part.backend == Backend.STATEVECTOR


### PR DESCRIPTION
## Summary
- Implement SSD partitions that track backend and cost
- Add heuristic backend selection favouring tableau, then MPS or decision diagrams before statevector
- Test backend selection for various circuit structures

## Testing
- `PYTHONPATH=. pytest tests`

------
https://chatgpt.com/codex/tasks/task_e_68ac61274820832194431eea91aee378