### PR TITLE
Add runtime monitoring hooks to scheduler

### DIFF
--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -166,7 +166,7 @@ def test_scheduler_reoptimises_when_requested():
 
     triggered = {"done": False}
 
-    def monitor(step, cost):
+    def monitor(step, observed, estimated):
         if not triggered["done"]:
             triggered["done"] = True
             return True


### PR DESCRIPTION
## Summary
- extend scheduler `run` to time and measure memory for each plan step
- replan remaining gates when observed runtime exceeds estimates
- update cost estimator coefficients with observed measurements and adjust monitor callback

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68aed9f7eecc8321b8e8b939842a53d8