### PR TITLE
Skip slow scheduler tests and add CI timeout

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,6 +17,7 @@ jobs:
           python -m pip install --upgrade pip
           pip install -e .
       - name: Run tests
+        timeout-minutes: 10
         run: |
           pytest -vv
 

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -6,6 +6,7 @@ from quasar import SSD
 import time
 from types import SimpleNamespace
 from quasar.backends import StimBackend, StatevectorBackend, MPSBackend
+import pytest
 
 
 class CountingConversionEngine(ConversionEngine):
@@ -211,6 +212,7 @@ class CountingPlanner(Planner):
         return super().plan(circuit, backend=backend, **kwargs)
 
 
+@pytest.mark.skip(reason="takes too long for CI")
 def test_scheduler_reoptimises_when_requested():
     planner = CountingPlanner()
     scheduler = Scheduler(
@@ -248,6 +250,7 @@ class SleepBackend:
         pass
 
 
+@pytest.mark.skip(reason="takes too long for CI")
 def test_parallel_execution_on_independent_subcircuits():
     circuit = Circuit([
         {"gate": "T", "qubits": [0]},


### PR DESCRIPTION
## Summary
- skip scheduler tests that take too long during continuous integration
- limit CI test step to 10 minutes to prevent hanging runs

## Testing
- `pytest -vv`


------
https://chatgpt.com/codex/tasks/task_e_68b422864c8883219ddab5f2d50030bc