### PR TITLE
Record preparation and execution times

### DIFF
--- a/benchmarks/benchmark_cli.py
+++ b/benchmarks/benchmark_cli.py
@@ -49,7 +49,7 @@ def run_suite(circuit_fn: Callable[[int], object], qubits: Iterable[int], repeti
         runner = BenchmarkRunner()
         for _ in range(repetitions):
             runner.run(circuit, backend, return_state=False)
-        times = [r["time"] for r in runner.results]
+        times = [r["run_time"] for r in runner.results]
         record = {
             "circuit": circuit_fn.__name__,
             "qubits": n,


### PR DESCRIPTION
## Summary
- Track `prepare_time` and `run_time` separately in `BenchmarkRunner` and expose them through the results DataFrame.
- Implement dedicated `StimAdapter.prepare` to compile circuits to a Stim circuit prior to simulation.
- Update CLI benchmark runner to consume new timing data.

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b30776c12483218cc07b5ae4128e81