### PR TITLE
Add runtime configuration hooks for planner and scheduler

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,23 @@ respectively.  Custom backend instances can be supplied to :class:`Scheduler`
 or :class:`SimulationEngine` via their ``backends`` argument to control the
 simulation method.
 
+## Configuration
+
+QuASAr exposes a small set of tunables that influence planning heuristics.  The
+default values are defined in ``quasar/config.py`` and may be overridden either
+programmatically or via environment variables at import time:
+
+* ``QUASAR_QUICK_MAX_QUBITS`` – maximum number of qubits for the quick-path
+  estimate.  Set to ``None`` to disable.
+* ``QUASAR_QUICK_MAX_GATES`` – maximum gate count for quick-path planning.
+* ``QUASAR_QUICK_MAX_DEPTH`` – maximum circuit depth for quick-path planning.
+* ``QUASAR_BACKEND_ORDER`` – comma-separated preference list of backends
+  (e.g. ``"MPS,STATEVECTOR"``).
+
+The same parameters can be passed directly to :class:`Planner` and
+:class:`Scheduler` constructors to override the defaults on a per-instance
+basis, allowing runtime tuning without relying on environment variables.
+
 ## Scalable benchmark circuits
 
 QuASAr can simulate parameterized circuits sourced from MQTBench and QASMBench.

--- a/quasar/config.py
+++ b/quasar/config.py
@@ -1,0 +1,56 @@
+import os
+from dataclasses import dataclass, field
+from typing import List
+
+from .cost import Backend
+
+
+def _int_from_env(name: str, default: int | None) -> int | None:
+    val = os.getenv(name)
+    if val is None:
+        return default
+    if val.lower() == "none":
+        return None
+    try:
+        return int(val)
+    except ValueError:
+        return default
+
+
+def _order_from_env(name: str, default: List[Backend]) -> List[Backend]:
+    val = os.getenv(name)
+    if val is None or not val.strip():
+        return list(default)
+    order: List[Backend] = []
+    for item in val.split(","):
+        item = item.strip().upper()
+        if not item:
+            continue
+        try:
+            order.append(Backend[item])
+        except KeyError:
+            continue
+    return order or list(default)
+
+
+@dataclass
+class Config:
+    """Runtime configuration defaults for QuASAr.
+
+    Values may be overridden via environment variables or by supplying
+    explicit arguments to :class:`Planner` and :class:`Scheduler`.
+    """
+
+    quick_max_qubits: int | None = _int_from_env("QUASAR_QUICK_MAX_QUBITS", 25)
+    quick_max_gates: int | None = _int_from_env("QUASAR_QUICK_MAX_GATES", 200)
+    quick_max_depth: int | None = _int_from_env("QUASAR_QUICK_MAX_DEPTH", 50)
+    preferred_backend_order: List[Backend] = field(
+        default_factory=lambda: _order_from_env(
+            "QUASAR_BACKEND_ORDER",
+            [Backend.MPS, Backend.DECISION_DIAGRAM, Backend.STATEVECTOR, Backend.TABLEAU],
+        )
+    )
+
+
+# Global configuration instance used when modules import ``quasar.config``.
+DEFAULT = Config()


### PR DESCRIPTION
## Summary
- centralize quick-path limits and backend priorities in `quasar.config`
- allow `Planner` and `Scheduler` to override or use config-driven defaults
- document environment variables for runtime tuning

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b422ad1cc88321b4dffbbd2477b799