### PR TITLE
Add optional backend selection to simulation engine

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,10 +32,10 @@ Running a circuit with :class:`quasar.SimulationEngine` returns a
 raw data:
 
 ```python
-from quasar import Circuit, SimulationEngine
+from quasar import Circuit, SimulationEngine, Backend
 
 engine = SimulationEngine()
-result = engine.simulate(Circuit([{"gate": "H", "qubits": [0]}]))
+result = engine.simulate(Circuit([{"gate": "H", "qubits": [0]}]), backend=Backend.STATEVECTOR)
 for part in result.ssd.partitions:
     state = result.ssd.extract_state(part)
     print(part.backend, type(state))
@@ -43,6 +43,11 @@ for part in result.ssd.partitions:
 
 Depending on the backend, ``state`` may be a dense NumPy vector, a list of MPS
 tensors, a ``stim.Tableau`` or a decision diagram node.
+
+The :func:`SimulationEngine.simulate` method accepts an optional ``backend``
+argument to explicitly choose the simulation backend (e.g.,
+``Backend.TABLEAU`` for Clifford circuits).  When omitted, the planner selects a
+backend automatically based on estimated cost.
 
 ## Scalable benchmark circuits
 

--- a/quasar/simulation_engine.py
+++ b/quasar/simulation_engine.py
@@ -18,7 +18,7 @@ from .analyzer import CircuitAnalyzer, AnalysisResult
 from .planner import Planner, PlanResult
 from .scheduler import Scheduler
 from .ssd import SSD
-from .cost import CostEstimator
+from .cost import CostEstimator, Backend
 from quasar_convert import ConversionEngine
 
 
@@ -61,14 +61,20 @@ class SimulationEngine:
         self.memory_threshold = memory_threshold
 
     # ------------------------------------------------------------------
-    def simulate(self, circuit: Circuit, *, memory_threshold: float | None = None) -> SimulationResult:
+    def simulate(
+        self,
+        circuit: Circuit,
+        *,
+        memory_threshold: float | None = None,
+        backend: Backend | None = None,
+    ) -> SimulationResult:
         """Simulate ``circuit`` and return the final :class:`SSD` and metrics."""
 
         analyzer = CircuitAnalyzer(circuit, estimator=self.planner.estimator)
         analysis = analyzer.analyze()
         threshold = memory_threshold if memory_threshold is not None else self.memory_threshold
-        plan = self.planner.plan(circuit, max_memory=threshold)
-        ssd = self.scheduler.run(circuit)
+        plan = self.planner.plan(circuit, max_memory=threshold, backend=backend)
+        ssd = self.scheduler.run(circuit, backend=backend)
         return SimulationResult(ssd=ssd, analysis=analysis, plan=plan)
 
 

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -69,7 +69,7 @@ class PrimitiveTrackingEngine(ConversionEngine):
 
 
 class TwoStepPlanner(Planner):
-    def plan(self, circuit):  # type: ignore[override]
+    def plan(self, circuit, *, backend=None, **kwargs):  # type: ignore[override]
         steps = [
             PlanStep(0, 5, Backend.TABLEAU),
             PlanStep(5, 6, Backend.MPS),
@@ -154,9 +154,9 @@ class CountingPlanner(Planner):
         super().__init__()
         self.calls = 0
 
-    def plan(self, circuit):
+    def plan(self, circuit, *, backend=None, **kwargs):  # type: ignore[override]
         self.calls += 1
-        return super().plan(circuit)
+        return super().plan(circuit, backend=backend, **kwargs)
 
 
 def test_scheduler_reoptimises_when_requested():
@@ -221,7 +221,7 @@ class BridgeTrackingEngine(ConversionEngine):
 
 
 class BridgePlanner(Planner):
-    def plan(self, circuit):  # type: ignore[override]
+    def plan(self, circuit, *, backend=None, **kwargs):  # type: ignore[override]
         steps = [
             PlanStep(0, 1, Backend.STATEVECTOR),
             PlanStep(1, 2, Backend.MPS),
@@ -307,7 +307,7 @@ class FailingOnceBackend(DummyBackend):
 
 
 class SVThenMPSPlanner(Planner):
-    def plan(self, circuit):  # type: ignore[override]
+    def plan(self, circuit, *, backend=None, **kwargs):  # type: ignore[override]
         steps = [
             PlanStep(0, 1, Backend.STATEVECTOR),
             PlanStep(1, 2, Backend.MPS),
@@ -336,7 +336,7 @@ class AutoTwoStepPlanner(Planner):
         super().__init__(estimator=estimator)
         self.calls = 0
 
-    def plan(self, circuit):  # type: ignore[override]
+    def plan(self, circuit, *, backend=None, **kwargs):  # type: ignore[override]
         self.calls += 1
         if not circuit.gates:
             steps = []

--- a/tests/test_simulation_engine.py
+++ b/tests/test_simulation_engine.py
@@ -1,4 +1,4 @@
-from quasar import Circuit, SimulationEngine, SSD
+from quasar import Circuit, SimulationEngine, SSD, Backend
 
 
 def test_simulation_engine_simulate_returns_metrics():
@@ -36,3 +36,14 @@ def test_memory_threshold_triggers_adaptive_plan():
     low = SimulationEngine().simulate(circuit, memory_threshold=1)
     assert low.plan.explicit_steps is None
     assert len(low.plan.steps) > 1
+
+
+def test_backend_selection():
+    circuit = Circuit([
+        {"gate": "H", "qubits": [0]},
+        {"gate": "CX", "qubits": [0, 1]},
+        {"gate": "S", "qubits": [1]},
+    ])
+    engine = SimulationEngine()
+    result = engine.simulate(circuit, backend=Backend.TABLEAU)
+    assert all(step.backend == Backend.TABLEAU for step in result.plan.steps)


### PR DESCRIPTION
## Summary
- allow choosing a specific simulation backend through `SimulationEngine.simulate`
- plumb backend choice through planner and scheduler, validating support
- document backend option in README

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b333e2465483219d9ecb0377acadff