### PR TITLE
feat: add benchmark mode hooks for backends

### DIFF
--- a/quasar/backends/mps.py
+++ b/quasar/backends/mps.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 """Matrix product state backend using Qiskit's MPS simulator."""
 
 from dataclasses import dataclass, field
-from typing import Dict, Sequence
+from typing import Dict, Sequence, List, Tuple
 import numpy as np
 from qiskit import QuantumCircuit
 from qiskit.circuit.library import U2Gate, UGate
@@ -24,6 +24,10 @@ class MPSBackend(Backend):
     num_qubits: int = field(default=0, init=False)
     chi: int = field(default=16, init=False)
     history: list[str] = field(default_factory=list, init=False)
+    _benchmark_mode: bool = field(default=False, init=False)
+    _benchmark_ops: List[Tuple[str, Sequence[int], Dict[str, float] | None]] = field(
+        default_factory=list, init=False
+    )
 
     # ------------------------------------------------------------------
     def load(self, num_qubits: int, **kwargs: dict) -> None:
@@ -63,6 +67,9 @@ class MPSBackend(Backend):
         qubits: Sequence[int],
         params: Dict[str, float] | None = None,
     ) -> None:
+        if self._benchmark_mode:
+            self._benchmark_ops.append((name, tuple(qubits), params))
+            return
         if self.circuit is None:
             raise RuntimeError("Backend not initialised; call 'load' first")
         lname = name.upper()

--- a/quasar/backends/mqt_dd.py
+++ b/quasar/backends/mqt_dd.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 """Wrapper for the MQT decision diagram simulators."""
 
 from dataclasses import dataclass, field
-from typing import Dict, Sequence
+from typing import Dict, Sequence, List, Tuple
 
 from mqt.core.ir import QuantumComputation
 import mqt.ddsim as ddsim
@@ -20,6 +20,10 @@ class DecisionDiagramBackend(Backend):
     num_qubits: int = field(default=0, init=False)
     history: list[str] = field(default_factory=list, init=False)
     state: object | None = field(default=None, init=False)
+    _benchmark_mode: bool = field(default=False, init=False)
+    _benchmark_ops: List[Tuple[str, Sequence[int], Dict[str, float] | None]] = field(
+        default_factory=list, init=False
+    )
 
     _ALIASES: Dict[str, str] = field(default_factory=lambda: {"SDG": "sdg", "U1": "p"})
 
@@ -46,6 +50,9 @@ class DecisionDiagramBackend(Backend):
         qubits: Sequence[int],
         params: Dict[str, float] | None = None,
     ) -> None:
+        if self._benchmark_mode:
+            self._benchmark_ops.append((name, tuple(qubits), params))
+            return
         if self.circuit is None:
             raise RuntimeError("Backend not initialised; call 'load' first")
         lname = self._ALIASES.get(name.upper(), name.lower())

--- a/quasar/backends/statevector.py
+++ b/quasar/backends/statevector.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 """Statevector backend powered by Qiskit Aer."""
 
 from dataclasses import dataclass, field
-from typing import Dict, Sequence
+from typing import Dict, Sequence, List, Tuple
 import numpy as np
 from qiskit import QuantumCircuit
 from qiskit.circuit.library import U2Gate, UGate
@@ -23,6 +23,10 @@ class StatevectorBackend(Backend):
     circuit: QuantumCircuit | None = field(default=None, init=False)
     num_qubits: int = field(default=0, init=False)
     history: list[str] = field(default_factory=list, init=False)
+    _benchmark_mode: bool = field(default=False, init=False)
+    _benchmark_ops: List[Tuple[str, Sequence[int], Dict[str, float] | None]] = field(
+        default_factory=list, init=False
+    )
 
     # ------------------------------------------------------------------
     def load(self, num_qubits: int, **_: dict) -> None:
@@ -63,6 +67,9 @@ class StatevectorBackend(Backend):
         qubits: Sequence[int],
         params: Dict[str, float] | None = None,
     ) -> None:
+        if self._benchmark_mode:
+            self._benchmark_ops.append((name, tuple(qubits), params))
+            return
         if self.circuit is None:
             raise RuntimeError("Backend not initialised; call 'load' first")
         lname = name.upper()

--- a/quasar/backends/stim_backend.py
+++ b/quasar/backends/stim_backend.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 """Wrapper around the Stim tableau simulator."""
 
 from dataclasses import dataclass, field
-from typing import Dict, Sequence
+from typing import Dict, Sequence, List, Tuple
 import stim
 
 from ..ssd import SSD, SSDPartition
@@ -17,6 +17,10 @@ class StimBackend(Backend):
     simulator: stim.TableauSimulator | None = field(default=None, init=False)
     num_qubits: int = field(default=0, init=False)
     history: list[str] = field(default_factory=list, init=False)
+    _benchmark_mode: bool = field(default=False, init=False)
+    _benchmark_ops: List[Tuple[str, Sequence[int], Dict[str, float] | None]] = field(
+        default_factory=list, init=False
+    )
 
     _ALIASES: Dict[str, str] = field(
         default_factory=lambda: {
@@ -54,6 +58,9 @@ class StimBackend(Backend):
         qubits: Sequence[int],
         params: Dict[str, float] | None = None,
     ) -> None:
+        if self._benchmark_mode:
+            self._benchmark_ops.append((name, tuple(qubits), params))
+            return
         if self.simulator is None:
             raise RuntimeError("Backend not initialised; call 'load' first")
         lname = self._ALIASES.get(name.upper(), name.lower())

--- a/tests/test_backend_benchmark_hooks.py
+++ b/tests/test_backend_benchmark_hooks.py
@@ -1,0 +1,35 @@
+from benchmarks.runner import BenchmarkRunner
+from quasar.backends.base import Backend
+from quasar.circuit import Circuit
+
+class DummyBackend(Backend):
+    def __init__(self):
+        self._benchmark_mode = False
+        self._benchmark_ops = []
+        self.executed = []
+
+    def load(self, num_qubits: int, **kwargs):
+        pass
+
+    def ingest(self, state):
+        pass
+
+    def apply_gate(self, name, qubits, params=None):
+        if self._benchmark_mode:
+            self._benchmark_ops.append((name, qubits, params))
+        else:
+            self.executed.append(name)
+
+    def extract_ssd(self):
+        return self.executed
+
+    def statevector(self):
+        return self.executed
+
+def test_benchmark_runner_uses_hooks():
+    circuit = Circuit([{"gate": "H", "qubits": [0]}])
+    backend = DummyBackend()
+    runner = BenchmarkRunner()
+    record = runner.run(circuit, backend)
+    assert backend.executed == ["H"]
+    assert record["result"] == ["H"]


### PR DESCRIPTION
## Summary
- add generic benchmark preparation and execution hooks to Backend
- queue gate descriptors during benchmarking and execute them on demand
- update BenchmarkRunner to leverage backend benchmark hooks
- test backend benchmarking to ensure hooks are used

## Testing
- `python -m pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b3382b33788321af24c81ede69eabf