### PR TITLE
Add circuit analysis module

### DIFF
--- a/quasar/__init__.py
+++ b/quasar/__init__.py
@@ -14,6 +14,7 @@ from .backends import (
     StimBackend,
     DecisionDiagramBackend,
 )
+from .analyzer import CircuitAnalyzer, AnalysisResult
 
 __all__ = [
     "Gate",
@@ -38,4 +39,6 @@ __all__ = [
     "MPSBackend",
     "StimBackend",
     "DecisionDiagramBackend",
+    "CircuitAnalyzer",
+    "AnalysisResult",
 ]

--- a/quasar/analyzer.py
+++ b/quasar/analyzer.py
@@ -1,0 +1,133 @@
+from __future__ import annotations
+
+"""Circuit analysis utilities for QuASAr.
+
+The analyzer inspects a :class:`~quasar.circuit.Circuit` and derives
+several high level metrics:
+
+* **Gate distribution** – frequency of each gate type in the circuit.
+* **Entanglement metrics** – connectivity properties of the qubit
+  interaction graph induced by multi-qubit gates.
+* **Resource estimates** – runtime and memory predictions for the
+  supported simulation backends using :class:`~quasar.cost.CostEstimator`.
+"""
+
+from dataclasses import dataclass
+from collections import Counter, defaultdict, deque
+from typing import Dict, Optional, Set
+
+from .circuit import Circuit
+from .cost import Backend, Cost, CostEstimator
+
+
+@dataclass
+class AnalysisResult:
+    """Container bundling the results of a circuit analysis."""
+
+    gate_distribution: Dict[str, int]
+    entanglement: Dict[str, float]
+    resources: Dict[Backend, Cost]
+
+
+class CircuitAnalyzer:
+    """Perform static analysis on a :class:`~quasar.circuit.Circuit`."""
+
+    def __init__(self, circuit: Circuit, estimator: Optional[CostEstimator] = None, chi: int = 4):
+        self.circuit = circuit
+        self.estimator = estimator or CostEstimator()
+        self.chi = chi
+
+    # ------------------------------------------------------------------
+    def gate_distribution(self) -> Dict[str, int]:
+        """Return the frequency of each gate type in the circuit."""
+
+        return dict(Counter(g.gate for g in self.circuit.gates))
+
+    # ------------------------------------------------------------------
+    def _entanglement_graph(self) -> Dict[int, Set[int]]:
+        """Build an undirected graph from multi-qubit gates."""
+
+        graph: Dict[int, Set[int]] = defaultdict(set)
+        for gate in self.circuit.gates:
+            qubits = gate.qubits
+            if len(qubits) < 2:
+                continue
+            for i in range(len(qubits)):
+                for j in range(i + 1, len(qubits)):
+                    a, b = qubits[i], qubits[j]
+                    graph[a].add(b)
+                    graph[b].add(a)
+        return graph
+
+    def entanglement_metrics(self) -> Dict[str, float]:
+        """Compute simple connectivity metrics for the circuit.
+
+        The routine interprets the circuit as an undirected graph where
+        vertices are qubits and edges connect qubits that participate in a
+        multi-qubit gate.  It then reports the number of connected
+        components, the size of the largest component and the number of
+        multi-qubit gates.
+        """
+
+        graph = self._entanglement_graph()
+        visited: Set[int] = set()
+        component_sizes = []
+        for q in graph:
+            if q in visited:
+                continue
+            queue = deque([q])
+            visited.add(q)
+            size = 0
+            while queue:
+                node = queue.popleft()
+                size += 1
+                for nb in graph[node]:
+                    if nb not in visited:
+                        visited.add(nb)
+                        queue.append(nb)
+            component_sizes.append(size)
+
+        # Account for isolated qubits which never appear in a multi-qubit
+        # interaction.
+        isolated = [q for q in range(self.circuit.num_qubits) if q not in graph]
+        component_sizes.extend([1] * len(isolated))
+
+        multi_qubit_gate_count = sum(1 for g in self.circuit.gates if len(g.qubits) > 1)
+
+        if component_sizes:
+            max_size = max(component_sizes)
+            avg_size = sum(component_sizes) / len(component_sizes)
+        else:
+            max_size = 0
+            avg_size = 0.0
+
+        return {
+            "multi_qubit_gate_count": float(multi_qubit_gate_count),
+            "connected_components": float(len(component_sizes)),
+            "max_connected_size": float(max_size),
+            "avg_connected_size": float(avg_size),
+        }
+
+    # ------------------------------------------------------------------
+    def resource_estimates(self) -> Dict[Backend, Cost]:
+        """Estimate runtime and memory for supported simulation backends."""
+
+        num_qubits = self.circuit.num_qubits
+        num_gates = len(self.circuit.gates)
+        estimates: Dict[Backend, Cost] = {
+            Backend.STATEVECTOR: self.estimator.statevector(num_qubits, num_gates),
+            Backend.TABLEAU: self.estimator.tableau(num_qubits, num_gates),
+            Backend.MPS: self.estimator.mps(num_qubits, num_gates, chi=self.chi),
+            Backend.DECISION_DIAGRAM: self.estimator.decision_diagram(num_gates=num_gates, frontier=num_qubits),
+        }
+        return estimates
+
+    # ------------------------------------------------------------------
+    def analyze(self) -> AnalysisResult:
+        """Return all analysis information in a single structure."""
+
+        return AnalysisResult(
+            gate_distribution=self.gate_distribution(),
+            entanglement=self.entanglement_metrics(),
+            resources=self.resource_estimates(),
+        )

--- a/quasar/circuit.py
+++ b/quasar/circuit.py
@@ -12,6 +12,7 @@ from qiskit_qasm3_import import api as qasm3_api
 
 from .partitioner import Partitioner
 from .ssd import SSD
+from .cost import Cost
 
 
 @dataclass
@@ -107,6 +108,11 @@ class Circuit:
         """Construct the initial subsystem descriptor."""
         return Partitioner().partition(self)
 
-    def _estimate_costs(self) -> Dict[str, float]:
-        """Placeholder cost estimation routine."""
-        return {}
+    def _estimate_costs(self) -> Dict[str, Cost]:
+        """Estimate simulation costs for standard backends."""
+
+        from .analyzer import CircuitAnalyzer
+
+        analyzer = CircuitAnalyzer(self)
+        estimates = analyzer.resource_estimates()
+        return {backend.name.lower(): cost for backend, cost in estimates.items()}

--- a/tests/test_analyzer.py
+++ b/tests/test_analyzer.py
@@ -1,0 +1,48 @@
+import pytest
+
+from quasar import Circuit, CircuitAnalyzer, Backend, Cost
+
+
+@pytest.fixture
+def sample_circuit():
+    gates = [
+        {"gate": "H", "qubits": [0]},
+        {"gate": "CX", "qubits": [0, 1]},
+        {"gate": "CX", "qubits": [1, 2]},
+        {"gate": "H", "qubits": [2]},
+    ]
+    return Circuit.from_dict(gates)
+
+
+def test_gate_distribution(sample_circuit):
+    analyzer = CircuitAnalyzer(sample_circuit)
+    dist = analyzer.gate_distribution()
+    assert dist["H"] == 2
+    assert dist["CX"] == 2
+    assert sum(dist.values()) == 4
+
+
+def test_entanglement_metrics(sample_circuit):
+    analyzer = CircuitAnalyzer(sample_circuit)
+    metrics = analyzer.entanglement_metrics()
+    assert metrics["multi_qubit_gate_count"] == 2
+    # CX gates connect qubits in a chain -> single component of size 3
+    assert metrics["connected_components"] == 1
+    assert metrics["max_connected_size"] == 3
+
+
+def test_resource_estimates(sample_circuit):
+    analyzer = CircuitAnalyzer(sample_circuit)
+    estimates = analyzer.resource_estimates()
+    # Ensure estimates for all backends are returned
+    assert set(estimates.keys()) == {
+        Backend.STATEVECTOR,
+        Backend.TABLEAU,
+        Backend.MPS,
+        Backend.DECISION_DIAGRAM,
+    }
+    # Basic sanity: costs should be non-negative numbers
+    for cost in estimates.values():
+        assert isinstance(cost, Cost)
+        assert cost.time >= 0
+        assert cost.memory >= 0


### PR DESCRIPTION
## Summary
- add CircuitAnalyzer to compute gate distribution, entanglement connectivity metrics and backend resource estimates
- expose new analyzer in public API and integrate cost estimates into Circuit
- cover analyzer with unit tests

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68ada84eb1688321a061631eb4ba19d4