### PR TITLE
Add backend-specific benchmark notebooks

### DIFF
--- a/benchmarks/notebooks/mps_backend.ipynb
+++ b/benchmarks/notebooks/mps_backend.ipynb
@@ -1,0 +1,54 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "64292951",
+   "metadata": {},
+   "source": [
+    "# Matrix Product State (MPS) backend benchmark\n",
+    "\n",
+    "This notebook runs a small selection of example circuits solely on the `Matrix Product State (MPS)` simulator. It demonstrates how to use `BenchmarkRunner` for collecting timing and memory metrics. Extend the `circuits_to_run` list or adjust parameters to analyze additional workloads.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "09be0175",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from benchmarks.backends import MPSAdapter\n",
+    "from benchmarks.runner import BenchmarkRunner\n",
+    "from benchmarks import circuits\n",
+    "import pandas as pd"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "efb8f7ab",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Select representative circuits\n",
+    "circuits_to_run = [\n",
+    "    (\"GHZ\", circuits.ghz_circuit(5)),\n",
+    "    (\"QFT\", circuits.qft_circuit(5)),\n",
+    "    (\"Grover\", circuits.grover_circuit(5, 1)),\n",
+    "]\n",
+    "\n",
+    "runner = BenchmarkRunner()\n",
+    "backend = MPSAdapter()\n",
+    "for name, circ in circuits_to_run:\n",
+    "    res = runner.run(circ, backend, return_state=False)\n",
+    "    res[\"circuit\"] = name\n",
+    "\n",
+    "df = runner.dataframe()\n",
+    "df[[\"circuit\", \"prepare_time\", \"run_time\", \"prepare_peak_memory\", \"run_peak_memory\"]]\n"
+   ]
+  }
+ ],
+ "metadata": {},
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/benchmarks/notebooks/mqt_dd_backend.ipynb
+++ b/benchmarks/notebooks/mqt_dd_backend.ipynb
@@ -1,0 +1,54 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "a4822faa",
+   "metadata": {},
+   "source": [
+    "# MQT Decision Diagram backend benchmark\n",
+    "\n",
+    "This notebook runs a small selection of example circuits solely on the `MQT Decision Diagram` simulator. It demonstrates how to use `BenchmarkRunner` for collecting timing and memory metrics. Extend the `circuits_to_run` list or adjust parameters to analyze additional workloads.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "214ffc01",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from benchmarks.backends import DecisionDiagramAdapter\n",
+    "from benchmarks.runner import BenchmarkRunner\n",
+    "from benchmarks import circuits\n",
+    "import pandas as pd"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "d021b28d",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Select representative circuits\n",
+    "circuits_to_run = [\n",
+    "    (\"GHZ\", circuits.ghz_circuit(5)),\n",
+    "    (\"QFT\", circuits.qft_circuit(5)),\n",
+    "    (\"Grover\", circuits.grover_circuit(5, 1)),\n",
+    "]\n",
+    "\n",
+    "runner = BenchmarkRunner()\n",
+    "backend = DecisionDiagramAdapter()\n",
+    "for name, circ in circuits_to_run:\n",
+    "    res = runner.run(circ, backend, return_state=False)\n",
+    "    res[\"circuit\"] = name\n",
+    "\n",
+    "df = runner.dataframe()\n",
+    "df[[\"circuit\", \"prepare_time\", \"run_time\", \"prepare_peak_memory\", \"run_peak_memory\"]]\n"
+   ]
+  }
+ ],
+ "metadata": {},
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/benchmarks/notebooks/statevector_backend.ipynb
+++ b/benchmarks/notebooks/statevector_backend.ipynb
@@ -1,0 +1,54 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "68432bc9",
+   "metadata": {},
+   "source": [
+    "# Statevector backend benchmark\n",
+    "\n",
+    "This notebook runs a small selection of example circuits solely on the `Statevector` simulator. It demonstrates how to use `BenchmarkRunner` for collecting timing and memory metrics. Extend the `circuits_to_run` list or adjust parameters to analyze additional workloads.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "ce56975c",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from benchmarks.backends import StatevectorAdapter\n",
+    "from benchmarks.runner import BenchmarkRunner\n",
+    "from benchmarks import circuits\n",
+    "import pandas as pd"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "3538a1de",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Select representative circuits\n",
+    "circuits_to_run = [\n",
+    "    (\"GHZ\", circuits.ghz_circuit(5)),\n",
+    "    (\"QFT\", circuits.qft_circuit(5)),\n",
+    "    (\"Grover\", circuits.grover_circuit(5, 1)),\n",
+    "]\n",
+    "\n",
+    "runner = BenchmarkRunner()\n",
+    "backend = StatevectorAdapter()\n",
+    "for name, circ in circuits_to_run:\n",
+    "    res = runner.run(circ, backend, return_state=False)\n",
+    "    res[\"circuit\"] = name\n",
+    "\n",
+    "df = runner.dataframe()\n",
+    "df[[\"circuit\", \"prepare_time\", \"run_time\", \"prepare_peak_memory\", \"run_peak_memory\"]]\n"
+   ]
+  }
+ ],
+ "metadata": {},
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/benchmarks/notebooks/stim_backend.ipynb
+++ b/benchmarks/notebooks/stim_backend.ipynb
@@ -1,0 +1,54 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "16ef742d",
+   "metadata": {},
+   "source": [
+    "# Stim backend benchmark\n",
+    "\n",
+    "This notebook runs a small selection of example circuits solely on the `Stim` simulator. It demonstrates how to use `BenchmarkRunner` for collecting timing and memory metrics. Extend the `circuits_to_run` list or adjust parameters to analyze additional workloads.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "53ea4c8f",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from benchmarks.backends import StimAdapter\n",
+    "from benchmarks.runner import BenchmarkRunner\n",
+    "from benchmarks import circuits\n",
+    "import pandas as pd"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "f265261e",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Select representative circuits\n",
+    "circuits_to_run = [\n",
+    "    (\"GHZ\", circuits.ghz_circuit(5)),\n",
+    "    (\"QFT\", circuits.qft_circuit(5)),\n",
+    "    (\"Grover\", circuits.grover_circuit(5, 1)),\n",
+    "]\n",
+    "\n",
+    "runner = BenchmarkRunner()\n",
+    "backend = StimAdapter()\n",
+    "for name, circ in circuits_to_run:\n",
+    "    res = runner.run(circ, backend, return_state=False)\n",
+    "    res[\"circuit\"] = name\n",
+    "\n",
+    "df = runner.dataframe()\n",
+    "df[[\"circuit\", \"prepare_time\", \"run_time\", \"prepare_peak_memory\", \"run_peak_memory\"]]\n"
+   ]
+  }
+ ],
+ "metadata": {},
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
## Summary
- Add Jupyter notebooks for statevector, MPS, Stim, and MQT decision diagram backends
- Each notebook runs sample circuits and records timing/memory with `BenchmarkRunner`
- Provide documentation inside notebooks on how to extend benchmarks

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b348dcb5048321a7a26251d83d8cbc