### PR TITLE
Handle conversion primitives in scheduler

### DIFF
--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -1,8 +1,11 @@
 from quasar import Circuit, Scheduler, Planner
+from quasar.planner import PlanStep
 from quasar_convert import ConversionEngine
 from quasar.cost import Backend
 from quasar import SSD
 import time
+from types import SimpleNamespace
+from quasar.backends import StimBackend
 
 
 class CountingConversionEngine(ConversionEngine):
@@ -10,21 +13,85 @@ class CountingConversionEngine(ConversionEngine):
         super().__init__()
         self.calls = 0
 
-    def convert_boundary_to_statevector(self, ssd):  # type: ignore[override]
+    def _bump(self):
         self.calls += 1
+
+    def convert_boundary_to_statevector(self, ssd):  # type: ignore[override]
+        self._bump()
         return super().convert_boundary_to_statevector(ssd)
 
     def convert_boundary_to_tableau(self, ssd):  # type: ignore[override]
-        self.calls += 1
+        self._bump()
         if hasattr(ConversionEngine, "convert_boundary_to_tableau"):
             return super().convert_boundary_to_tableau(ssd)
         raise AttributeError("convert_boundary_to_tableau not available")
 
     def convert_boundary_to_dd(self, ssd):  # type: ignore[override]
-        self.calls += 1
+        self._bump()
         if hasattr(ConversionEngine, "convert_boundary_to_dd"):
             return super().convert_boundary_to_dd(ssd)
         raise AttributeError("convert_boundary_to_dd not available")
+
+    def extract_ssd(self, *args, **kwargs):  # type: ignore[override]
+        self._bump()
+        return super().extract_ssd(*args, **kwargs)
+
+    def build_bridge_tensor(self, *args, **kwargs):  # type: ignore[override]
+        self._bump()
+        return super().build_bridge_tensor(*args, **kwargs)
+
+    def extract_local_window(self, *args, **kwargs):  # type: ignore[override]
+        self._bump()
+        dim = 1 << len(args[1]) if args else 1
+        vec = [0j] * dim
+        if dim:
+            vec[0] = 1.0 + 0j
+        return vec
+
+
+class PrimitiveTrackingEngine(ConversionEngine):
+    def __init__(self):
+        super().__init__()
+        self.local_windows = 0
+        self.dense_calls = 0
+
+    def extract_local_window(self, state, qubits):  # type: ignore[override]
+        self.local_windows += 1
+        dim = 1 << len(qubits)
+        win = [0j] * dim
+        if dim:
+            win[0] = 1.0 + 0j
+        return win
+
+    def convert_boundary_to_statevector(self, ssd):  # type: ignore[override]
+        self.dense_calls += 1
+        return super().convert_boundary_to_statevector(ssd)
+
+
+class TwoStepPlanner(Planner):
+    def plan(self, circuit):  # type: ignore[override]
+        steps = [
+            PlanStep(0, 5, Backend.TABLEAU),
+            PlanStep(5, 6, Backend.MPS),
+        ]
+        return SimpleNamespace(steps=steps)
+
+
+class DummyBackend:
+    def __init__(self):
+        self.backend = Backend.MPS
+
+    def load(self, n):
+        self.num_qubits = n
+
+    def ingest(self, state):
+        self.state = state
+
+    def apply_gate(self, gate, qubits, params):
+        pass
+
+    def extract_ssd(self):
+        return SSD([])
 
 
 def build_switch_circuit():
@@ -38,12 +105,36 @@ def build_switch_circuit():
     ])
 
 
+def build_switch_circuit_rz():
+    return Circuit([
+        {"gate": "H", "qubits": [0]},
+        {"gate": "CX", "qubits": [0, 1]},
+        {"gate": "H", "qubits": [0]},
+        {"gate": "H", "qubits": [1]},
+        {"gate": "CX", "qubits": [0, 1]},
+        {"gate": "RZ", "qubits": [0], "params": {"param0": 0.78539816339}},
+    ])
+
+
 def test_scheduler_triggers_conversion():
     engine = CountingConversionEngine()
     scheduler = Scheduler(conversion_engine=engine)
     circuit = build_switch_circuit()
     scheduler.run(circuit)
     assert engine.calls == 1
+
+
+def test_scheduler_uses_non_dense_primitive():
+    engine = PrimitiveTrackingEngine()
+    scheduler = Scheduler(
+        conversion_engine=engine,
+        planner=TwoStepPlanner(),
+        backends={Backend.TABLEAU: StimBackend(), Backend.MPS: DummyBackend()},
+    )
+    circuit = build_switch_circuit_rz()
+    scheduler.run(circuit)
+    assert engine.local_windows == 1
+    assert engine.dense_calls == 0
 
 
 def test_scheduler_returns_final_ssd():


### PR DESCRIPTION
## Summary
- teach scheduler to select conversion primitives and invoke specialized extraction helpers
- exercise non-dense primitive path with a dedicated unit test

## Testing
- `pytest tests/test_scheduler.py -q`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68adb36ea36483218f0688ae5e49071c