### PR TITLE
Capture memory usage in benchmark runner

### DIFF
--- a/benchmarks/benchmark_cli.py
+++ b/benchmarks/benchmark_cli.py
@@ -51,13 +51,16 @@ def run_suite(circuit_fn: Callable[[int], object], qubits: Iterable[int], repeti
         for _ in range(repetitions):
             runner.run(circuit, backend, return_state=False)
         times = [r["run_time"] for r in runner.results]
+        memories = [r["run_memory"] for r in runner.results]
         record = {
             "circuit": circuit_fn.__name__,
             "qubits": n,
             "framework": backend.name,
             "repetitions": repetitions,
             "avg_time": statistics.mean(times),
-            "variance": statistics.pvariance(times) if repetitions > 1 else 0.0,
+            "time_variance": statistics.pvariance(times) if repetitions > 1 else 0.0,
+            "avg_memory": statistics.mean(memories),
+            "memory_variance": statistics.pvariance(memories) if repetitions > 1 else 0.0,
         }
         results.append(record)
     return results
@@ -67,7 +70,16 @@ def save_results(results: List[dict], output: Path) -> None:
     base = output.with_suffix("")
     csv_path = base.with_suffix(".csv")
     json_path = base.with_suffix(".json")
-    fields = ["circuit", "qubits", "framework", "repetitions", "avg_time", "variance"]
+    fields = [
+        "circuit",
+        "qubits",
+        "framework",
+        "repetitions",
+        "avg_time",
+        "time_variance",
+        "avg_memory",
+        "memory_variance",
+    ]
     csv_path.parent.mkdir(parents=True, exist_ok=True)
     with csv_path.open("w", newline="") as f:
         writer = csv.DictWriter(f, fieldnames=fields)

--- a/tests/test_benchmark_runner_memory.py
+++ b/tests/test_benchmark_runner_memory.py
@@ -1,0 +1,49 @@
+from benchmarks.runner import BenchmarkRunner
+
+
+class DummyBackend:
+    name = "dummy"
+
+    def prepare(self, circuit):
+        # allocate some memory to ensure tracemalloc captures it
+        self._prep = [0] * 10000
+        return circuit
+
+    def run(self, circuit, **kwargs):
+        self._run = [0] * 10000
+        return "done"
+
+
+def test_run_records_memory():
+    runner = BenchmarkRunner()
+    record = runner.run(None, DummyBackend())
+    assert record["prepare_memory"] > 0
+    assert record["run_memory"] > 0
+
+    df = runner.dataframe()
+    if isinstance(df, list):
+        assert "prepare_memory" in df[0]
+        assert "run_memory" in df[0]
+    else:  # pragma: no cover - requires pandas
+        assert set(["prepare_memory", "run_memory"]).issubset(df.columns)
+
+
+class DummyPlanner:
+    def plan(self, circuit):
+        self._data = [0] * 10000
+
+
+class DummyScheduler:
+    def __init__(self):
+        self.planner = DummyPlanner()
+
+    def run(self, circuit):
+        self._data = [0] * 10000
+        return "done"
+
+
+def test_run_quasar_records_memory():
+    runner = BenchmarkRunner()
+    record = runner.run_quasar(None, DummyScheduler())
+    assert record["prepare_memory"] > 0
+    assert record["run_memory"] > 0


### PR DESCRIPTION
## Summary
- measure peak memory usage during prepare and run phases in BenchmarkRunner
- expose prepare_memory and run_memory in results and downstream CLI
- add tests verifying memory capture

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b336414dc08321866823bfbd1bf171