### PR TITLE
Add total runtime metric to benchmark results

### DIFF
--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -28,11 +28,13 @@ python benchmarks/run_benchmarks.py --circuit ghz --qubits 4:12:2 --repetitions 
 - `--repetitions` repeats each configuration to compute a mean and variance.
 - `--output` is the base path for the generated `.json` and `.csv` files.
 
-Each benchmark records two separate timings:
+Each benchmark records separate timings for the preparation and execution
+phases as well as their sum:
 
 - **prepare_time** – conversion, circuit construction and any backend specific
   compilation that happens before execution.
 - **run_time** – execution of the prepared circuit on the backend.
+- **total_time** – combined runtime of both phases.
 
 Adapters are expected to perform heavy translation work in the preparation
 phase so that `run_time` reflects only the actual simulation cost.

--- a/benchmarks/benchmark_cli.py
+++ b/benchmarks/benchmark_cli.py
@@ -51,6 +51,7 @@ def run_suite(circuit_fn: Callable[[int], object], qubits: Iterable[int], repeti
         for _ in range(repetitions):
             runner.run(circuit, backend, return_state=False)
         times = [r["run_time"] for r in runner.results]
+        total_times = [r["total_time"] for r in runner.results]
         run_memories = [r["run_peak_memory"] for r in runner.results]
         prepare_memories = [r["prepare_peak_memory"] for r in runner.results]
         record = {
@@ -60,6 +61,8 @@ def run_suite(circuit_fn: Callable[[int], object], qubits: Iterable[int], repeti
             "repetitions": repetitions,
             "avg_time": statistics.mean(times),
             "time_variance": statistics.pvariance(times) if repetitions > 1 else 0.0,
+            "avg_total_time": statistics.mean(total_times),
+            "total_time_variance": statistics.pvariance(total_times) if repetitions > 1 else 0.0,
             "avg_prepare_peak_memory": statistics.mean(prepare_memories),
             "prepare_peak_memory_variance": statistics.pvariance(prepare_memories)
             if repetitions > 1
@@ -84,6 +87,8 @@ def save_results(results: List[dict], output: Path) -> None:
         "repetitions",
         "avg_time",
         "time_variance",
+        "avg_total_time",
+        "total_time_variance",
         "avg_prepare_peak_memory",
         "prepare_peak_memory_variance",
         "avg_run_peak_memory",

--- a/benchmarks/notebooks/comparison.ipynb
+++ b/benchmarks/notebooks/comparison.ipynb
@@ -259,7 +259,7 @@
     "        rec[\"qubits\"] = n\n",
     "\n",
     "df = pd.DataFrame(runner.results)\n",
-    "df[\"total_time\"] = df[\"prepare_time\"] + df[\"run_time\"]\n",
+    "# total_time provided by BenchmarkRunner\n",
     "df_long = df.melt(id_vars=[\"circuit\", \"framework\", \"qubits\"], value_vars=[\"prepare_time\", \"run_time\"], var_name=\"phase\", value_name=\"time\")\n",
     "g = sns.relplot(data=df_long, x=\"qubits\", y=\"time\", hue=\"framework\", style=\"phase\", col=\"circuit\", col_wrap=3, kind=\"line\")\n",
     "g.set(yscale=\"log\")\n",

--- a/benchmarks/notebooks/mps_backend.ipynb
+++ b/benchmarks/notebooks/mps_backend.ipynb
@@ -44,7 +44,7 @@
     "    res[\"circuit\"] = name\n",
     "\n",
     "df = runner.dataframe()\n",
-    "df[[\"circuit\", \"prepare_time\", \"run_time\", \"prepare_peak_memory\", \"run_peak_memory\"]]\n"
+    "df[[\"circuit\", \"prepare_time\", \"run_time\", \"total_time\", \"prepare_peak_memory\", \"run_peak_memory\"]]\n"
    ]
   }
  ],

--- a/benchmarks/notebooks/mqt_dd_backend.ipynb
+++ b/benchmarks/notebooks/mqt_dd_backend.ipynb
@@ -44,7 +44,7 @@
     "    res[\"circuit\"] = name\n",
     "\n",
     "df = runner.dataframe()\n",
-    "df[[\"circuit\", \"prepare_time\", \"run_time\", \"prepare_peak_memory\", \"run_peak_memory\"]]\n"
+    "df[[\"circuit\", \"prepare_time\", \"run_time\", \"total_time\", \"prepare_peak_memory\", \"run_peak_memory\"]]\n"
    ]
   }
  ],

--- a/benchmarks/notebooks/statevector_backend.ipynb
+++ b/benchmarks/notebooks/statevector_backend.ipynb
@@ -44,7 +44,7 @@
     "    res[\"circuit\"] = name\n",
     "\n",
     "df = runner.dataframe()\n",
-    "df[[\"circuit\", \"prepare_time\", \"run_time\", \"prepare_peak_memory\", \"run_peak_memory\"]]\n"
+    "df[[\"circuit\", \"prepare_time\", \"run_time\", \"total_time\", \"prepare_peak_memory\", \"run_peak_memory\"]]\n"
    ]
   }
  ],

--- a/benchmarks/notebooks/stim_backend.ipynb
+++ b/benchmarks/notebooks/stim_backend.ipynb
@@ -44,7 +44,7 @@
     "    res[\"circuit\"] = name\n",
     "\n",
     "df = runner.dataframe()\n",
-    "df[[\"circuit\", \"prepare_time\", \"run_time\", \"prepare_peak_memory\", \"run_peak_memory\"]]\n"
+    "df[[\"circuit\", \"prepare_time\", \"run_time\", \"total_time\", \"prepare_peak_memory\", \"run_peak_memory\"]]\n"
    ]
   }
  ],

--- a/benchmarks/runner.py
+++ b/benchmarks/runner.py
@@ -99,6 +99,7 @@ class BenchmarkRunner:
             "framework": getattr(backend, "name", backend.__class__.__name__),
             "prepare_time": prepare_time,
             "run_time": run_time,
+            "total_time": prepare_time + run_time,
             "prepare_peak_memory": prepare_peak_memory,
             "run_peak_memory": run_peak_memory,
             "result": result,
@@ -139,6 +140,7 @@ class BenchmarkRunner:
             "framework": "quasar",
             "prepare_time": prepare_time,
             "run_time": run_time,
+            "total_time": prepare_time + run_time,
             "prepare_peak_memory": prepare_peak_memory,
             "run_peak_memory": run_peak_memory,
             "result": result,
@@ -151,8 +153,8 @@ class BenchmarkRunner:
         """Return collected results as a :class:`pandas.DataFrame` if available.
 
         The returned data includes separate ``prepare_time``/``run_time`` and
-        ``prepare_peak_memory``/``run_peak_memory`` columns for downstream
-        analysis.
+        their sum ``total_time`` as well as ``prepare_peak_memory``/``run_peak_memory``
+        columns for downstream analysis.
         """
 
         if pd is None:

--- a/tests/test_benchmark_total_time.py
+++ b/tests/test_benchmark_total_time.py
@@ -1,0 +1,29 @@
+from unittest.mock import patch
+
+from benchmarks.runner import BenchmarkRunner
+from quasar.circuit import Circuit
+
+
+class MockBackend:
+    """Backend that exposes ``prepare`` and ``run`` without delays."""
+
+    name = "mock"
+
+    def prepare(self, circuit: Circuit) -> Circuit:
+        return circuit
+
+    def run(self, circuit: Circuit, **_):
+        return None
+
+
+def test_total_time_sums_prepare_and_run():
+    circuit = Circuit([{"gate": "H", "qubits": [0]}])
+    backend = MockBackend()
+    runner = BenchmarkRunner()
+    # Simulate timings: prepare takes 1s, run takes 2s
+    with patch("benchmarks.runner.time.perf_counter", side_effect=[0.0, 1.0, 1.0, 3.0]):
+        record = runner.run(circuit, backend)
+    assert record["prepare_time"] == 1.0
+    assert record["run_time"] == 2.0
+    assert record["total_time"] == 3.0
+    assert record["total_time"] == record["prepare_time"] + record["run_time"]


### PR DESCRIPTION
## Summary
- Include `total_time` (prepare + run) in `BenchmarkRunner` records
- Surface average total runtime in benchmark CLI output
- Document and exercise `total_time` in benchmarks and tests

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b34e3712748321a3e47e541ae4225f