### PR TITLE
docs: add benchmark usage guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,3 +78,6 @@ families. Select the file matching the desired qubit count (e.g.
 ``QuantumCircuit.from_qasm_file`` and convert via ``Circuit.from_qiskit``;
 decompose any gates unsupported by the chosen backend.
 
+
+See [benchmarks/README.md](benchmarks/README.md) for instructions on running
+and extending the benchmark suite.

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -1,0 +1,82 @@
+# Benchmark Suite
+
+This directory provides utilities for measuring the performance of the
+various QuASAr simulation backends and conversion primitives.
+
+## Installation
+
+The benchmarks require the core project dependencies plus a few optional
+packages for data analysis and notebooks:
+
+```bash
+pip install -e .[test]
+pip install pandas jupyter
+```
+
+## Running `run_benchmarks.py`
+
+The `run_benchmarks.py` script executes parameterised circuit families and
+records average runtimes:
+
+```bash
+python benchmarks/run_benchmarks.py --circuit ghz --qubits 4:12:2 --repetitions 5 --output results/ghz
+```
+
+- `--circuit` selects a family from [circuits.py](circuits.py) using the
+  `<name>_circuit` naming pattern.
+- `--qubits` specifies a `start:end[:step]` range.
+- `--repetitions` repeats each configuration to compute a mean and variance.
+- `--output` is the base path for the generated `.json` and `.csv` files.
+
+## Using notebooks
+
+Benchmark results can be explored with the Jupyter notebooks in
+[notebooks/](notebooks):
+
+```bash
+jupyter notebook benchmarks/notebooks/comparison.ipynb
+```
+
+## Adding circuit families
+
+New circuit generators are added to
+[circuits.py](circuits.py).  Implement a function returning a
+`Circuit` object and follow the `<name>_circuit` convention so that the
+CLI can discover it automatically.  The existing functions, such as
+[`ghz_circuit`](circuits.py), illustrate the expected structure.
+
+## Adding backends
+
+Backend adapters live in [backends.py](backends.py).  Subclass
+`_BaseAdapter` and provide a `name` along with the underlying backend
+class:
+
+```python
+class MyBackendAdapter(_BaseAdapter):
+    def __init__(self) -> None:
+        super().__init__(name="my_backend", backend_cls=MyBackend)
+```
+
+Include the new adapter in the module's `__all__` list so that it can be
+imported by `run_benchmarks.py`.
+
+## Feeding results into the cost model
+
+The JSON results produced by the runner can calibrate
+`CostEstimator` coefficients.  Compute per‑gate or per‑primitive times
+from the measurements and update the estimator in place:
+
+```python
+import json
+from quasar import CostEstimator
+
+with open("results/ghz.json") as f:
+    data = json.load(f)
+coeff = {"sv_gate": data[0]["avg_time"] / len(circuit.gates)}
+
+est = CostEstimator()
+est.update_coefficients(coeff)
+```
+
+Persist updated coefficients with `est.to_file("coeff.json")` and load
+them in future runs via `CostEstimator.from_file`.

--- a/benchmarks/run_benchmarks.py
+++ b/benchmarks/run_benchmarks.py
@@ -1,0 +1,5 @@
+"""Convenience wrapper for the benchmark command line interface."""
+from benchmark_cli import main
+
+if __name__ == "__main__":  # pragma: no cover - script entry point
+    main()


### PR DESCRIPTION
## Summary
- document benchmark dependencies, execution script and notebooks
- explain how to add circuit families and backends
- describe calibrating CostEstimator with benchmark results

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b10bcd1400832187f29d18543bc229