### PR TITLE
Consolidate dependencies in pyproject

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,6 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install -r quasar/requirements.txt
           pip install -e .
       - name: Run tests
         run: |

--- a/README.md
+++ b/README.md
@@ -16,3 +16,10 @@ pip install .
 If a compiler is not available the build will fall back to a pure Python stub
 implementation with reduced performance but identical APIs.
 
+The project's dependencies are declared in `pyproject.toml`. For development,
+including running the test suite, install the package with its testing extras:
+
+```bash
+pip install -e .[test]
+```
+

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,7 @@ dependencies = [
     "qiskit==2.1.2",
     "qiskit-qasm3-import==0.6.0",
     "stim==1.15.0",
-    "pytest====8.4.1",
+    "pytest==8.4.1",
 ]
 
 [project.optional-dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,6 +14,7 @@ dependencies = [
     "qiskit==2.1.2",
     "qiskit-qasm3-import==0.6.0",
     "stim==1.15.0",
+    "pytest====8.4.1",
 ]
 
 [project.optional-dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,17 @@ name = "quasar"
 version = "0.1.0"
 description = "QuASAr simulation utilities"
 requires-python = ">=3.8"
-dependencies = ["numpy"]
+dependencies = [
+    "numpy",
+    "mqt-core==3.2.1",
+    "mqt.ddsim==2.0.0",
+    "qiskit==2.1.2",
+    "qiskit-qasm3-import==0.6.0",
+    "stim==1.15.0",
+]
+
+[project.optional-dependencies]
+test = ["pytest==8.4.1"]
 
 [tool.scikit-build]
 # Include the Python packages in the wheel and place the compiled extension

--- a/quasar/requirements.txt
+++ b/quasar/requirements.txt
@@ -1,6 +1,0 @@
-mqt-core==3.2.1
-mqt.ddsim==2.0.0
-pytest==8.4.1
-qiskit==2.1.2
-qiskit-qasm3-import==0.6.0
-stim==1.15.0


### PR DESCRIPTION
## Summary
- remove redundant requirements.txt and rely solely on pyproject
- declare runtime and test dependencies in pyproject.toml
- document dependency management and test extras in README

## Testing
- `pip install -e .[test]`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68ad76cbe6d483218d7dfd1a7818902b