### PR TITLE
Add caching to ConversionEngine

### DIFF
--- a/quasar_convert/tests/test_cache.py
+++ b/quasar_convert/tests/test_cache.py
@@ -1,0 +1,44 @@
+import unittest
+from unittest import mock
+import quasar_convert as qc
+
+class CacheTests(unittest.TestCase):
+    def setUp(self):
+        self.eng = qc.ConversionEngine()
+        if hasattr(self.eng, "_ensure_impl"):
+            # ensure underlying implementation exists for patching
+            self.eng._ensure_impl()
+
+    def _patch(self, base_name: str):
+        if hasattr(self.eng, "_impl"):
+            target = self.eng._impl
+            attr = base_name
+        else:
+            target = self.eng
+            attr = f"_{base_name}_impl"
+        return mock.patch.object(target, attr, wraps=getattr(target, attr))
+
+    def test_extract_ssd_cached(self):
+        with self._patch("extract_ssd") as spy:
+            self.eng.extract_ssd([0, 1], 2)
+            self.eng.extract_ssd([0, 1], 2)
+            self.assertEqual(spy.call_count, 1)
+
+    def test_extract_boundary_ssd_cached(self):
+        bridges = [(0, 5), (1, 6)]
+        with self._patch("extract_boundary_ssd") as spy:
+            self.eng.extract_boundary_ssd(bridges, 2)
+            # Different list instance but identical contents should hit cache
+            self.eng.extract_boundary_ssd(list(bridges), 2)
+            self.assertEqual(spy.call_count, 1)
+
+    def test_build_bridge_tensor_cached(self):
+        left = qc.SSD(boundary_qubits=[0, 1], top_s=2)
+        right = qc.SSD(boundary_qubits=[0, 1], top_s=2)
+        with self._patch("build_bridge_tensor") as spy:
+            self.eng.build_bridge_tensor(left, right)
+            self.eng.build_bridge_tensor(left, right)
+            self.assertEqual(spy.call_count, 1)
+
+if __name__ == "__main__":
+    unittest.main()

--- a/quasar_convert/tests/test_cache.py
+++ b/quasar_convert/tests/test_cache.py
@@ -6,39 +6,45 @@ class CacheTests(unittest.TestCase):
     def setUp(self):
         self.eng = qc.ConversionEngine()
         if hasattr(self.eng, "_ensure_impl"):
-            # ensure underlying implementation exists for patching
+            # ensure underlying implementation exists so that we can spy on it
             self.eng._ensure_impl()
 
-    def _patch(self, base_name: str):
+    def _spy(self, base_name: str):
+        """Return a spy for the underlying implementation method."""
         if hasattr(self.eng, "_impl"):
-            target = self.eng._impl
-            attr = base_name
-        else:
-            target = self.eng
-            attr = f"_{base_name}_impl"
-        return mock.patch.object(target, attr, wraps=getattr(target, attr))
+            # Replace the native implementation with a wrapping mock so that we
+            # can observe how often it is invoked.
+            wrapped = mock.Mock(wraps=self.eng._impl)
+            self.eng._impl = wrapped
+            return getattr(wrapped, base_name)
+        # Fall back to the pure Python stub helpers when the native extension
+        # isn't present.
+        attr = f"_{base_name}_impl"
+        spy = mock.Mock(wraps=getattr(self.eng, attr))
+        setattr(self.eng, attr, spy)
+        return spy
 
     def test_extract_ssd_cached(self):
-        with self._patch("extract_ssd") as spy:
-            self.eng.extract_ssd([0, 1], 2)
-            self.eng.extract_ssd([0, 1], 2)
-            self.assertEqual(spy.call_count, 1)
+        spy = self._spy("extract_ssd")
+        self.eng.extract_ssd([0, 1], 2)
+        self.eng.extract_ssd([0, 1], 2)
+        self.assertEqual(spy.call_count, 1)
 
     def test_extract_boundary_ssd_cached(self):
         bridges = [(0, 5), (1, 6)]
-        with self._patch("extract_boundary_ssd") as spy:
-            self.eng.extract_boundary_ssd(bridges, 2)
-            # Different list instance but identical contents should hit cache
-            self.eng.extract_boundary_ssd(list(bridges), 2)
-            self.assertEqual(spy.call_count, 1)
+        spy = self._spy("extract_boundary_ssd")
+        self.eng.extract_boundary_ssd(bridges, 2)
+        # Different list instance but identical contents should hit cache
+        self.eng.extract_boundary_ssd(list(bridges), 2)
+        self.assertEqual(spy.call_count, 1)
 
     def test_build_bridge_tensor_cached(self):
         left = qc.SSD(boundary_qubits=[0, 1], top_s=2)
         right = qc.SSD(boundary_qubits=[0, 1], top_s=2)
-        with self._patch("build_bridge_tensor") as spy:
-            self.eng.build_bridge_tensor(left, right)
-            self.eng.build_bridge_tensor(left, right)
-            self.assertEqual(spy.call_count, 1)
+        spy = self._spy("build_bridge_tensor")
+        self.eng.build_bridge_tensor(left, right)
+        self.eng.build_bridge_tensor(left, right)
+        self.assertEqual(spy.call_count, 1)
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
- add LRU-style caches for SSD extraction and bridge building in ConversionEngine
- expose `clear_cache` and `set_cache_limit` helpers
- test that repeated calls reuse cached results

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68adb373ba648321ae9265096a89ed81