### PR TITLE
Add execution scheduler for backend coordination

### DIFF
--- a/quasar/__init__.py
+++ b/quasar/__init__.py
@@ -4,6 +4,7 @@ from .circuit import Gate, Circuit
 from .cost import Backend, Cost, ConversionEstimate, CostEstimator
 from .partitioner import Partitioner
 from .planner import Planner, PlanResult, PlanStep, DPEntry
+from .scheduler import Scheduler
 from .ssd import SSD, SSDPartition, ConversionLayer
 from .calibration import run_calibration, save_coefficients
 from .backends import (
@@ -26,6 +27,7 @@ __all__ = [
     "PlanResult",
     "PlanStep",
     "DPEntry",
+    "Scheduler",
     "SSD",
     "SSDPartition",
     "ConversionLayer",

--- a/quasar/backends/statevector.py
+++ b/quasar/backends/statevector.py
@@ -34,6 +34,7 @@ class StatevectorBackend(Backend):
         "H": 1 / np.sqrt(2) * np.array([[1, 1], [1, -1]], dtype=complex),
         "S": np.array([[1, 0], [0, 1j]], dtype=complex),
         "SDG": np.array([[1, 0], [0, -1j]], dtype=complex),
+        "T": np.array([[1, 0], [0, np.exp(1j * np.pi / 4)]], dtype=complex),
         "CX": np.array(
             [[1, 0, 0, 0], [0, 1, 0, 0], [0, 0, 0, 1], [0, 0, 1, 0]],
             dtype=complex,

--- a/quasar/scheduler.py
+++ b/quasar/scheduler.py
@@ -1,0 +1,104 @@
+from __future__ import annotations
+
+"""Execution scheduler for QuASAr."""
+
+from dataclasses import dataclass
+from typing import Callable, Dict, List
+
+from .planner import Planner, PlanStep
+from .cost import Backend
+from .circuit import Circuit
+from .backends import (
+    StatevectorBackend,
+    MPSBackend,
+    StimBackend,
+    DecisionDiagramBackend,
+)
+from quasar_convert import ConversionEngine
+
+# Type alias for cost monitoring hook
+CostHook = Callable[[PlanStep, float], bool]
+
+
+@dataclass
+class Scheduler:
+    """Coordinate execution of planned circuit partitions."""
+
+    planner: Planner | None = None
+    conversion_engine: ConversionEngine | None = None
+    backends: Dict[Backend, object] | None = None
+
+    def __post_init__(self) -> None:
+        self.planner = self.planner or Planner()
+        self.conversion_engine = self.conversion_engine or ConversionEngine()
+        if self.backends is None:
+            self.backends = {
+                Backend.STATEVECTOR: StatevectorBackend(),
+                Backend.MPS: MPSBackend(),
+                Backend.TABLEAU: StimBackend(),
+                Backend.DECISION_DIAGRAM: DecisionDiagramBackend(),
+            }
+
+    # ------------------------------------------------------------------
+    def run(self, circuit: Circuit, monitor: CostHook | None = None) -> None:
+        """Execute ``circuit`` according to a planner-derived schedule.
+
+        Parameters
+        ----------
+        circuit:
+            Circuit to simulate.
+        monitor:
+            Optional callback receiving ``(step, cost)``.  If the callback
+            returns ``True`` the scheduler re-plans the remaining gates starting
+            from ``step.end``.
+        """
+
+        plan = self.planner.plan(circuit)
+        steps: List[PlanStep] = list(plan.steps)
+
+        current_backend = None
+        current_sim = None
+        i = 0
+        while i < len(steps):
+            step = steps[i]
+            target = step.backend
+            backend = self.backends[target]
+
+            # Prepare backend and perform conversions when switching
+            if current_sim is None:
+                backend.load(circuit.num_qubits)
+            elif backend is not current_sim:
+                ssd = current_sim.extract_ssd()
+                self.conversion_engine.convert(ssd)
+                backend.load(circuit.num_qubits)
+            current_sim = backend
+            current_backend = target
+
+            for gate in circuit.gates[step.start : step.end]:
+                current_sim.apply_gate(gate.gate, gate.qubits, gate.params)
+
+            if monitor:
+                frag = circuit.gates[step.start : step.end]
+                qubits = {q for g in frag for q in g.qubits}
+                cost = self._estimate_cost(target, len(qubits), len(frag))
+                if monitor(step, cost):
+                    remaining = Circuit(circuit.gates[step.end :])
+                    replanned = self.planner.plan(remaining)
+                    offset = step.end
+                    new_steps = [
+                        PlanStep(s.start + offset, s.end + offset, s.backend)
+                        for s in replanned.steps
+                    ]
+                    steps = steps[: i + 1] + new_steps
+            i += 1
+
+    # ------------------------------------------------------------------
+    def _estimate_cost(self, backend: Backend, n: int, m: int) -> float:
+        est = self.planner.estimator
+        if backend == Backend.TABLEAU:
+            return est.tableau(n, m).time
+        if backend == Backend.MPS:
+            return est.mps(n, m, chi=4).time
+        if backend == Backend.DECISION_DIAGRAM:
+            return est.decision_diagram(num_gates=m, frontier=n).time
+        return est.statevector(n, m).time

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -1,0 +1,57 @@
+from quasar import Circuit, Scheduler, Planner
+from quasar_convert import ConversionEngine
+
+
+class CountingConversionEngine(ConversionEngine):
+    def __init__(self):
+        self.calls = 0
+
+    def convert(self, ssd):
+        self.calls += 1
+        return super().convert(self.extract_ssd([], 0))
+
+
+def build_switch_circuit():
+    return Circuit([
+        {"gate": "H", "qubits": [0]},
+        {"gate": "CX", "qubits": [0, 1]},
+        {"gate": "H", "qubits": [0]},
+        {"gate": "H", "qubits": [1]},
+        {"gate": "CX", "qubits": [0, 1]},
+        {"gate": "T", "qubits": [0]},
+    ])
+
+
+def test_scheduler_triggers_conversion():
+    engine = CountingConversionEngine()
+    scheduler = Scheduler(conversion_engine=engine)
+    circuit = build_switch_circuit()
+    scheduler.run(circuit)
+    assert engine.calls == 1
+
+
+class CountingPlanner(Planner):
+    def __init__(self):
+        super().__init__()
+        self.calls = 0
+
+    def plan(self, circuit):
+        self.calls += 1
+        return super().plan(circuit)
+
+
+def test_scheduler_reoptimises_when_requested():
+    planner = CountingPlanner()
+    scheduler = Scheduler(planner=planner, conversion_engine=CountingConversionEngine())
+    circuit = build_switch_circuit()
+
+    triggered = {"done": False}
+
+    def monitor(step, cost):
+        if not triggered["done"]:
+            triggered["done"] = True
+            return True
+        return False
+
+    scheduler.run(circuit, monitor=monitor)
+    assert planner.calls >= 2


### PR DESCRIPTION
## Summary
- introduce a Scheduler to execute planner-derived partitions and manage backend switching
- support cost monitoring hooks with optional re-planning and on-demand conversions via ConversionEngine
- extend statevector backend with T gate and expose Scheduler via package API

## Testing
- `python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68ad23184b5c8321a1cf38e1e63cad32