### PR TITLE
Add scalable benchmark circuit generators

### DIFF
--- a/benchmarks/circuits.py
+++ b/benchmarks/circuits.py
@@ -6,7 +6,17 @@ from typing import List
 
 import numpy as np
 from qiskit import QuantumCircuit, transpile
-from qiskit.circuit.library import QFT
+from qiskit.circuit.library import (
+    QFT,
+    RealAmplitudes,
+    EfficientSU2,
+    TwoLocal,
+    ZZFeatureMap,
+    CDKMRippleCarryAdder,
+    DraperQFTAdder,
+    VBERippleCarryAdder,
+)
+from qiskit.circuit.random import random_circuit as qiskit_random_circuit
 
 from quasar.circuit import Circuit, Gate
 
@@ -107,5 +117,265 @@ def bernstein_vazirani_circuit(n_qubits: int, secret: int = 0) -> Circuit:
             qc.cx(i, n_qubits)
 
     qc.h(range(n_qubits))
+    qc = transpile(qc, basis_gates=["u", "p", "cx", "h", "x"])
+    return Circuit.from_qiskit(qc)
+
+
+def amplitude_estimation_circuit(num_qubits: int, probability: float) -> Circuit:
+    """Construct an amplitude estimation circuit.
+
+    Args:
+        num_qubits: Number of evaluation qubits.
+        probability: Success probability encoded by the oracle.
+
+    Returns:
+        A :class:`Circuit` implementing a basic amplitude estimation routine.
+    """
+
+    if not 0.0 <= probability <= 1.0:
+        raise ValueError("probability must lie in [0, 1]")
+    qc = QuantumCircuit(num_qubits + 1)
+    theta = 2 * math.asin(math.sqrt(probability))
+    qc.h(range(num_qubits))
+    qc.ry(theta, num_qubits)
+    for i in range(num_qubits):
+        qc.crz(2 ** i * 2 * theta, i, num_qubits)
+    qc.append(QFT(num_qubits, inverse=True), range(num_qubits))
+    qc = transpile(qc, basis_gates=["u", "p", "cx", "h", "x"])
+    return Circuit.from_qiskit(qc)
+
+
+def bmw_quark_circuit(num_qubits: int, depth: int, kind: str = "cardinality") -> Circuit:
+    """Generate BMW-QUARK ansatz circuits.
+
+    Args:
+        num_qubits: Number of qubits.
+        depth: Number of alternating rotation/entangling layers.
+        kind: ``"cardinality"`` or ``"circular"`` ansatz style.
+
+    Returns:
+        The requested ansatz circuit as a :class:`Circuit`.
+    """
+
+    qc = QuantumCircuit(num_qubits)
+    for _ in range(depth):
+        for q in range(num_qubits):
+            qc.rx(np.pi / 2, q)
+        if kind == "cardinality":
+            for q in range(0, num_qubits - 1, 2):
+                qc.rxx(np.pi / 2, q, q + 1)
+            for q in range(1, num_qubits - 1, 2):
+                qc.rxx(np.pi / 2, q, q + 1)
+        else:  # circular
+            for q in range(num_qubits):
+                qc.rxx(np.pi / 2, q, (q + 1) % num_qubits)
+    qc = transpile(qc, basis_gates=["u", "p", "cx", "h", "x"])
+    return Circuit.from_qiskit(qc)
+
+
+def adder_circuit(num_qubits: int, kind: str = "cdkm") -> Circuit:
+    """Construct CDKM, Draper or VBE adder circuits.
+
+    Args:
+        num_qubits: Number of bits in each addend.
+        kind: ``"cdkm"``, ``"draper"`` or ``"vbe"``.
+    """
+
+    if kind == "cdkm":
+        qc = CDKMRippleCarryAdder(num_qubits)
+    elif kind == "draper":
+        qc = DraperQFTAdder(num_qubits)
+    elif kind == "vbe":
+        qc = VBERippleCarryAdder(num_qubits)
+    else:
+        raise ValueError("Unknown adder kind")
+    qc = transpile(qc, basis_gates=["u", "p", "cx", "h", "x"])
+    return Circuit.from_qiskit(qc)
+
+
+def deutsch_jozsa_circuit(num_qubits: int, balanced: bool = True) -> Circuit:
+    """Construct a Deutsch-Jozsa circuit.
+
+    Args:
+        num_qubits: Number of input bits.
+        balanced: Whether to use a balanced oracle; otherwise constant.
+    """
+
+    qc = QuantumCircuit(num_qubits + 1)
+    qc.x(num_qubits)
+    qc.h(range(num_qubits + 1))
+    if balanced:
+        for i in range(num_qubits):
+            qc.cx(i, num_qubits)
+    qc.h(range(num_qubits))
+    qc = transpile(qc, basis_gates=["u", "p", "cx", "h", "x"])
+    return Circuit.from_qiskit(qc)
+
+
+def graph_state_circuit(num_qubits: int, degree: int, seed: int | None = None) -> Circuit:
+    """Generate a random regular graph state circuit."""
+
+    import networkx as nx
+
+    if degree >= num_qubits:
+        raise ValueError("degree must be < num_qubits")
+    if (num_qubits * degree) % 2 != 0:
+        raise ValueError("n * degree must be even for a regular graph")
+    g = nx.random_regular_graph(degree, num_qubits, seed=seed)
+    qc = QuantumCircuit(num_qubits)
+    qc.h(range(num_qubits))
+    for u, v in g.edges():
+        qc.cz(u, v)
+    qc = transpile(qc, basis_gates=["u", "p", "cx", "h", "x"])
+    return Circuit.from_qiskit(qc)
+
+
+def hhl_circuit(num_qubits: int) -> Circuit:
+    """Create a simple HHL circuit. Requires ``num_qubits >= 3``."""
+
+    if num_qubits < 3:
+        raise ValueError("HHL requires at least 3 qubits")
+    qc = QuantumCircuit(num_qubits)
+    qc.h(0)
+    qc.cx(0, 1)
+    qc.h(0)
+    qc.cx(1, 2)
+    qc.ry(math.pi / 4, 2)
+    qc.cx(1, 2)
+    qc.h(0)
+    qc = transpile(qc, basis_gates=["u", "p", "cx", "h", "x"])
+    return Circuit.from_qiskit(qc)
+
+
+def hrs_circuit(num_qubits: int) -> Circuit:
+    """Construct a toy HRS arithmetic circuit."""
+
+    if num_qubits % 2 != 0:
+        raise ValueError("num_qubits must be even for HRS circuit")
+    qc = QuantumCircuit(num_qubits)
+    for i in range(0, num_qubits, 2):
+        target = (i + 2) % num_qubits
+        qc.ccx(i, i + 1, target)
+    qc = transpile(qc, basis_gates=["u", "p", "cx", "h", "x"])
+    return Circuit.from_qiskit(qc)
+
+
+def qaoa_circuit(num_qubits: int, repetitions: int = 1, seed: int | None = None) -> Circuit:
+    """Create a basic QAOA circuit on a ring graph."""
+
+    rng = np.random.default_rng(seed)
+    gammas = rng.uniform(0, 2 * np.pi, size=repetitions)
+    betas = rng.uniform(0, 2 * np.pi, size=repetitions)
+    edges = [(i, (i + 1) % num_qubits) for i in range(num_qubits)]
+    qc = QuantumCircuit(num_qubits)
+    qc.h(range(num_qubits))
+    for p in range(repetitions):
+        for u, v in edges:
+            qc.rzz(gammas[p], u, v)
+        for q in range(num_qubits):
+            qc.rx(betas[p], q)
+    qc = transpile(qc, basis_gates=["u", "p", "cx", "h", "x"])
+    return Circuit.from_qiskit(qc)
+
+
+def qnn_circuit(num_qubits: int) -> Circuit:
+    """Construct a simple quantum neural network circuit."""
+
+    fm = ZZFeatureMap(num_qubits)
+    ansatz = RealAmplitudes(num_qubits)
+    qc = QuantumCircuit(num_qubits)
+    qc.append(fm, range(num_qubits))
+    qc.append(ansatz, range(num_qubits))
+    params = {p: (i + 1) * 0.1 for i, p in enumerate(qc.parameters)}
+    qc = qc.assign_parameters(params)
+    qc = transpile(qc, basis_gates=["u", "p", "cx", "h", "x"])
+    return Circuit.from_qiskit(qc)
+
+
+def qpe_circuit(num_qubits: int, inexact: bool = False) -> Circuit:
+    """Quantum phase estimation circuit.
+
+    Args:
+        num_qubits: Number of counting qubits.
+        inexact: Whether to use an inexact eigenphase.
+    """
+
+    qc = QuantumCircuit(num_qubits + 1)
+    theta = 2 * np.pi / (2**num_qubits)
+    if inexact:
+        theta *= 1.1
+    qc.h(range(num_qubits))
+    for j in range(num_qubits):
+        qc.cp(2 ** j * theta, j, num_qubits)
+    qc.append(QFT(num_qubits, inverse=True), range(num_qubits))
+    qc = transpile(qc, basis_gates=["u", "p", "cx", "h", "x"])
+    return Circuit.from_qiskit(qc)
+
+
+def quantum_walk_circuit(num_qubits: int, depth: int) -> Circuit:
+    """Construct a simple quantum walk circuit."""
+
+    qc = QuantumCircuit(num_qubits)
+    qc.h(range(num_qubits))
+    for _ in range(depth):
+        if num_qubits > 1:
+            qc.mcx(list(range(num_qubits - 1)), num_qubits - 1)
+        qc.h(range(num_qubits))
+    qc = transpile(qc, basis_gates=["u", "p", "cx", "h", "x"])
+    return Circuit.from_qiskit(qc)
+
+
+def random_circuit(num_qubits: int, seed: int | None = None) -> Circuit:
+    """Generate a random circuit of depth ``2*num_qubits``."""
+
+    qc = qiskit_random_circuit(num_qubits, 2 * num_qubits, seed=seed)
+    qc = transpile(qc, basis_gates=["u", "p", "cx", "h", "x"])
+    return Circuit.from_qiskit(qc)
+
+
+def shor_circuit(circuit_size: int) -> Circuit:
+    """Create a toy Shor factoring circuit of a given size."""
+
+    qc = QuantumCircuit(circuit_size)
+    qc.h(range(circuit_size))
+    if circuit_size > 1:
+        qc.cx(0, circuit_size - 1)
+    qc.append(QFT(circuit_size), range(circuit_size))
+    qc = transpile(qc, basis_gates=["u", "p", "cx", "h", "x"])
+    return Circuit.from_qiskit(qc)
+
+
+def real_amplitudes_circuit(
+    num_qubits: int, reps: int = 1, entanglement: str | List[int] | List[List[int]] = "full"
+) -> Circuit:
+    """Construct a ``RealAmplitudes`` ansatz with bound parameters."""
+
+    qc = RealAmplitudes(num_qubits, reps=reps, entanglement=entanglement)
+    params = {p: 0.1 * (i + 1) for i, p in enumerate(qc.parameters)}
+    qc = qc.assign_parameters(params)
+    qc = transpile(qc, basis_gates=["u", "p", "cx", "h", "x"])
+    return Circuit.from_qiskit(qc)
+
+
+def efficient_su2_circuit(
+    num_qubits: int, reps: int = 1, entanglement: str | List[int] | List[List[int]] = "full"
+) -> Circuit:
+    """Construct an ``EfficientSU2`` ansatz with bound parameters."""
+
+    qc = EfficientSU2(num_qubits, reps=reps, entanglement=entanglement)
+    params = {p: 0.1 * (i + 1) for i, p in enumerate(qc.parameters)}
+    qc = qc.assign_parameters(params)
+    qc = transpile(qc, basis_gates=["u", "p", "cx", "h", "x"])
+    return Circuit.from_qiskit(qc)
+
+
+def two_local_circuit(
+    num_qubits: int, reps: int = 1, entanglement: str | List[int] | List[List[int]] = "full"
+) -> Circuit:
+    """Construct a ``TwoLocal`` ansatz with bound parameters."""
+
+    qc = TwoLocal(num_qubits, reps=reps, entanglement=entanglement)
+    params = {p: 0.1 * (i + 1) for i, p in enumerate(qc.parameters)}
+    qc = qc.assign_parameters(params)
     qc = transpile(qc, basis_gates=["u", "p", "cx", "h", "x"])
     return Circuit.from_qiskit(qc)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,6 +14,7 @@ dependencies = [
     "qiskit==2.1.2",
     "qiskit-qasm3-import==0.6.0",
     "stim==1.15.0",
+    "networkx",
     "pytest==8.4.1",
 ]
 


### PR DESCRIPTION
## Summary
- add generator functions for amplitude estimation, BMW-QUARK ansätze, arithmetic adders, Deutsch–Jozsa, graph states, HHL, HRS, QAOA, QNN, QPE, quantum walk, random circuits, Shor, and variational ansätze
- declare networkx dependency

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b04bd27a9083218451e21c3e5fbfee