### PR TITLE
Include external simulators in benchmark comparison

### DIFF
--- a/benchmarks/notebooks/comparison.ipynb
+++ b/benchmarks/notebooks/comparison.ipynb
@@ -13,7 +13,16 @@
    "id": "5755f2e7",
    "metadata": {},
    "source": [
-    "This notebook demonstrates how to run benchmarks using the command line interface and visualize the results."
+    "This notebook demonstrates how to run benchmarks using the command line interface and visualize the results. It additionally compares QuASAr's native backends with external simulators from Qiskit Aer and MQT DD.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "%pip install qiskit-aer mqt.ddsim mqt-core\n"
    ]
   },
   {
@@ -179,31 +188,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
-   "id": "3079cd6c",
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2025-08-29T01:57:33.681499Z",
-     "iopub.status.busy": "2025-08-29T01:57:33.681175Z",
-     "iopub.status.idle": "2025-08-29T01:57:34.376305Z",
-     "shell.execute_reply": "2025-08-29T01:57:34.375437Z"
-    }
-   },
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "[{'framework': 'statevector',\n",
-       "  'time': 0.0006222740000225713,\n",
-       "  'result': array([0.70710678+0.j, 0.        +0.j, 0.        +0.j, 0.        +0.j,\n",
-       "         0.        +0.j, 0.        +0.j, 0.        +0.j, 0.70710678+0.j])}]"
-      ]
-     },
-     "execution_count": 4,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "metadata": {},
+   "execution_count": null,
+   "outputs": [],
    "source": [
     "import sys\n",
     "from pathlib import Path\n",
@@ -211,15 +198,38 @@
     "sys.path.append(str(nb_root))\n",
     "sys.path.append(str(nb_root.parent))\n",
     "from runner import BenchmarkRunner\n",
-    "from backends import StatevectorAdapter\n",
+    "from backends import (StatevectorAdapter, StimAdapter, MPSAdapter,\n",
+    "    DecisionDiagramAdapter, AerStatevectorAdapter, AerMPSAdapter, MQTDDAdapter)\n",
     "import circuits as circuit_lib\n",
+    "from quasar import SimulationEngine\n",
     "\n",
-    "backend = StatevectorAdapter()\n",
+    "backends = [StatevectorAdapter(), StimAdapter(), MPSAdapter(), DecisionDiagramAdapter()]\n",
+    "for cls in [AerStatevectorAdapter, AerMPSAdapter, MQTDDAdapter]:\n",
+    "    try:\n",
+    "        backends.append(cls())\n",
+    "    except Exception:\n",
+    "        pass\n",
     "runner = BenchmarkRunner()\n",
+    "engine = SimulationEngine()\n",
     "\n",
-    "circuit = circuit_lib.ghz_circuit(3)\n",
-    "runner.run(circuit, backend)\n",
-    "runner.results"
+    "for n in range(2, 13, 2):\n",
+    "    circ = circuit_lib.ghz_circuit(n)\n",
+    "    for b in backends:\n",
+    "        try:\n",
+    "            rec = runner.run(circ, b)\n",
+    "            rec['qubits'] = n\n",
+    "        except Exception:\n",
+    "            continue\n",
+    "    rec = runner.run_quasar(circ, engine)\n",
+    "    rec['qubits'] = n\n",
+    "for n in range(14, 21, 2):\n",
+    "    circ = circuit_lib.ghz_circuit(n)\n",
+    "    rec = runner.run_quasar(circ, engine)\n",
+    "    rec['qubits'] = n\n",
+    "df = pd.DataFrame(runner.results)\n",
+    "sns.lineplot(data=df, x='qubits', y='time', hue='framework')\n",
+    "plt.yscale('log')\n",
+    "plt.show()\n"
    ]
   }
  ],

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,6 +12,7 @@ dependencies = [
     "mqt-core==3.2.1",
     "mqt.ddsim==2.0.0",
     "qiskit==2.1.2",
+    "qiskit-aer==0.17.1",
     "qiskit-qasm3-import==0.6.0",
     "stim==1.15.0",
     "networkx",


### PR DESCRIPTION
## Summary
- add qiskit-aer dependency for optional Aer backends
- expand comparison notebook to install Qiskit Aer and MQT DD, run their adapters alongside QuASAr backends, and plot results

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b1c48776448321bf9f325b0ad6b7f6