### PR TITLE
Add support for parameterized rotation and phase gates

### DIFF
--- a/quasar/backends/mqt_dd.py
+++ b/quasar/backends/mqt_dd.py
@@ -21,7 +21,7 @@ class DecisionDiagramBackend(Backend):
     history: list[str] = field(default_factory=list, init=False)
     state: object | None = field(default=None, init=False)
 
-    _ALIASES: Dict[str, str] = field(default_factory=lambda: {"SDG": "sdg"})
+    _ALIASES: Dict[str, str] = field(default_factory=lambda: {"SDG": "sdg", "U1": "p"})
 
     def load(self, num_qubits: int, **_: dict) -> None:
         self.circuit = QuantumComputation(num_qubits)
@@ -59,7 +59,8 @@ class DecisionDiagramBackend(Backend):
         func = getattr(self.circuit, lname, None)
         if func is None:
             raise ValueError(f"Unsupported MQT DD gate {name}")
-        func(*qubits)
+        args = [float(v) for v in params.values()] if params else []
+        func(*args, *qubits)
         self.history.append(name.upper())
 
     def extract_ssd(self) -> SSD:

--- a/quasar/backends/statevector.py
+++ b/quasar/backends/statevector.py
@@ -64,6 +64,65 @@ class StatevectorBackend(Backend):
         self.history.clear()
 
     # ------------------------------------------------------------------
+    def _param(self, params: Dict[str, float] | None, idx: int) -> float:
+        if not params:
+            return 0.0
+        key = f"param{idx}"
+        if key in params:
+            return float(params[key])
+        values = list(params.values())
+        return float(values[idx]) if idx < len(values) else 0.0
+
+    def _gate_matrix(self, name: str, params: Dict[str, float] | None) -> np.ndarray:
+        gate = self._GATES.get(name)
+        if gate is not None:
+            return gate
+
+        p0 = self._param(params, 0)
+        if name == "RX":
+            c = np.cos(p0 / 2)
+            s = np.sin(p0 / 2)
+            return np.array([[c, -1j * s], [-1j * s, c]], dtype=complex)
+        if name == "RY":
+            c = np.cos(p0 / 2)
+            s = np.sin(p0 / 2)
+            return np.array([[c, -s], [s, c]], dtype=complex)
+        if name == "RZ":
+            return np.diag([np.exp(-1j * p0 / 2), np.exp(1j * p0 / 2)]).astype(complex)
+        if name in {"P", "U1"}:
+            return np.diag([1.0, np.exp(1j * p0)]).astype(complex)
+        if name == "RZZ":
+            return np.diag(
+                [
+                    np.exp(-1j * p0 / 2),
+                    np.exp(1j * p0 / 2),
+                    np.exp(1j * p0 / 2),
+                    np.exp(-1j * p0 / 2),
+                ]
+            ).astype(complex)
+        if name == "U2":
+            p1 = self._param(params, 1)
+            return (1 / np.sqrt(2)) * np.array(
+                [
+                    [1.0, -np.exp(1j * p1)],
+                    [np.exp(1j * p0), np.exp(1j * (p0 + p1))],
+                ],
+                dtype=complex,
+            )
+        if name in {"U", "U3"}:
+            p1 = self._param(params, 1)
+            p2 = self._param(params, 2)
+            c = np.cos(p0 / 2)
+            s = np.sin(p0 / 2)
+            return np.array(
+                [
+                    [c, -np.exp(1j * p2) * s],
+                    [np.exp(1j * p1) * s, np.exp(1j * (p1 + p2)) * c],
+                ],
+                dtype=complex,
+            )
+        raise ValueError(f"Unsupported gate {name}")
+
     def apply_gate(
         self,
         name: str,
@@ -73,11 +132,10 @@ class StatevectorBackend(Backend):
         if self.state is None:
             raise RuntimeError("Backend not initialised; call 'load' first")
 
-        gate = self._GATES.get(name.upper())
-        if gate is None:
-            raise ValueError(f"Unsupported gate {name}")
+        lname = name.upper()
+        gate = self._gate_matrix(lname, params)
 
-        self.history.append(name.upper())
+        self.history.append(lname)
         k = len(qubits)
         order = list(qubits) + [i for i in range(self.num_qubits) if i not in qubits]
         state = self.state.reshape([2] * self.num_qubits).transpose(order)

--- a/tests/test_parameterized_gates.py
+++ b/tests/test_parameterized_gates.py
@@ -1,0 +1,49 @@
+import numpy as np
+from qiskit import QuantumCircuit
+from qiskit.quantum_info import Statevector
+from qiskit.circuit.library import U1Gate, U2Gate, UGate
+
+from quasar.circuit import Circuit
+from quasar.backends import StatevectorBackend, MPSBackend, DecisionDiagramBackend
+
+
+def _run_backend(cls, circuit):
+    backend = cls()
+    backend.load(circuit.num_qubits)
+    for g in circuit.gates:
+        backend.apply_gate(g.gate, g.qubits, g.params)
+    return backend
+
+
+def _mps_to_state(tensors):
+    state = tensors[0]
+    for t in tensors[1:]:
+        state = np.tensordot(state, t, axes=([-1], [0]))
+    return state.reshape(-1)
+
+
+def test_parameterized_gates():
+    qc = QuantumCircuit(2)
+    qc.rx(0.1, 0)
+    qc.ry(0.2, 1)
+    qc.rz(0.3, 0)
+    qc.p(0.4, 1)
+    qc.append(U1Gate(0.5), [1])
+    qc.rzz(0.6, 0, 1)
+    qc.append(U2Gate(0.7, 0.8), [0])
+    qc.append(UGate(0.9, 1.0, 1.1), [1])
+
+    expected = Statevector.from_instruction(qc).data
+    expected = expected.reshape(2, 2).transpose(1, 0).reshape(-1)
+
+    circuit = Circuit.from_qiskit(qc)
+
+    sv = _run_backend(StatevectorBackend, circuit)
+    np.testing.assert_allclose(sv.state, expected, atol=1e-8)
+
+    mps = _run_backend(MPSBackend, circuit)
+    np.testing.assert_allclose(_mps_to_state(mps.tensors), expected, atol=1e-8)
+
+    dd = _run_backend(DecisionDiagramBackend, circuit)
+    ssd = dd.extract_ssd()
+    assert ssd.partitions[0].history == tuple(g.gate for g in circuit.gates)


### PR DESCRIPTION
## Summary
- Extend statevector and MPS backends with matrices for RX, RY, RZ, P/U1, RZZ, U2, and U (U3)
- Allow passing gate parameters to MQT decision diagram backend
- Add tests covering parameterized gate execution across backends

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68ada8ef2ce4832193753b93fac3776d