### PR TITLE
feat: expose backend states per partition

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,3 +23,24 @@ including running the test suite, install the package with its testing extras:
 pip install -e .[test]
 ```
 
+## Retrieving partition states
+
+Running a circuit with :class:`quasar.SimulationEngine` returns a
+:class:`~quasar.ssd.SSD` object describing the final state.  Each entry in
+``SSD.partitions`` exposes the backend specific state of that subsystem via
+``SSD.extract_state``.  Users can iterate over all partitions to access the
+raw data:
+
+```python
+from quasar import Circuit, SimulationEngine
+
+engine = SimulationEngine()
+result = engine.simulate(Circuit([{"gate": "H", "qubits": [0]}]))
+for part in result.ssd.partitions:
+    state = result.ssd.extract_state(part)
+    print(part.backend, type(state))
+```
+
+Depending on the backend, ``state`` may be a dense NumPy vector, a list of MPS
+tensors, a ``stim.Tableau`` or a decision diagram node.
+

--- a/quasar/backends/mps.py
+++ b/quasar/backends/mps.py
@@ -187,10 +187,12 @@ class MPSBackend(Backend):
 
     # ------------------------------------------------------------------
     def extract_ssd(self) -> SSD:
+        state = [t.copy() for t in self.tensors]
         part = SSDPartition(
             subsystems=(tuple(range(self.num_qubits)),),
             history=tuple(self.history),
             backend=self.backend,
+            state=state,
         )
         return SSD([part])
 

--- a/quasar/backends/mqt_dd.py
+++ b/quasar/backends/mqt_dd.py
@@ -72,6 +72,7 @@ class DecisionDiagramBackend(Backend):
             subsystems=(tuple(range(self.num_qubits)),),
             history=tuple(self.history),
             backend=self.backend,
+            state=self.state,
         )
         return SSD([part])
 

--- a/quasar/backends/statevector.py
+++ b/quasar/backends/statevector.py
@@ -150,6 +150,7 @@ class StatevectorBackend(Backend):
             subsystems=(tuple(range(self.num_qubits)),),
             history=tuple(self.history),
             backend=self.backend,
+            state=self.statevector(),
         )
         return SSD([part])
 

--- a/quasar/backends/stim_backend.py
+++ b/quasar/backends/stim_backend.py
@@ -74,10 +74,17 @@ class StimBackend(Backend):
         self.history.append(name.upper())
 
     def extract_ssd(self) -> SSD:
+        tableau = None
+        if self.simulator is not None:
+            try:
+                tableau = self.simulator.current_inverse_tableau()
+            except Exception:
+                tableau = None
         part = SSDPartition(
             subsystems=(tuple(range(self.num_qubits)),),
             history=tuple(self.history),
             backend=self.backend,
+            state=tableau,
         )
         return SSD([part])
 

--- a/tests/test_backends.py
+++ b/tests/test_backends.py
@@ -16,6 +16,7 @@ def _exercise_backend(backend_cls):
     ssd = backend.extract_ssd()
     assert ssd.partitions[0].backend == backend.backend
     assert ssd.partitions[0].history == ("H", "CX")
+    assert ssd.extract_state(ssd.partitions[0]) is not None
 
 
 def test_statevector_backend():

--- a/tests/test_simulation_engine.py
+++ b/tests/test_simulation_engine.py
@@ -14,3 +14,11 @@ def test_simulation_engine_simulate_returns_metrics():
     assert sum(result.analysis.gate_distribution.values()) == 3
     # Planner produced at least one step
     assert result.plan.steps
+
+
+def test_partition_state_extraction():
+    circuit = Circuit([{"gate": "H", "qubits": [0]}])
+    engine = SimulationEngine()
+    result = engine.simulate(circuit)
+    states = [result.ssd.extract_state(p) for p in result.ssd.partitions]
+    assert any(s is not None for s in states)


### PR DESCRIPTION
## Summary
- attach backend-specific state objects to each SSD partition and provide `SSD.extract_state`
- document how to iterate over `SSD.partitions` to access backend states
- cover partition state retrieval with tests

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68aed9e5c2408321a920c302a03596db