### PR TITLE
Add benchmarking notebooks for common circuit families

### DIFF
--- a/benchmarks/notebooks/ghz_bench.ipynb
+++ b/benchmarks/notebooks/ghz_bench.ipynb
@@ -1,0 +1,60 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# GHZ Circuit Benchmark"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "source": [
+    "from benchmarks.circuits import ghz_circuit\n",
+    "from benchmarks.backends import (\n",
+    "    StatevectorAdapter, StimAdapter, MPSAdapter,\n",
+    "    DecisionDiagramAdapter, AerStatevectorAdapter,\n",
+    "    AerMPSAdapter, MQTDDAdapter,\n",
+    ")\n",
+    "from benchmarks.runner import BenchmarkRunner\n",
+    "from quasar import SimulationEngine\n",
+    "import pandas as pd\n",
+    "import seaborn as sns\n",
+    "import matplotlib.pyplot as plt\n",
+    "\n",
+    "qubit_counts = range(2, 13, 2)\n",
+    "backends = [StatevectorAdapter(), StimAdapter(), MPSAdapter(), DecisionDiagramAdapter()]\n",
+    "for cls in [AerStatevectorAdapter, AerMPSAdapter, MQTDDAdapter]:\n",
+    "    try:\n",
+    "        backends.append(cls())\n",
+    "    except Exception:\n",
+    "        pass\n",
+    "runner = BenchmarkRunner()\n",
+    "for n in qubit_counts:\n",
+    "    circ = ghz_circuit(n)\n",
+    "    for b in backends:\n",
+    "        rec = runner.run(circ, b)\n",
+    "        rec['qubits'] = n\n",
+    "    rec = runner.run_quasar(circ, SimulationEngine())\n",
+    "    rec['qubits'] = n\n",
+    "df = pd.DataFrame(runner.results)\n",
+    "sns.lineplot(data=df, x='qubits', y='time', hue='framework')\n",
+    "plt.yscale('log')\n",
+    "plt.show()\n"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/benchmarks/notebooks/grover_bench.ipynb
+++ b/benchmarks/notebooks/grover_bench.ipynb
@@ -1,0 +1,60 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Grover Circuit Benchmark"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "source": [
+    "from benchmarks.circuits import grover_circuit\n",
+    "from benchmarks.backends import (\n",
+    "    StatevectorAdapter, StimAdapter, MPSAdapter,\n",
+    "    DecisionDiagramAdapter, AerStatevectorAdapter,\n",
+    "    AerMPSAdapter, MQTDDAdapter,\n",
+    ")\n",
+    "from benchmarks.runner import BenchmarkRunner\n",
+    "from quasar import SimulationEngine\n",
+    "import pandas as pd\n",
+    "import seaborn as sns\n",
+    "import matplotlib.pyplot as plt\n",
+    "\n",
+    "qubit_counts = range(2, 13, 2)\n",
+    "backends = [StatevectorAdapter(), StimAdapter(), MPSAdapter(), DecisionDiagramAdapter()]\n",
+    "for cls in [AerStatevectorAdapter, AerMPSAdapter, MQTDDAdapter]:\n",
+    "    try:\n",
+    "        backends.append(cls())\n",
+    "    except Exception:\n",
+    "        pass\n",
+    "runner = BenchmarkRunner()\n",
+    "for n in qubit_counts:\n",
+    "    circ = grover_circuit(n)\n",
+    "    for b in backends:\n",
+    "        rec = runner.run(circ, b)\n",
+    "        rec['qubits'] = n\n",
+    "    rec = runner.run_quasar(circ, SimulationEngine())\n",
+    "    rec['qubits'] = n\n",
+    "df = pd.DataFrame(runner.results)\n",
+    "sns.lineplot(data=df, x='qubits', y='time', hue='framework')\n",
+    "plt.yscale('log')\n",
+    "plt.show()\n"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/benchmarks/notebooks/qft_bench.ipynb
+++ b/benchmarks/notebooks/qft_bench.ipynb
@@ -1,0 +1,60 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# QFT Circuit Benchmark"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "source": [
+    "from benchmarks.circuits import qft_circuit\n",
+    "from benchmarks.backends import (\n",
+    "    StatevectorAdapter, StimAdapter, MPSAdapter,\n",
+    "    DecisionDiagramAdapter, AerStatevectorAdapter,\n",
+    "    AerMPSAdapter, MQTDDAdapter,\n",
+    ")\n",
+    "from benchmarks.runner import BenchmarkRunner\n",
+    "from quasar import SimulationEngine\n",
+    "import pandas as pd\n",
+    "import seaborn as sns\n",
+    "import matplotlib.pyplot as plt\n",
+    "\n",
+    "qubit_counts = range(2, 13, 2)\n",
+    "backends = [StatevectorAdapter(), StimAdapter(), MPSAdapter(), DecisionDiagramAdapter()]\n",
+    "for cls in [AerStatevectorAdapter, AerMPSAdapter, MQTDDAdapter]:\n",
+    "    try:\n",
+    "        backends.append(cls())\n",
+    "    except Exception:\n",
+    "        pass\n",
+    "runner = BenchmarkRunner()\n",
+    "for n in qubit_counts:\n",
+    "    circ = qft_circuit(n)\n",
+    "    for b in backends:\n",
+    "        rec = runner.run(circ, b)\n",
+    "        rec['qubits'] = n\n",
+    "    rec = runner.run_quasar(circ, SimulationEngine())\n",
+    "    rec['qubits'] = n\n",
+    "df = pd.DataFrame(runner.results)\n",
+    "sns.lineplot(data=df, x='qubits', y='time', hue='framework')\n",
+    "plt.yscale('log')\n",
+    "plt.show()\n"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/benchmarks/notebooks/random_bench.ipynb
+++ b/benchmarks/notebooks/random_bench.ipynb
@@ -1,0 +1,60 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Random Circuit Benchmark"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "source": [
+    "from benchmarks.circuits import random_circuit\n",
+    "from benchmarks.backends import (\n",
+    "    StatevectorAdapter, StimAdapter, MPSAdapter,\n",
+    "    DecisionDiagramAdapter, AerStatevectorAdapter,\n",
+    "    AerMPSAdapter, MQTDDAdapter,\n",
+    ")\n",
+    "from benchmarks.runner import BenchmarkRunner\n",
+    "from quasar import SimulationEngine\n",
+    "import pandas as pd\n",
+    "import seaborn as sns\n",
+    "import matplotlib.pyplot as plt\n",
+    "\n",
+    "qubit_counts = range(2, 13, 2)\n",
+    "backends = [StatevectorAdapter(), StimAdapter(), MPSAdapter(), DecisionDiagramAdapter()]\n",
+    "for cls in [AerStatevectorAdapter, AerMPSAdapter, MQTDDAdapter]:\n",
+    "    try:\n",
+    "        backends.append(cls())\n",
+    "    except Exception:\n",
+    "        pass\n",
+    "runner = BenchmarkRunner()\n",
+    "for n in qubit_counts:\n",
+    "    circ = random_circuit(n, seed=42)\n",
+    "    for b in backends:\n",
+    "        rec = runner.run(circ, b)\n",
+    "        rec['qubits'] = n\n",
+    "    rec = runner.run_quasar(circ, SimulationEngine())\n",
+    "    rec['qubits'] = n\n",
+    "df = pd.DataFrame(runner.results)\n",
+    "sns.lineplot(data=df, x='qubits', y='time', hue='framework')\n",
+    "plt.yscale('log')\n",
+    "plt.show()\n"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/benchmarks/notebooks/summary.ipynb
+++ b/benchmarks/notebooks/summary.ipynb
@@ -1,0 +1,80 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Benchmark Summary",
+    "\n",
+    "This notebook aggregates runtime measurements for multiple circuit families and highlights backend crossover points."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "source": [
+    "from benchmarks.circuits import ghz_circuit, qft_circuit, grover_circuit, random_circuit\n",
+    "from benchmarks.backends import (\n",
+    "    StatevectorAdapter, StimAdapter, MPSAdapter,\n",
+    "    DecisionDiagramAdapter, AerStatevectorAdapter,\n",
+    "    AerMPSAdapter, MQTDDAdapter,\n",
+    ")\n",
+    "from benchmarks.runner import BenchmarkRunner\n",
+    "from quasar import SimulationEngine\n",
+    "import pandas as pd\n",
+    "import seaborn as sns\n",
+    "import matplotlib.pyplot as plt\n",
+    "\n",
+    "families = {\n",
+    "    'ghz': ghz_circuit,\n",
+    "    'qft': qft_circuit,\n",
+    "    'grover': grover_circuit,\n",
+    "    'random': lambda n: random_circuit(n, seed=42),\n",
+    "}\n",
+    "qubit_counts = range(2, 13, 2)\n",
+    "backends = [StatevectorAdapter(), StimAdapter(), MPSAdapter(), DecisionDiagramAdapter()]\n",
+    "for cls in [AerStatevectorAdapter, AerMPSAdapter, MQTDDAdapter]:\n",
+    "    try:\n",
+    "        backends.append(cls())\n",
+    "    except Exception:\n",
+    "        pass\n",
+    "runner = BenchmarkRunner()\n",
+    "for name, fn in families.items():\n",
+    "    for n in qubit_counts:\n",
+    "        circ = fn(n)\n",
+    "        for b in backends:\n",
+    "            rec = runner.run(circ, b)\n",
+    "            rec['qubits'] = n\n",
+    "            rec['family'] = name\n",
+    "        rec = runner.run_quasar(circ, SimulationEngine())\n",
+    "        rec['qubits'] = n\n",
+    "        rec['family'] = name\n",
+    "df = pd.DataFrame(runner.results)\n",
+    "sns.relplot(data=df, x='qubits', y='time', hue='framework', col='family', kind='line', facet_kws={'sharey': False})\n",
+    "plt.yscale('log')\n",
+    "plt.show()\n",
+    "\n",
+    "# Identify crossover points where the fastest backend changes\n",
+    "def find_crossover(group):\n",
+    "    g = group.sort_values('qubits')\n",
+    "    best = g.loc[g.groupby('qubits')['time'].idxmin()][['qubits','framework']]\n",
+    "    change = best[best['framework'] != best['framework'].shift()].copy()\n",
+    "    return change\n",
+    "crossover = df.groupby('family').apply(find_crossover)\n",
+    "crossover\n"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
## Summary
- add GHZ, QFT, Grover, and random circuit benchmark notebooks leveraging BenchmarkRunner across multiple backends
- provide a summary notebook aggregating results and highlighting backend crossover points

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b1827a3fe483218cff8d91be25e459