### PR TITLE
Record per-phase peak memory in benchmarks

### DIFF
--- a/benchmarks/benchmark_cli.py
+++ b/benchmarks/benchmark_cli.py
@@ -51,7 +51,8 @@ def run_suite(circuit_fn: Callable[[int], object], qubits: Iterable[int], repeti
         for _ in range(repetitions):
             runner.run(circuit, backend, return_state=False)
         times = [r["run_time"] for r in runner.results]
-        memories = [r["run_memory"] for r in runner.results]
+        run_memories = [r["run_peak_memory"] for r in runner.results]
+        prepare_memories = [r["prepare_peak_memory"] for r in runner.results]
         record = {
             "circuit": circuit_fn.__name__,
             "qubits": n,
@@ -59,8 +60,14 @@ def run_suite(circuit_fn: Callable[[int], object], qubits: Iterable[int], repeti
             "repetitions": repetitions,
             "avg_time": statistics.mean(times),
             "time_variance": statistics.pvariance(times) if repetitions > 1 else 0.0,
-            "avg_memory": statistics.mean(memories),
-            "memory_variance": statistics.pvariance(memories) if repetitions > 1 else 0.0,
+            "avg_prepare_peak_memory": statistics.mean(prepare_memories),
+            "prepare_peak_memory_variance": statistics.pvariance(prepare_memories)
+            if repetitions > 1
+            else 0.0,
+            "avg_run_peak_memory": statistics.mean(run_memories),
+            "run_peak_memory_variance": statistics.pvariance(run_memories)
+            if repetitions > 1
+            else 0.0,
         }
         results.append(record)
     return results
@@ -77,8 +84,10 @@ def save_results(results: List[dict], output: Path) -> None:
         "repetitions",
         "avg_time",
         "time_variance",
-        "avg_memory",
-        "memory_variance",
+        "avg_prepare_peak_memory",
+        "prepare_peak_memory_variance",
+        "avg_run_peak_memory",
+        "run_peak_memory_variance",
     ]
     csv_path.parent.mkdir(parents=True, exist_ok=True)
     with csv_path.open("w", newline="") as f:

--- a/tests/test_benchmark_runner_memory.py
+++ b/tests/test_benchmark_runner_memory.py
@@ -17,15 +17,15 @@ class DummyBackend:
 def test_run_records_memory():
     runner = BenchmarkRunner()
     record = runner.run(None, DummyBackend())
-    assert record["prepare_memory"] > 0
-    assert record["run_memory"] > 0
+    assert record["prepare_peak_memory"] > 0
+    assert record["run_peak_memory"] > 0
 
     df = runner.dataframe()
     if isinstance(df, list):
-        assert "prepare_memory" in df[0]
-        assert "run_memory" in df[0]
+        assert "prepare_peak_memory" in df[0]
+        assert "run_peak_memory" in df[0]
     else:  # pragma: no cover - requires pandas
-        assert set(["prepare_memory", "run_memory"]).issubset(df.columns)
+        assert set(["prepare_peak_memory", "run_peak_memory"]).issubset(df.columns)
 
 
 class DummyPlanner:
@@ -45,5 +45,5 @@ class DummyScheduler:
 def test_run_quasar_records_memory():
     runner = BenchmarkRunner()
     record = runner.run_quasar(None, DummyScheduler())
-    assert record["prepare_memory"] > 0
-    assert record["run_memory"] > 0
+    assert record["prepare_peak_memory"] > 0
+    assert record["run_peak_memory"] > 0


### PR DESCRIPTION
## Summary
- measure preparation and run peak memory separately using `tracemalloc.reset_peak`
- expose `prepare_peak_memory` and `run_peak_memory` in benchmark results
- report per-phase peak memory statistics in the benchmark CLI

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68b33f895c6c8321ad2e52187cb37170