### PR TITLE
Handle gates crossing fragment boundaries

### DIFF
--- a/quasar/backends/mps.py
+++ b/quasar/backends/mps.py
@@ -61,10 +61,16 @@ class MPSBackend(Backend):
         qubits: Sequence[int],
         params: Dict[str, float] | None = None,
     ) -> None:
-        gate = self._GATES.get(name.upper())
+        lname = name.upper()
+        if lname == "BRIDGE":
+            # Bridge tensors are identities for this reference backend.
+            self.history.append(lname)
+            return
+
+        gate = self._GATES.get(lname)
         if gate is None:
             raise ValueError(f"Unsupported gate {name}")
-        self.history.append(name.upper())
+        self.history.append(lname)
 
         if len(qubits) == 1:
             i = qubits[0]

--- a/quasar/backends/mqt_dd.py
+++ b/quasar/backends/mqt_dd.py
@@ -38,6 +38,9 @@ class DecisionDiagramBackend(Backend):
         if self.circuit is None:
             raise RuntimeError("Backend not initialised; call 'load' first")
         lname = self._ALIASES.get(name.upper(), name.lower())
+        if lname == "bridge":
+            self.history.append(name.upper())
+            return
         func = getattr(self.circuit, lname, None)
         if func is None:
             raise ValueError(f"Unsupported MQT DD gate {name}")

--- a/quasar/backends/statevector.py
+++ b/quasar/backends/statevector.py
@@ -61,12 +61,18 @@ class StatevectorBackend(Backend):
     ) -> None:
         if self.state is None:
             raise RuntimeError("Backend not initialised; call 'load' first")
+        lname = name.upper()
+        if lname == "BRIDGE":
+            # Bridge tensors act as identities in this toy backend but we record
+            # their application for testing purposes.
+            self.history.append(lname)
+            return
 
-        gate = self._GATES.get(name.upper())
+        gate = self._GATES.get(lname)
         if gate is None:
             raise ValueError(f"Unsupported gate {name}")
 
-        self.history.append(name.upper())
+        self.history.append(lname)
         k = len(qubits)
         order = list(qubits) + [i for i in range(self.num_qubits) if i not in qubits]
         state = self.state.reshape([2] * self.num_qubits).transpose(order)

--- a/quasar/backends/stim_backend.py
+++ b/quasar/backends/stim_backend.py
@@ -38,7 +38,7 @@ class StimBackend(Backend):
         if self.simulator is None:
             raise RuntimeError("Backend not initialised; call 'load' first")
         lname = self._ALIASES.get(name.upper(), name.lower())
-        if lname == "i" or lname == "id":
+        if lname in {"i", "id", "bridge"}:
             self.history.append(name.upper())
             return
         if lname == "cswap":

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -1,14 +1,20 @@
-from quasar import Circuit, Scheduler, Planner
+from quasar import Circuit, Scheduler, Planner, Backend, CostEstimator
 from quasar_convert import ConversionEngine
 
 
 class CountingConversionEngine(ConversionEngine):
     def __init__(self):
+        super().__init__()
         self.calls = 0
+        self.bridges = 0
 
     def convert(self, ssd):
         self.calls += 1
         return super().convert(self.extract_ssd([], 0))
+
+    def build_bridge_tensor(self, left, right):
+        self.bridges += 1
+        return super().build_bridge_tensor(left, right)
 
 
 def build_switch_circuit():
@@ -55,3 +61,35 @@ def test_scheduler_reoptimises_when_requested():
 
     scheduler.run(circuit, monitor=monitor)
     assert planner.calls >= 2
+
+
+def build_cross_circuit():
+    return Circuit([
+        {"gate": "CX", "qubits": [0, 1]},
+        {"gate": "CX", "qubits": [0, 1]},
+        {"gate": "T", "qubits": [2]},
+        {"gate": "CX", "qubits": [1, 2]},
+    ])
+
+
+def test_scheduler_builds_bridge_for_cross_fragment_gate():
+    coeff = {
+        "b2b_svd": 0.0,
+        "b2b_copy": 0.0,
+        "ingest_dd": 0.0,
+        "ingest_tab": 0.0,
+        "ingest_sv": 0.0,
+        "dd_gate": 10.0,
+    }
+    planner = Planner(CostEstimator(coeff))
+    engine = CountingConversionEngine()
+    scheduler = Scheduler(planner=planner, conversion_engine=engine)
+    circuit = build_cross_circuit()
+    scheduler.run(circuit)
+    assert engine.bridges == 1
+    sv_hist = scheduler.backends[Backend.STATEVECTOR].history
+    tab_hist = scheduler.backends[Backend.TABLEAU].history
+    assert "BRIDGE" in sv_hist
+    assert "BRIDGE" in tab_hist
+    assert sv_hist.count("CX") >= 1
+    assert tab_hist.count("CX") >= 1


### PR DESCRIPTION
## Summary
- track fragment qubits in `Scheduler.run` and build bridge tensors for gates spanning fragments
- allow backends to accept a `BRIDGE` operation representing inter-fragment tensors
- regression test for cross-fragment gate bridging

## Testing
- `python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68ad65148b30832189e20a950a74bafa