### PR TITLE
Implement complete conversion engine

### DIFF
--- a/quasar_convert/conversion_engine.hpp
+++ b/quasar_convert/conversion_engine.hpp
@@ -57,11 +57,12 @@ class ConversionEngine {
 
     SSD extract_ssd(const std::vector<uint32_t>& qubits, std::size_t s) const;
 
-    // Extract the set of boundary qubits participating in cross-fragment
-    // operations.  The input `bridges` lists gates that connect a qubit in the
-    // current fragment (first element of the pair) with a qubit in another
-    // fragment (second element).  A simple SSD descriptor is constructed from
-    // the unique local qubits appearing in the bridge set.
+    // Extract the boundary directions induced by cross-fragment operations.
+    // The input ``bridges`` lists gates that connect a qubit in the current
+    // fragment (first element of the pair) with a qubit in another fragment
+    // (second element).  A small SVD of the induced connection matrix yields a
+    // Schmidt-style descriptor whose left singular vectors form the ``vectors``
+    // entry of the returned SSD.
     SSD extract_boundary_ssd(const std::vector<std::pair<uint32_t, uint32_t>>& bridges,
                              std::size_t s) const;
 
@@ -76,13 +77,14 @@ class ConversionEngine {
 
     // Construct a simple bridge tensor that links two fragments described by
     // their SSD descriptors.  The tensor corresponds to an identity operation
-    // on all boundary qubits and is returned as a flat amplitude vector.
+    // on the overlapping boundary qubits and is returned as a flat amplitude
+    // vector.
     std::vector<std::complex<double>> build_bridge_tensor(const SSD& left,
                                                           const SSD& right) const;
 
-    // Choose a conversion primitive for the given SSD and simulate the
-    // associated cost. The implementation uses simple heuristics based on the
-    // boundary size and Schmidt rank to select between B2B, LW, ST and Full.
+    // Choose a conversion primitive for the given SSD by estimating the cost of
+    // each available strategy (B2B, LW, ST and Full) and returning the minimal
+    // option.
     ConversionResult convert(const SSD& ssd) const;
 
     // Provide a concrete statevector representation for the boundary qubits.
@@ -101,9 +103,9 @@ class ConversionEngine {
     StimTableau convert_boundary_to_tableau(const SSD& ssd) const;
     std::optional<StimTableau> try_build_tableau(const std::vector<std::complex<double>>& state) const;
     // Attempt to learn a stabilizer tableau from an arbitrary state vector.
-    // Currently supports the computational basis state |0...0> and the fully
-    // uniform superposition |+...+>.  Returns std::nullopt if the state does
-    // not appear to be a stabilizer state under these checks.
+    // Simple analytic checks recognise computational basis states and uniform
+    // superpositions with phases in {±1, ±i}.  Returns ``std::nullopt`` if the
+    // state does not appear to be a stabilizer state under these checks.
     std::optional<StimTableau> learn_stabilizer(
         const std::vector<std::complex<double>>& state) const;
 #endif


### PR DESCRIPTION
## Summary
- add quadratic cost model for fragment conversions
- derive boundary SSD using Gram matrix eigenvectors
- select conversion primitive via analytic cost estimates
- expand stabilizer learner to detect basis and uniform-phase states

## Testing
- `pytest quasar_convert/tests/test_engine.py -q`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68ada93d828c832192a9a6a3714f8d76