### PR TITLE
feat: add adapters for external simulators

### DIFF
--- a/benchmarks/runner.py
+++ b/benchmarks/runner.py
@@ -52,10 +52,17 @@ class BenchmarkRunner:
 
     # ------------------------------------------------------------------
     def run(self, circuit: Any, backend: Any) -> Dict[str, Any]:
-        """Execute ``circuit`` on ``backend`` and record the runtime."""
+        """Execute ``circuit`` on ``backend`` and record the runtime.
+
+        If ``backend`` provides a :meth:`prepare` method, it is invoked prior
+        to measurement so that only the actual simulation call is timed.
+        """
+        prepared = circuit
+        if hasattr(backend, "prepare"):
+            prepared = backend.prepare(circuit)
 
         start = time.perf_counter()
-        result = self._invoke(backend, circuit)
+        result = self._invoke(backend, prepared)
         elapsed = time.perf_counter() - start
         record = {
             "framework": getattr(backend, "name", backend.__class__.__name__),


### PR DESCRIPTION
## Summary
- add benchmark adapters for Qiskit Aer statevector and MPS simulators
- add adapter for MQT's decision diagram simulator
- allow BenchmarkRunner to precompile circuits via backend.prepare

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b17d4ff8388321989add3786acece7