### PR TITLE
Add policy caps for conversion planning

### DIFF
--- a/quasar/partitioner.py
+++ b/quasar/partitioner.py
@@ -92,7 +92,7 @@ class Partitioner:
 
                 boundary = sorted(current_qubits & future_qubits[idx])
                 if boundary:
-                    rank = min(2 ** len(boundary), 2 ** 8)
+                    rank = 2 ** len(boundary)
                     frontier = len(boundary)
                     conv_est = self.estimator.conversion(
                         current_backend,

--- a/quasar/planner.py
+++ b/quasar/planner.py
@@ -266,7 +266,7 @@ class Planner:
                         if prev_backend is not None and prev_backend != backend:
                             boundary = boundaries[j]
                             if boundary:
-                                rank = min(2 ** len(boundary), 2 ** 8)
+                                rank = 2 ** len(boundary)
                                 frontier = len(boundary)
                                 conv_est = self.estimator.conversion(
                                     prev_backend,

--- a/tests/test_cost.py
+++ b/tests/test_cost.py
@@ -1,4 +1,5 @@
 from quasar import Backend, CostEstimator
+import math
 
 
 def test_statevector_scaling():
@@ -53,3 +54,17 @@ def test_conversion_primitive_selection():
     )
     assert large.primitive == "LW"
     assert large.cost.time > small.cost.time
+
+
+def test_conversion_caps():
+    est = CostEstimator(q_max=2, r_max=2, s_max=4)
+    res = est.conversion(
+        Backend.STATEVECTOR,
+        Backend.TABLEAU,
+        num_qubits=3,
+        rank=8,
+        frontier=3,
+    )
+    assert res.primitive == "Full"
+    assert math.isinf(res.cost.time)
+    assert math.isinf(res.cost.memory)

--- a/tests/test_planner.py
+++ b/tests/test_planner.py
@@ -43,3 +43,26 @@ def test_split_and_recover():
         (0, 2, Backend.TABLEAU),
         (2, 3, Backend.STATEVECTOR),
     ]
+
+
+def test_planner_respects_caps():
+    gates = [
+        {"gate": "CX", "qubits": [0, 1]},
+        {"gate": "CX", "qubits": [0, 1]},
+        {"gate": "T", "qubits": [0]},
+    ]
+    circ = Circuit.from_dict(gates)
+    coeff = {
+        "b2b_svd": 0.0,
+        "b2b_copy": 0.0,
+        "ingest_dd": 0.0,
+        "ingest_tab": 0.0,
+        "ingest_sv": 0.0,
+        "dd_gate": 10.0,
+    }
+    est = CostEstimator(coeff, q_max=0, r_max=0, s_max=1)
+    planner = Planner(est)
+    result = planner.plan(circ)
+    steps = result.steps
+    assert len(steps) == 1
+    assert steps[0].backend == Backend.STATEVECTOR


### PR DESCRIPTION
## Summary
- add optional `s_max`, `r_max`, and `q_max` caps to `CostEstimator` and enforce them during conversions
- use actual boundary size in planner and partitioner to respect caps
- test conversion and planner behavior when limits are exceeded

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68adb37d5eb083218a1a43a6fc3fd7c4