### PR TITLE
refactor: use mqt.dd package for decision diagrams

### DIFF
--- a/quasar/backends/__init__.py
+++ b/quasar/backends/__init__.py
@@ -69,8 +69,8 @@ except ImportError as exc:  # pragma: no cover - executed when MQT libraries mis
 
         def _unavailable(self, *_, **__):
             raise ImportError(
-                "DecisionDiagramBackend requires the 'mqt.core' and 'mqt.ddsim' "
-                "packages. Install them to use this backend."
+                "DecisionDiagramBackend requires the 'mqt.core' package. "
+                "Install it to use this backend."
             ) from exc
 
         load = ingest = apply_gate = extract_ssd = _unavailable


### PR DESCRIPTION
## Summary
- replace ddsim usage with direct `DDPackage` operations for incremental gate application
- simplify optional backend import message

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b353b963308321b0e4495b1f528b1c