### PR TITLE
Add planning result caching

### DIFF
--- a/quasar/scheduler.py
+++ b/quasar/scheduler.py
@@ -60,7 +60,9 @@ class Scheduler:
             executed.
         """
 
-        plan = self.planner.plan(circuit)
+        plan = self.planner.cache_lookup(circuit.gates)
+        if plan is None:
+            plan = self.planner.plan(circuit)
         steps: List[PlanStep] = list(plan.steps)
 
         current_backend = None
@@ -152,7 +154,9 @@ class Scheduler:
                 cost = self._estimate_cost(target, len(qubits), len(frag))
                 if monitor(step, cost):
                     remaining = Circuit(circuit.gates[step.end :])
-                    replanned = self.planner.plan(remaining)
+                    replanned = self.planner.cache_lookup(remaining.gates)
+                    if replanned is None:
+                        replanned = self.planner.plan(remaining)
                     offset = step.end
                     new_steps = [
                         PlanStep(s.start + offset, s.end + offset, s.backend)


### PR DESCRIPTION
## Summary
- add in-memory cache for `Planner` keyed by gate fingerprints and track hits
- expose cache lookup/insert and use cache during planning
- `Scheduler` consults `Planner` cache before planning and during replanning

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68adc29fa0688321b6a4e7758ee83e37