### PR TITLE
feat: add state ingestion across backends

### DIFF
--- a/quasar/backends/base.py
+++ b/quasar/backends/base.py
@@ -51,6 +51,10 @@ class Backend:
         """
         raise NotImplementedError
 
+    def ingest_state(self, data: Any) -> None:
+        """Ingest an external state representation into the backend."""
+        raise NotImplementedError
+
     def extract_ssd(self) -> 'SSD':
         """Return a :class:`~quasar.ssd.SSD` describing the backend state."""
         raise NotImplementedError

--- a/quasar/backends/mps.py
+++ b/quasar/backends/mps.py
@@ -54,6 +54,12 @@ class MPSBackend(Backend):
             tensor[0, 0, 0] = 1.0
         self.history.clear()
 
+    def ingest_state(self, data: Sequence[np.ndarray]) -> None:
+        """Ingest an MPS represented as a sequence of tensors."""
+        self.tensors = [np.array(t, dtype=complex) for t in data]
+        self.num_qubits = len(self.tensors)
+        self.history.clear()
+
     # ------------------------------------------------------------------
     def apply_gate(
         self,

--- a/quasar/backends/mqt_dd.py
+++ b/quasar/backends/mqt_dd.py
@@ -29,6 +29,12 @@ class DecisionDiagramBackend(Backend):
         self.history.clear()
         self.state = None
 
+    def ingest_state(self, data: object) -> None:
+        """Ingest a decision-diagram handle ``data`` into the backend."""
+        self.state = data
+        self.circuit = None
+        self.history.clear()
+
     def apply_gate(
         self,
         name: str,

--- a/quasar/backends/statevector.py
+++ b/quasar/backends/statevector.py
@@ -52,6 +52,13 @@ class StatevectorBackend(Backend):
         self.state[0] = 1.0
         self.history.clear()
 
+    def ingest_state(self, data: np.ndarray) -> None:
+        """Ingest a dense statevector ``data`` into the backend."""
+        arr = np.asarray(data, dtype=complex)
+        self.state = arr.copy()
+        self.num_qubits = int(np.log2(arr.size))
+        self.history.clear()
+
     # ------------------------------------------------------------------
     def apply_gate(
         self,

--- a/quasar/backends/stim_backend.py
+++ b/quasar/backends/stim_backend.py
@@ -29,6 +29,13 @@ class StimBackend(Backend):
         self.num_qubits = num_qubits
         self.history.clear()
 
+    def ingest_state(self, data: stim.Tableau) -> None:
+        """Ingest a Stim tableau ``data`` into the simulator."""
+        self.simulator = stim.TableauSimulator()
+        self.simulator.set_inverse_tableau(data)
+        self.num_qubits = len(data)
+        self.history.clear()
+
     def apply_gate(
         self,
         name: str,

--- a/tests/test_backends.py
+++ b/tests/test_backends.py
@@ -1,4 +1,8 @@
 import pytest
+import numpy as np
+import stim
+import mqt.ddsim as ddsim
+from mqt.core.ir import QuantumComputation
 
 from quasar.backends import (
     StatevectorBackend,
@@ -32,3 +36,43 @@ def test_stim_backend():
 
 def test_decision_diagram_backend():
     _exercise_backend(DecisionDiagramBackend)
+
+
+def test_statevector_ingest():
+    state = np.array([0.0, 1.0, 0.0, 0.0], dtype=complex)
+    backend = StatevectorBackend()
+    backend.ingest_state(state)
+    assert backend.num_qubits == 2
+    assert np.allclose(backend.state, state)
+
+
+def test_mps_ingest():
+    tensors = [np.zeros((1, 2, 1), dtype=complex) for _ in range(2)]
+    tensors[0][0, 0, 0] = 1.0
+    tensors[1][0, 1, 0] = 1.0
+    backend = MPSBackend()
+    backend.ingest_state(tensors)
+    assert backend.num_qubits == 2
+    assert np.allclose(backend.tensors[1], tensors[1])
+
+
+def test_stim_ingest():
+    circuit = stim.Circuit("H 0\nCX 0 1")
+    tableau = stim.Tableau.from_circuit(circuit)
+    backend = StimBackend()
+    backend.ingest_state(tableau)
+    assert backend.num_qubits == 2
+    assert backend.simulator.current_inverse_tableau() == tableau
+
+
+def test_decision_diagram_ingest():
+    qc = QuantumComputation(2)
+    qc.h(0)
+    qc.cx(0, 1)
+    sim = ddsim.CircuitSimulator(qc)
+    state = sim.get_constructed_dd()
+    backend = DecisionDiagramBackend()
+    backend.load(2)
+    backend.ingest_state(state)
+    assert backend.state == state
+    assert backend.num_qubits == 2


### PR DESCRIPTION
## Summary
- add `ingest_state` abstract method to backend interface
- implement state ingestion for statevector, MPS, Stim, and decision diagram backends
- test ingestion paths for all backends

## Testing
- `PYTHONPATH=. pytest`

------
https://chatgpt.com/codex/tasks/task_e_68ad6515255083219171f5c119c39481