### PR TITLE
Add simulation backend wrappers

### DIFF
--- a/quasar/__init__.py
+++ b/quasar/__init__.py
@@ -4,6 +4,13 @@ from .circuit import Gate, Circuit
 from .cost import Backend, Cost, ConversionEstimate, CostEstimator
 from .partitioner import Partitioner
 from .ssd import SSD, SSDPartition, ConversionLayer
+from .backends import (
+    Backend as SimulatorBackend,
+    StatevectorBackend,
+    MPSBackend,
+    StimBackend,
+    DecisionDiagramBackend,
+)
 
 __all__ = [
     "Gate",
@@ -16,4 +23,9 @@ __all__ = [
     "SSD",
     "SSDPartition",
     "ConversionLayer",
+    "SimulatorBackend",
+    "StatevectorBackend",
+    "MPSBackend",
+    "StimBackend",
+    "DecisionDiagramBackend",
 ]

--- a/quasar/backends/__init__.py
+++ b/quasar/backends/__init__.py
@@ -1,0 +1,15 @@
+"""Simulation backend adapters for QuASAr."""
+
+from .base import Backend
+from .statevector import StatevectorBackend
+from .mps import MPSBackend
+from .stim_backend import StimBackend
+from .mqt_dd import DecisionDiagramBackend
+
+__all__ = [
+    "Backend",
+    "StatevectorBackend",
+    "MPSBackend",
+    "StimBackend",
+    "DecisionDiagramBackend",
+]

--- a/quasar/backends/base.py
+++ b/quasar/backends/base.py
@@ -1,0 +1,56 @@
+from __future__ import annotations
+
+"""Common backend interface for QuASAr simulators."""
+
+from typing import Sequence, Dict, Any, TYPE_CHECKING
+
+from ..cost import Backend as BackendType
+
+if TYPE_CHECKING:  # pragma: no cover - type checking only
+    from ..ssd import SSD
+
+
+class Backend:
+    """Abstract simulation backend.
+
+    Concrete backends need to implement three core methods:
+
+    ``load``
+        Prepare the backend for a given number of qubits.
+    ``apply_gate``
+        Execute a quantum gate on the backend's internal state.
+    ``extract_ssd``
+        Convert the backend's state into a :class:`~quasar.ssd.SSD` object
+        so that the scheduler can reason about further conversions or
+        simulations.
+    """
+
+    #: Backend type exposed to the scheduler.
+    backend: BackendType = BackendType.STATEVECTOR
+
+    def load(self, num_qubits: int, **kwargs: Any) -> None:
+        """Initialise the simulator for ``num_qubits`` qubits."""
+        raise NotImplementedError
+
+    def apply_gate(
+        self,
+        name: str,
+        qubits: Sequence[int],
+        params: Dict[str, float] | None = None,
+    ) -> None:
+        """Execute ``name`` on ``qubits``.
+
+        Parameters
+        ----------
+        name:
+            Gate identifier (e.g. ``"H"`` or ``"CX"``).
+        qubits:
+            Target qubit indices.
+        params:
+            Optional gate parameters.
+        """
+        raise NotImplementedError
+
+    def extract_ssd(self) -> 'SSD':
+        """Return a :class:`~quasar.ssd.SSD` describing the backend state."""
+        raise NotImplementedError

--- a/quasar/backends/mps.py
+++ b/quasar/backends/mps.py
@@ -1,0 +1,106 @@
+from __future__ import annotations
+
+"""Matrix product state (MPS) simulator."""
+
+from dataclasses import dataclass, field
+from typing import Dict, Sequence
+import numpy as np
+
+from ..ssd import SSD, SSDPartition
+from ..cost import Backend as BackendType
+from .base import Backend
+
+
+@dataclass
+class MPSBackend(Backend):
+    """Lightweight MPS simulator for local circuits.
+
+    The implementation supports single-qubit gates and two-qubit gates on
+    neighbouring qubits.  Bond dimensions are truncated to ``chi`` during
+    two-qubit updates.
+    """
+
+    backend: BackendType = BackendType.MPS
+    tensors: list[np.ndarray] = field(default_factory=list, init=False)
+    num_qubits: int = field(default=0, init=False)
+    chi: int = field(default=16, init=False)
+    history: list[str] = field(default_factory=list, init=False)
+
+    _GATES: Dict[str, np.ndarray] = field(default_factory=lambda: {
+        "I": np.eye(2, dtype=complex),
+        "ID": np.eye(2, dtype=complex),
+        "X": np.array([[0, 1], [1, 0]], dtype=complex),
+        "Y": np.array([[0, -1j], [1j, 0]], dtype=complex),
+        "Z": np.array([[1, 0], [0, -1]], dtype=complex),
+        "H": 1 / np.sqrt(2) * np.array([[1, 1], [1, -1]], dtype=complex),
+        "S": np.array([[1, 0], [0, 1j]], dtype=complex),
+        "SDG": np.array([[1, 0], [0, -1j]], dtype=complex),
+        "CX": np.array(
+            [[1, 0, 0, 0], [0, 1, 0, 0], [0, 0, 0, 1], [0, 0, 1, 0]],
+            dtype=complex,
+        ),
+        "CZ": np.diag([1, 1, 1, -1]).astype(complex),
+        "SWAP": np.array(
+            [[1, 0, 0, 0], [0, 0, 1, 0], [0, 1, 0, 0], [0, 0, 0, 1]],
+            dtype=complex,
+        ),
+    }, init=False)
+
+    def load(self, num_qubits: int, **kwargs: dict) -> None:
+        self.num_qubits = num_qubits
+        self.chi = int(kwargs.get("chi", 16))
+        self.tensors = [np.zeros((1, 2, 1), dtype=complex) for _ in range(num_qubits)]
+        for tensor in self.tensors:
+            tensor[0, 0, 0] = 1.0
+        self.history.clear()
+
+    # ------------------------------------------------------------------
+    def apply_gate(
+        self,
+        name: str,
+        qubits: Sequence[int],
+        params: Dict[str, float] | None = None,
+    ) -> None:
+        gate = self._GATES.get(name.upper())
+        if gate is None:
+            raise ValueError(f"Unsupported gate {name}")
+        self.history.append(name.upper())
+
+        if len(qubits) == 1:
+            i = qubits[0]
+            A = self.tensors[i]
+            self.tensors[i] = np.tensordot(gate, A, axes=(1, 1)).transpose(1, 0, 2)
+            return
+
+        if len(qubits) == 2:
+            q0, q1 = qubits
+            if abs(q0 - q1) != 1:
+                raise NotImplementedError("MPS backend supports only nearest-neighbour gates")
+            i = min(q0, q1)
+            j = i + 1
+            left = self.tensors[i]
+            right = self.tensors[j]
+            theta = np.tensordot(left, right, axes=(2, 0))  # l,2,2,r
+            theta = np.tensordot(gate.reshape(2, 2, 2, 2), theta, axes=([2, 3], [1, 2]))
+            theta = theta.transpose(2, 0, 1, 3)
+            l, _, _, r = theta.shape
+            theta = theta.reshape(l * 2, 2 * r)
+            u, s, vh = np.linalg.svd(theta, full_matrices=False)
+            chi = min(self.chi, len(s))
+            u = u[:, :chi]
+            s = s[:chi]
+            vh = vh[:chi, :]
+            self.tensors[i] = u.reshape(l, 2, chi)
+            self.tensors[j] = (np.diag(s) @ vh).reshape(chi, 2, r)
+            return
+
+        raise NotImplementedError("Gate arity beyond 2 is not supported")
+
+    # ------------------------------------------------------------------
+    def extract_ssd(self) -> SSD:
+        part = SSDPartition(
+            subsystems=(tuple(range(self.num_qubits)),),
+            history=tuple(self.history),
+            backend=self.backend,
+        )
+        return SSD([part])

--- a/quasar/backends/mqt_dd.py
+++ b/quasar/backends/mqt_dd.py
@@ -1,0 +1,57 @@
+from __future__ import annotations
+
+"""Wrapper for the MQT decision diagram simulators."""
+
+from dataclasses import dataclass, field
+from typing import Dict, Sequence
+
+from mqt.core.ir import QuantumComputation
+import mqt.ddsim as ddsim
+
+from ..ssd import SSD, SSDPartition
+from ..cost import Backend as BackendType
+from .base import Backend
+
+
+@dataclass
+class DecisionDiagramBackend(Backend):
+    backend: BackendType = BackendType.DECISION_DIAGRAM
+    circuit: QuantumComputation | None = field(default=None, init=False)
+    num_qubits: int = field(default=0, init=False)
+    history: list[str] = field(default_factory=list, init=False)
+    state: object | None = field(default=None, init=False)
+
+    _ALIASES: Dict[str, str] = field(default_factory=lambda: {"SDG": "sdg"})
+
+    def load(self, num_qubits: int, **_: dict) -> None:
+        self.circuit = QuantumComputation(num_qubits)
+        self.num_qubits = num_qubits
+        self.history.clear()
+        self.state = None
+
+    def apply_gate(
+        self,
+        name: str,
+        qubits: Sequence[int],
+        params: Dict[str, float] | None = None,
+    ) -> None:
+        if self.circuit is None:
+            raise RuntimeError("Backend not initialised; call 'load' first")
+        lname = self._ALIASES.get(name.upper(), name.lower())
+        func = getattr(self.circuit, lname, None)
+        if func is None:
+            raise ValueError(f"Unsupported MQT DD gate {name}")
+        func(*qubits)
+        self.history.append(name.upper())
+
+    def extract_ssd(self) -> SSD:
+        if self.circuit is None:
+            raise RuntimeError("Backend not initialised; call 'load' first")
+        simulator = ddsim.CircuitSimulator(self.circuit)
+        self.state = simulator.get_constructed_dd()
+        part = SSDPartition(
+            subsystems=(tuple(range(self.num_qubits)),),
+            history=tuple(self.history),
+            backend=self.backend,
+        )
+        return SSD([part])

--- a/quasar/backends/statevector.py
+++ b/quasar/backends/statevector.py
@@ -1,0 +1,84 @@
+from __future__ import annotations
+
+"""Dense statevector simulation using NumPy."""
+
+from dataclasses import dataclass, field
+from typing import Dict, Sequence
+import numpy as np
+
+from ..ssd import SSD, SSDPartition
+from ..cost import Backend as BackendType
+from .base import Backend
+
+
+@dataclass
+class StatevectorBackend(Backend):
+    """Simple statevector simulator.
+
+    The implementation is intentionally minimal and optimised for clarity
+    rather than performance.  It supports a subset of common gates used in
+    the QuASAr tests.
+    """
+
+    backend: BackendType = BackendType.STATEVECTOR
+    state: np.ndarray | None = field(default=None, init=False)
+    num_qubits: int = field(default=0, init=False)
+    history: list[str] = field(default_factory=list, init=False)
+
+    _GATES: Dict[str, np.ndarray] = field(default_factory=lambda: {
+        "I": np.eye(2, dtype=complex),
+        "ID": np.eye(2, dtype=complex),
+        "X": np.array([[0, 1], [1, 0]], dtype=complex),
+        "Y": np.array([[0, -1j], [1j, 0]], dtype=complex),
+        "Z": np.array([[1, 0], [0, -1]], dtype=complex),
+        "H": 1 / np.sqrt(2) * np.array([[1, 1], [1, -1]], dtype=complex),
+        "S": np.array([[1, 0], [0, 1j]], dtype=complex),
+        "SDG": np.array([[1, 0], [0, -1j]], dtype=complex),
+        "CX": np.array(
+            [[1, 0, 0, 0], [0, 1, 0, 0], [0, 0, 0, 1], [0, 0, 1, 0]],
+            dtype=complex,
+        ),
+        "CZ": np.diag([1, 1, 1, -1]).astype(complex),
+        "SWAP": np.array(
+            [[1, 0, 0, 0], [0, 0, 1, 0], [0, 1, 0, 0], [0, 0, 0, 1]],
+            dtype=complex,
+        ),
+    }, init=False)
+
+    def load(self, num_qubits: int, **_: dict) -> None:
+        self.num_qubits = num_qubits
+        self.state = np.zeros(2 ** num_qubits, dtype=complex)
+        self.state[0] = 1.0
+        self.history.clear()
+
+    # ------------------------------------------------------------------
+    def apply_gate(
+        self,
+        name: str,
+        qubits: Sequence[int],
+        params: Dict[str, float] | None = None,
+    ) -> None:
+        if self.state is None:
+            raise RuntimeError("Backend not initialised; call 'load' first")
+
+        gate = self._GATES.get(name.upper())
+        if gate is None:
+            raise ValueError(f"Unsupported gate {name}")
+
+        self.history.append(name.upper())
+        k = len(qubits)
+        order = list(qubits) + [i for i in range(self.num_qubits) if i not in qubits]
+        state = self.state.reshape([2] * self.num_qubits).transpose(order)
+        state = state.reshape(2 ** k, -1)
+        state = gate @ state
+        state = state.reshape([2] * self.num_qubits).transpose(np.argsort(order))
+        self.state = state.reshape(-1)
+
+    # ------------------------------------------------------------------
+    def extract_ssd(self) -> SSD:
+        part = SSDPartition(
+            subsystems=(tuple(range(self.num_qubits)),),
+            history=tuple(self.history),
+            backend=self.backend,
+        )
+        return SSD([part])

--- a/quasar/backends/stim_backend.py
+++ b/quasar/backends/stim_backend.py
@@ -1,0 +1,65 @@
+from __future__ import annotations
+
+"""Wrapper around the Stim tableau simulator."""
+
+from dataclasses import dataclass, field
+from typing import Dict, Sequence
+import stim
+
+from ..ssd import SSD, SSDPartition
+from ..cost import Backend as BackendType
+from .base import Backend
+
+
+@dataclass
+class StimBackend(Backend):
+    backend: BackendType = BackendType.TABLEAU
+    simulator: stim.TableauSimulator | None = field(default=None, init=False)
+    num_qubits: int = field(default=0, init=False)
+    history: list[str] = field(default_factory=list, init=False)
+
+    _ALIASES: Dict[str, str] = field(
+        default_factory=lambda: {
+            "SDG": "s_dag",
+        }
+    )
+
+    def load(self, num_qubits: int, **_: dict) -> None:
+        self.simulator = stim.TableauSimulator()
+        self.num_qubits = num_qubits
+        self.history.clear()
+
+    def apply_gate(
+        self,
+        name: str,
+        qubits: Sequence[int],
+        params: Dict[str, float] | None = None,
+    ) -> None:
+        if self.simulator is None:
+            raise RuntimeError("Backend not initialised; call 'load' first")
+        lname = self._ALIASES.get(name.upper(), name.lower())
+        if lname == "i" or lname == "id":
+            self.history.append(name.upper())
+            return
+        if lname == "cswap":
+            c, a, b = qubits
+            self.simulator.cx(c, b)
+            self.simulator.cx(a, b)
+            self.simulator.cx(c, a)
+            self.simulator.cx(a, b)
+            self.simulator.cx(c, b)
+            self.history.append(name.upper())
+            return
+        func = getattr(self.simulator, lname, None)
+        if func is None:
+            raise ValueError(f"Unsupported Stim gate {name}")
+        func(*qubits)
+        self.history.append(name.upper())
+
+    def extract_ssd(self) -> SSD:
+        part = SSDPartition(
+            subsystems=(tuple(range(self.num_qubits)),),
+            history=tuple(self.history),
+            backend=self.backend,
+        )
+        return SSD([part])

--- a/tests/test_backends.py
+++ b/tests/test_backends.py
@@ -1,0 +1,34 @@
+import pytest
+
+from quasar.backends import (
+    StatevectorBackend,
+    MPSBackend,
+    StimBackend,
+    DecisionDiagramBackend,
+)
+
+
+def _exercise_backend(backend_cls):
+    backend = backend_cls()
+    backend.load(2)
+    backend.apply_gate("H", [0])
+    backend.apply_gate("CX", [0, 1])
+    ssd = backend.extract_ssd()
+    assert ssd.partitions[0].backend == backend.backend
+    assert ssd.partitions[0].history == ("H", "CX")
+
+
+def test_statevector_backend():
+    _exercise_backend(StatevectorBackend)
+
+
+def test_mps_backend():
+    _exercise_backend(MPSBackend)
+
+
+def test_stim_backend():
+    _exercise_backend(StimBackend)
+
+
+def test_decision_diagram_backend():
+    _exercise_backend(DecisionDiagramBackend)


### PR DESCRIPTION
## Summary
- Introduce unified backend interface for loading, gate execution, and SSD extraction
- Implement Stim, MQT DD, statevector, and MPS backend adapters
- Expose backends via package API and add basic smoke tests

## Testing
- `PYTHONPATH=. pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68ac7ea9c4948321b106facd85a68aa9