### PR TITLE
Implement cost models and fidelity tracking in conversion engine

### DIFF
--- a/quasar_convert/binding.cpp
+++ b/quasar_convert/binding.cpp
@@ -48,7 +48,8 @@ PYBIND11_MODULE(_conversion_engine, m) {
 
     py::class_<quasar::ConversionResult>(m, "ConversionResult")
         .def_readonly("primitive", &quasar::ConversionResult::primitive)
-        .def_readonly("cost", &quasar::ConversionResult::cost);
+        .def_readonly("cost", &quasar::ConversionResult::cost)
+        .def_readonly("fidelity", &quasar::ConversionResult::fidelity);
 
     py::class_<quasar::ConversionEngine>(m, "ConversionEngine")
         .def(py::init<>())

--- a/quasar_convert/conversion_engine.hpp
+++ b/quasar_convert/conversion_engine.hpp
@@ -46,7 +46,8 @@ enum class Primitive {
 
 struct ConversionResult {
     Primitive primitive;   // primitive that was chosen
-    double cost;           // simplistic cost measure
+    double cost;           // estimated time cost
+    double fidelity;       // crude fidelity estimate
 };
 
 class ConversionEngine {


### PR DESCRIPTION
## Summary
- Add time-cost models for B2B, LW, ST and full extraction primitives and select primitive using policy thresholds
- Track fidelity alongside primitive choice and cost
- Expose fidelity through the Python bindings and stub implementation, preserving SSD/bridge tensor caching

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b01569da288321ac10f3c4d5c9841c