### PR TITLE
Add quick single backend shortcut in Planner

### DIFF
--- a/tests/test_planner.py
+++ b/tests/test_planner.py
@@ -30,7 +30,7 @@ def test_split_and_recover():
         "ingest_sv": 0.0,
         "dd_gate": 10.0,
     }
-    planner = Planner(CostEstimator(coeff))
+    planner = Planner(CostEstimator(coeff), quick_max_qubits=None, quick_max_gates=None, quick_max_depth=None)
     result = planner.plan(circ)
     steps = result.steps
     assert [(s.start, s.end, s.backend) for s in steps] == [

--- a/tests/test_planner_batch_pruning.py
+++ b/tests/test_planner_batch_pruning.py
@@ -60,14 +60,22 @@ def test_batch_pruning_speed_and_quality():
     circuit = _build_circuit(40)
 
     start = time.perf_counter()
-    base = Planner(top_k=4, batch_size=1).plan(circuit)
+    base = Planner(top_k=4, batch_size=1, quick_max_qubits=None, quick_max_gates=None, quick_max_depth=None).plan(circuit)
     t_base = time.perf_counter() - start
-    cost_base = _plan_cost(Planner(top_k=4, batch_size=1), circuit, base.steps).time
+    cost_base = _plan_cost(
+        Planner(top_k=4, batch_size=1, quick_max_qubits=None, quick_max_gates=None, quick_max_depth=None),
+        circuit,
+        base.steps,
+    ).time
 
     start = time.perf_counter()
-    fast = Planner(top_k=1, batch_size=5).plan(circuit)
+    fast = Planner(top_k=1, batch_size=5, quick_max_qubits=None, quick_max_gates=None, quick_max_depth=None).plan(circuit)
     t_fast = time.perf_counter() - start
-    cost_fast = _plan_cost(Planner(top_k=1, batch_size=5), circuit, fast.steps).time
+    cost_fast = _plan_cost(
+        Planner(top_k=1, batch_size=5, quick_max_qubits=None, quick_max_gates=None, quick_max_depth=None),
+        circuit,
+        fast.steps,
+    ).time
 
     assert t_fast < t_base
     assert cost_fast <= cost_base * 1.2

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -1,5 +1,5 @@
-from quasar import Circuit, Scheduler, Planner
-from quasar.planner import PlanStep
+from quasar import Circuit, Scheduler
+from quasar.planner import PlanStep, Planner
 from quasar_convert import ConversionEngine
 from quasar.cost import Backend, CostEstimator
 from quasar import SSD
@@ -118,7 +118,10 @@ def build_switch_circuit_rz():
 
 def test_scheduler_triggers_conversion():
     engine = CountingConversionEngine()
-    scheduler = Scheduler(conversion_engine=engine)
+    scheduler = Scheduler(
+        conversion_engine=engine,
+        planner=Planner(quick_max_qubits=None, quick_max_gates=None, quick_max_depth=None),
+    )
     circuit = build_switch_circuit()
     plan = scheduler.planner.plan(circuit)
     scheduler.run(circuit)


### PR DESCRIPTION
## Summary
- add optional quick thresholds for qubits, gates, and depth
- bypass dynamic programming for small circuits with single backend estimate
- adjust tests to account for optional quick planning shortcut

## Testing
- `python -m pytest tests/test_planner.py::test_split_and_recover tests/test_scheduler.py::test_scheduler_triggers_conversion -q`
- `python -m pytest tests/test_planner_batch_pruning.py::test_batch_pruning_speed_and_quality -q`
- `python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68b40025584483219c0b56132d00e067