### PR TITLE
feat: visualize prepare time vs run time

### DIFF
--- a/benchmarks/notebooks/comparison.ipynb
+++ b/benchmarks/notebooks/comparison.ipynb
@@ -228,10 +228,25 @@
     "    circ = circuit_lib.ghz_circuit(n)\n",
     "    rec = runner.run_quasar(circ, engine)\n",
     "    rec['qubits'] = n\n",
+    "\n",
+    "\n",
     "df = pd.DataFrame(runner.results)\n",
-    "sns.lineplot(data=df, x='qubits', y='time', hue='framework')\n",
+    "df['total_time'] = df['prepare_time'] + df['run_time']\n",
+    "df_long = df.melt(id_vars=['framework', 'qubits'], value_vars=['prepare_time', 'run_time'],\n",
+    "                  var_name='phase', value_name='time')\n",
+    "sns.lineplot(data=df_long, x='qubits', y='time', hue='framework', style='phase')\n",
     "plt.yscale('log')\n",
-    "plt.show()\n"
+    "plt.title('GHZ circuit benchmark')\n",
+    "plt.show()\n",
+    "\n",
+    "df[['framework', 'qubits', 'prepare_time', 'run_time', 'total_time']]\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "These results separate the **preparation** time from the actual **simulation** run time. Preparation typically includes converting circuits or planning steps, whereas simulation measures the time spent executing the circuit. The table and plot above illustrate how both components contribute to the total runtime."
    ]
   }
  ],


### PR DESCRIPTION
## Summary
- show benchmark preparation and simulation times in comparison notebook
- explain how preparation vs run time contribute to total runtime

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b309fae23c83219e863f04ed453a7c