### PR TITLE
Add benchmark circuit generators and tests

### DIFF
--- a/benchmarks/circuits.py
+++ b/benchmarks/circuits.py
@@ -1,0 +1,52 @@
+"""Common benchmark circuits for QuASAr."""
+from __future__ import annotations
+
+import math
+from typing import List
+
+import numpy as np
+from qiskit import QuantumCircuit, transpile
+from qiskit.circuit.library import QFT
+
+from quasar.circuit import Circuit, Gate
+
+
+def ghz_circuit(n_qubits: int) -> Circuit:
+    """Create an ``n_qubits`` GHZ state preparation circuit."""
+    gates: List[Gate] = []
+    if n_qubits <= 0:
+        return Circuit(gates)
+    gates.append(Gate("H", [0]))
+    for i in range(1, n_qubits):
+        gates.append(Gate("CX", [i - 1, i]))
+    return Circuit(gates)
+
+
+def qft_circuit(n_qubits: int) -> Circuit:
+    """Create an ``n_qubits`` quantum Fourier transform circuit."""
+    qc = QFT(n_qubits)
+    qc = transpile(qc, basis_gates=["u", "p", "cx", "swap", "h"])
+    return Circuit.from_qiskit(qc)
+
+
+def qft_on_ghz_circuit(n_qubits: int) -> Circuit:
+    """Apply the QFT to a GHZ state."""
+    ghz = ghz_circuit(n_qubits)
+    qft = qft_circuit(n_qubits)
+    return Circuit(list(ghz.gates) + list(qft.gates))
+
+
+def w_state_circuit(n_qubits: int) -> Circuit:
+    """Create an ``n_qubits`` W state preparation circuit."""
+    qc = QuantumCircuit(n_qubits)
+    state = np.zeros(2**n_qubits)
+    for i in range(n_qubits):
+        state[1 << i] = 1 / math.sqrt(n_qubits)
+    qc.initialize(state, range(n_qubits))
+    qc = transpile(qc, basis_gates=["u", "cx"])
+    new_qc = QuantumCircuit(n_qubits)
+    for inst, qargs, cargs in qc.data:
+        if inst.name == "reset":
+            continue
+        new_qc.append(inst, qargs, cargs)
+    return Circuit.from_qiskit(new_qc)

--- a/tests/test_benchmark_circuits.py
+++ b/tests/test_benchmark_circuits.py
@@ -1,0 +1,70 @@
+import math
+import numpy as np
+from qiskit import QuantumCircuit
+from qiskit.circuit.library import QFT
+from qiskit.quantum_info import Statevector
+
+from quasar.circuit import Circuit, Gate
+from quasar.backends.statevector import StatevectorBackend
+from benchmarks.circuits import ghz_circuit, w_state_circuit, qft_circuit, qft_on_ghz_circuit
+
+
+def _simulate(circ: Circuit, n: int) -> np.ndarray:
+    backend = StatevectorBackend()
+    backend.load(n)
+    for g in circ.gates:
+        backend.apply_gate(g.gate, g.qubits, g.params)
+    return backend.state
+
+
+def _assert_equivalent(actual: np.ndarray, expected: np.ndarray, atol: float = 1e-8) -> None:
+    idx = np.flatnonzero(expected)[0]
+    phase = actual[idx] / expected[idx]
+    assert np.allclose(actual / phase, expected, atol=atol)
+
+
+def test_ghz_circuit_state():
+    n = 3
+    circ = ghz_circuit(n)
+    state = _simulate(circ, n)
+    expected = np.zeros(2**n, dtype=complex)
+    expected[0] = 1 / math.sqrt(2)
+    expected[-1] = 1 / math.sqrt(2)
+    _assert_equivalent(state, expected)
+
+
+def test_w_state_circuit_state():
+    n = 3
+    circ = w_state_circuit(n)
+    state = _simulate(circ, n)
+    expected = np.zeros(2**n, dtype=complex)
+    for i in range(n):
+        expected[1 << i] = 1 / math.sqrt(n)
+    _assert_equivalent(state, expected)
+
+
+def test_qft_circuit_matches_qiskit():
+    n = 3
+    init = [Gate("X", [0])]
+    circ = Circuit(init + list(qft_circuit(n).gates))
+    state = _simulate(circ, n)
+
+    qc = QuantumCircuit(n)
+    qc.x(0)
+    qc.append(QFT(n), range(n))
+    expected = Statevector.from_instruction(qc).data
+    _assert_equivalent(state, expected)
+
+
+def test_qft_on_ghz_circuit_matches_qiskit():
+    n = 3
+    circ = qft_on_ghz_circuit(n)
+    state = _simulate(circ, n)
+
+    qc = QuantumCircuit(n)
+    qc.h(0)
+    for i in range(1, n):
+        qc.cx(i - 1, i)
+    qc.append(QFT(n), range(n))
+    expected = Statevector.from_instruction(qc).data
+    _assert_equivalent(state, expected)


### PR DESCRIPTION
## Summary
- add helper functions to build GHZ, W state, QFT and QFT-on-GHZ circuits
- add unit tests validating the generated circuits

## Testing
- `python -m pytest tests/test_benchmark_circuits.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68b023cb01f08321b5a7e3e7769c6f60