### PR TITLE
feat: allow selecting Aer simulator method for backends

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,18 @@ argument to explicitly choose the simulation backend (e.g.,
 ``Backend.TABLEAU`` for Clifford circuits).  When omitted, the planner selects a
 backend automatically based on estimated cost.
 
+Dense backends are powered by Qiskit Aer and accept a ``method`` argument to
+select the underlying simulator implementation.  For example::
+
+    from quasar.backends import StatevectorBackend
+    backend = StatevectorBackend(method="density_matrix")
+
+Convenience classes :class:`AerStatevectorBackend` and :class:`AerMPSBackend`
+preconfigure the common ``statevector`` and ``matrix_product_state`` methods
+respectively.  Custom backend instances can be supplied to :class:`Scheduler`
+or :class:`SimulationEngine` via their ``backends`` argument to control the
+simulation method.
+
 ## Scalable benchmark circuits
 
 QuASAr can simulate parameterized circuits sourced from MQTBench and QASMBench.

--- a/quasar/__init__.py
+++ b/quasar/__init__.py
@@ -11,7 +11,9 @@ from .calibration import run_calibration, save_coefficients
 from .backends import (
     Backend as SimulatorBackend,
     StatevectorBackend,
+    AerStatevectorBackend,
     MPSBackend,
+    AerMPSBackend,
     StimBackend,
     DecisionDiagramBackend,
 )
@@ -39,7 +41,9 @@ __all__ = [
     "save_coefficients",
     "SimulatorBackend",
     "StatevectorBackend",
+    "AerStatevectorBackend",
     "MPSBackend",
+    "AerMPSBackend",
     "StimBackend",
     "DecisionDiagramBackend",
     "CircuitAnalyzer",

--- a/quasar/backends/__init__.py
+++ b/quasar/backends/__init__.py
@@ -5,7 +5,7 @@ from ..cost import Backend as BackendType
 
 # Core backends -----------------------------------------------------------
 try:  # pragma: no cover - optional dependency
-    from .statevector import StatevectorBackend
+    from .statevector import StatevectorBackend, AerStatevectorBackend
 except ImportError as exc:  # pragma: no cover - executed when qiskit is missing
     class StatevectorBackend(Backend):
         """Stub when Qiskit Aer is not installed."""
@@ -20,8 +20,11 @@ except ImportError as exc:  # pragma: no cover - executed when qiskit is missing
 
         load = ingest = apply_gate = extract_ssd = statevector = _unavailable
 
+    class AerStatevectorBackend(StatevectorBackend):
+        pass
+
 try:  # pragma: no cover - optional dependency
-    from .mps import MPSBackend
+    from .mps import MPSBackend, AerMPSBackend
 except ImportError as exc:  # pragma: no cover - executed when qiskit is missing
     class MPSBackend(Backend):
         """Stub when Qiskit Aer is not installed."""
@@ -35,6 +38,9 @@ except ImportError as exc:  # pragma: no cover - executed when qiskit is missing
             ) from exc
 
         load = ingest = apply_gate = extract_ssd = statevector = _unavailable
+
+    class AerMPSBackend(MPSBackend):
+        pass
 
 # Optional backends -------------------------------------------------------
 try:  # pragma: no cover - optional dependency
@@ -72,7 +78,9 @@ except ImportError as exc:  # pragma: no cover - executed when MQT libraries mis
 __all__ = [
     "Backend",
     "StatevectorBackend",
+    "AerStatevectorBackend",
     "MPSBackend",
+    "AerMPSBackend",
     "StimBackend",
     "DecisionDiagramBackend",
 ]

--- a/quasar/scheduler.py
+++ b/quasar/scheduler.py
@@ -13,8 +13,8 @@ from .cost import Backend, Cost
 from .circuit import Circuit
 from .ssd import SSD, ConversionLayer, SSDPartition
 from .backends import (
-    StatevectorBackend as AerStatevectorBackend,
-    MPSBackend as AerMPSBackend,
+    AerStatevectorBackend,
+    AerMPSBackend,
     StimBackend,
     DecisionDiagramBackend,
 )
@@ -37,9 +37,10 @@ class Scheduler:
         self.conversion_engine = self.conversion_engine or ConversionEngine()
         if self.backends is None:
             # Instantiate default simulation backends.  The dense
-            # representations use Qiskit Aer implementations while the
-            # other optional backends fall back to stub classes when their
-            # dependencies are missing.
+            # representations use Qiskit Aer implementations; callers may
+            # supply instances with custom ``method`` arguments via the
+            # ``backends`` parameter.  The other optional backends fall back
+            # to stub classes when their dependencies are missing.
             self.backends = {
                 Backend.STATEVECTOR: AerStatevectorBackend(),
                 Backend.MPS: AerMPSBackend(),

--- a/tests/test_backends.py
+++ b/tests/test_backends.py
@@ -27,6 +27,16 @@ def test_mps_backend():
     _exercise_backend(MPSBackend)
 
 
+def test_statevector_backend_rejects_unknown_method():
+    with pytest.raises(ValueError):
+        StatevectorBackend(method="bogus")
+
+
+def test_mps_backend_rejects_unknown_method():
+    with pytest.raises(ValueError):
+        MPSBackend(method="bogus")
+
+
 def test_stim_backend():
     _exercise_backend(StimBackend)
 


### PR DESCRIPTION
## Summary
- add `method` parameter to StatevectorBackend and MPSBackend with validation
- provide `AerStatevectorBackend` and `AerMPSBackend` convenience classes
- document Aer `method` selection and update scheduler default backends

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b339fa8618832190c8939325fa6f07