### PR TITLE
Add Grover and Bernstein-Vazirani benchmark circuits

### DIFF
--- a/tests/test_benchmark_circuits.py
+++ b/tests/test_benchmark_circuits.py
@@ -6,7 +6,14 @@ from qiskit.quantum_info import Statevector
 
 from quasar.circuit import Circuit, Gate
 from quasar.backends.statevector import StatevectorBackend
-from benchmarks.circuits import ghz_circuit, w_state_circuit, qft_circuit, qft_on_ghz_circuit
+from benchmarks.circuits import (
+    ghz_circuit,
+    w_state_circuit,
+    qft_circuit,
+    qft_on_ghz_circuit,
+    grover_circuit,
+    bernstein_vazirani_circuit,
+)
 
 
 def _simulate(circ: Circuit, n: int) -> np.ndarray:
@@ -67,4 +74,26 @@ def test_qft_on_ghz_circuit_matches_qiskit():
         qc.cx(i - 1, i)
     qc.append(QFT(n), range(n))
     expected = Statevector.from_instruction(qc).data
+    _assert_equivalent(state, expected)
+
+
+def test_grover_circuit_state():
+    n = 2
+    circ = grover_circuit(n, 1)
+    state = _simulate(circ, n)
+    expected = np.zeros(2**n, dtype=complex)
+    expected[-1] = 1
+    _assert_equivalent(state, expected)
+
+
+def test_bernstein_vazirani_circuit_state():
+    n = 3
+    secret = 0b101
+    circ = bernstein_vazirani_circuit(n, secret)
+    state = _simulate(circ, n + 1)
+    expected = np.zeros(2 ** (n + 1), dtype=complex)
+    idx0 = secret << 1
+    idx1 = idx0 | 1
+    expected[idx0] = 1 / math.sqrt(2)
+    expected[idx1] = -1 / math.sqrt(2)
     _assert_equivalent(state, expected)


### PR DESCRIPTION
## Summary
- add Grover search circuit with configurable iterations
- add Bernstein-Vazirani circuit parameterized by secret string
- test new benchmark circuits for correct state preparation

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b0415256a48321bff09fb6d54d8782