### PR TITLE
Feed conversion engine with real simulator state

### DIFF
--- a/quasar/backends/base.py
+++ b/quasar/backends/base.py
@@ -65,3 +65,13 @@ class Backend:
     def extract_ssd(self) -> 'SSD':
         """Return a :class:`~quasar.ssd.SSD` describing the backend state."""
         raise NotImplementedError
+
+    # ------------------------------------------------------------------
+    def statevector(self) -> Sequence[complex]:
+        """Return the full statevector representing the backend state.
+
+        Backends that do not maintain a dense representation may override
+        this to reconstruct a statevector on demand or raise
+        ``NotImplementedError`` if such extraction is not supported.
+        """
+        raise NotImplementedError

--- a/quasar/backends/mps.py
+++ b/quasar/backends/mps.py
@@ -193,3 +193,13 @@ class MPSBackend(Backend):
             backend=self.backend,
         )
         return SSD([part])
+
+    # ------------------------------------------------------------------
+    def statevector(self) -> np.ndarray:
+        """Return a dense statevector corresponding to the MPS."""
+        if not self.tensors:
+            raise RuntimeError("Backend not initialised; call 'load' first")
+        psi = self.tensors[0]
+        for tensor in self.tensors[1:]:
+            psi = np.tensordot(psi, tensor, axes=(2, 0))
+        return psi.reshape(-1).copy()

--- a/quasar/backends/mqt_dd.py
+++ b/quasar/backends/mqt_dd.py
@@ -74,3 +74,12 @@ class DecisionDiagramBackend(Backend):
             backend=self.backend,
         )
         return SSD([part])
+
+    # ------------------------------------------------------------------
+    def statevector(self) -> Sequence[complex]:
+        """Return a dense statevector for the DD backend.
+
+        The decision diagram package does not currently expose an efficient
+        statevector extraction method, hence this is left unimplemented.
+        """
+        raise NotImplementedError("Statevector extraction not supported")

--- a/quasar/backends/statevector.py
+++ b/quasar/backends/statevector.py
@@ -152,3 +152,10 @@ class StatevectorBackend(Backend):
             backend=self.backend,
         )
         return SSD([part])
+
+    # ------------------------------------------------------------------
+    def statevector(self) -> np.ndarray:
+        """Return a dense statevector of the current simulator state."""
+        if self.state is None:
+            raise RuntimeError("Backend not initialised; call 'load' first")
+        return self.state.copy()

--- a/quasar/backends/stim_backend.py
+++ b/quasar/backends/stim_backend.py
@@ -80,3 +80,11 @@ class StimBackend(Backend):
             backend=self.backend,
         )
         return SSD([part])
+
+    # ------------------------------------------------------------------
+    def statevector(self) -> Sequence[complex]:
+        """Return a dense statevector for the current tableau state."""
+        if self.simulator is None:
+            raise RuntimeError("Backend not initialised; call 'load' first")
+        # Stim returns a numpy array of complex amplitudes
+        return self.simulator.state_vector().astype(complex)

--- a/quasar/scheduler.py
+++ b/quasar/scheduler.py
@@ -99,16 +99,13 @@ class Scheduler:
                         primitive = None
                 try:
                     if primitive == "B2B":
-                        rep = self.conversion_engine.extract_ssd(boundary, rank)
+                        rep = ssd
                     elif primitive == "LW":
-                        dim = 1 << len(boundary)
-                        state = [0j] * dim
-                        if dim:
-                            state[0] = 1.0 + 0j
+                        state = current_sim.statevector()
                         rep = self.conversion_engine.extract_local_window(state, boundary)
                     elif primitive == "ST":
-                        left = self.conversion_engine.extract_ssd(boundary, rank)
-                        right = self.conversion_engine.extract_ssd(boundary, rank)
+                        left = current_sim.extract_ssd()
+                        right = current_sim.extract_ssd()
                         rep = self.conversion_engine.build_bridge_tensor(left, right)
                     else:
                         raise ValueError("unknown primitive")


### PR DESCRIPTION
## Summary
- expose a `statevector` extraction hook in the backend base class
- implement statevector extraction for statevector, MPS, Stim and stub DD backend
- drive backend conversion using real simulation state in `Scheduler.run`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68adc29e26e08321a5aba05b3a8c6a2c