### PR TITLE
Expose dd edge wrapper with qubit count

### DIFF
--- a/quasar/backends/mqt_dd.py
+++ b/quasar/backends/mqt_dd.py
@@ -32,10 +32,11 @@ class DecisionDiagramBackend(Backend):
     def ingest(self, state: object) -> None:
         """Initialise the backend from an existing decision diagram state."""
         n = getattr(state, "num_qubits", None)
-        if n is None:
+        edge = getattr(state, "edge", None)
+        if n is None or edge is None:
             raise TypeError("Unsupported state for decision diagram backend")
         self.num_qubits = int(n)
-        self.state = state
+        self.state = edge
         self.circuit = QuantumComputation(self.num_qubits)
         self.history.clear()
 

--- a/quasar_convert/__init__.py
+++ b/quasar_convert/__init__.py
@@ -14,6 +14,7 @@ try:  # pragma: no cover - exercised when the extension is available
         Backend,
         Primitive,
         ConversionResult,
+        DDEdge,
         ConversionEngine as _CEngine,
     )
 
@@ -74,6 +75,7 @@ try:  # pragma: no cover - exercised when the extension is available
         "Primitive",
         "ConversionResult",
         "ConversionEngine",
+        "DDEdge",
     ]
 except Exception:  # pragma: no cover - exercised when extension missing
     from dataclasses import dataclass
@@ -101,6 +103,11 @@ except Exception:  # pragma: no cover - exercised when extension missing
     class ConversionResult:
         primitive: Primitive
         cost: float
+
+    @dataclass
+    class DDEdge:
+        edge: object | None = None
+        num_qubits: int = 0
 
     class ConversionEngine:
         def estimate_cost(self, fragment_size: int, backend: Backend) -> Tuple[float, float]:
@@ -184,7 +191,7 @@ except Exception:  # pragma: no cover - exercised when extension missing
             return Tableau(len(ssd.boundary_qubits or []))
 
         def convert_boundary_to_dd(self, ssd: SSD):
-            return object()
+            return DDEdge(edge=object(), num_qubits=len(ssd.boundary_qubits or []))
 
         def learn_stabilizer(self, state: List[complex]):
             if not state:
@@ -218,5 +225,6 @@ except Exception:  # pragma: no cover - exercised when extension missing
         "Primitive",
         "ConversionResult",
         "ConversionEngine",
+        "DDEdge",
     ]
 

--- a/quasar_convert/tests/test_stim_mqt.py
+++ b/quasar_convert/tests/test_stim_mqt.py
@@ -20,7 +20,14 @@ class OptionalBackendTests(unittest.TestCase):
             ssd.boundary_qubits = [0, 1]
             ssd.top_s = 2
             edge = eng.convert_boundary_to_dd(ssd)
-            self.assertIsNotNone(edge)
+            self.assertEqual(edge.num_qubits, 2)
+            try:
+                from quasar.backends import DecisionDiagramBackend
+            except Exception:
+                self.skipTest('MQT DD backend not available')
+            backend = DecisionDiagramBackend()
+            backend.ingest(edge)
+            self.assertEqual(backend.num_qubits, 2)
         else:
             self.skipTest('MQT DD support not built')
 


### PR DESCRIPTION
## Summary
- expose a `DDEdge` wrapper for `dd::vEdge` including qubit count
- allow `DecisionDiagramBackend.ingest` to accept the wrapper
- test round-trip decision diagram conversion

## Testing
- `pytest quasar_convert/tests/test_stim_mqt.py::OptionalBackendTests::test_dd_conversion -q`
- `pytest tests/test_backends.py -q`
- `pytest quasar_convert/tests/test_stim_mqt.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68ad796603b48321bf6c321dd8dbc059