### PR TITLE
Refactor scheduler to manage simulators per fragment

### DIFF
--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -120,8 +120,9 @@ def test_scheduler_triggers_conversion():
     engine = CountingConversionEngine()
     scheduler = Scheduler(conversion_engine=engine)
     circuit = build_switch_circuit()
+    plan = scheduler.planner.plan(circuit)
     scheduler.run(circuit)
-    assert engine.calls == 1
+    assert engine.calls == len(plan.steps) - 1
 
 
 def test_scheduler_uses_non_dense_primitive():


### PR DESCRIPTION
## Summary
- track live simulator instances per partition/backend in `Scheduler.run`
- dispatch independent gate groups in parallel on owning simulator
- update conversion counting test to reflect per-step conversions

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68add234a0748321a124aef1717fadb6