### PR TITLE
Add run method to apply queued gates in Stim and DD backends

### DIFF
--- a/quasar/backends/mqt_dd.py
+++ b/quasar/backends/mqt_dd.py
@@ -63,7 +63,19 @@ class DecisionDiagramBackend(Backend):
         func(*args, *qubits)
         self.history.append(name.upper())
 
+    # ------------------------------------------------------------------
+    def run(self) -> None:
+        """Apply any operations queued during benchmark preparation."""
+        if not self._benchmark_ops:
+            return
+        ops = self._benchmark_ops
+        self._benchmark_ops = []
+        self._benchmark_mode = False
+        for name, qubits, params in ops:
+            self.apply_gate(name, qubits, params)
+
     def extract_ssd(self) -> SSD:
+        self.run()
         if self.circuit is None:
             raise RuntimeError("Backend not initialised; call 'load' first")
         if self.state is not None and not self.history:
@@ -87,4 +99,5 @@ class DecisionDiagramBackend(Backend):
         The decision diagram package does not currently expose an efficient
         statevector extraction method, hence this is left unimplemented.
         """
+        self.run()
         raise NotImplementedError("Statevector extraction not supported")

--- a/quasar/backends/stim_backend.py
+++ b/quasar/backends/stim_backend.py
@@ -82,7 +82,19 @@ class StimBackend(Backend):
         func(*qubits)
         self.history.append(name.upper())
 
+    # ------------------------------------------------------------------
+    def run(self) -> None:
+        """Apply any operations queued during benchmark preparation."""
+        if not self._benchmark_ops:
+            return
+        ops = self._benchmark_ops
+        self._benchmark_ops = []
+        self._benchmark_mode = False
+        for name, qubits, params in ops:
+            self.apply_gate(name, qubits, params)
+
     def extract_ssd(self) -> SSD:
+        self.run()
         tableau = None
         if self.simulator is not None:
             try:
@@ -100,6 +112,7 @@ class StimBackend(Backend):
     # ------------------------------------------------------------------
     def statevector(self) -> Sequence[complex]:
         """Return a dense statevector for the current tableau state."""
+        self.run()
         if self.simulator is None:
             raise RuntimeError("Backend not initialised; call 'load' first")
         # Stim returns a numpy array of complex amplitudes


### PR DESCRIPTION
## Summary
- queue gates when benchmark mode is active and replay them via new `run` method
- ensure `run` flushes operations before `extract_ssd`/`statevector`

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b340f6cc208321bdb55885e94d9d51