### PR TITLE
Add benchmark circuit generators and documentation

### DIFF
--- a/benchmarks/notebooks/00_environment_setup.ipynb
+++ b/benchmarks/notebooks/00_environment_setup.ipynb
@@ -2,6 +2,7 @@
  "cells": [
   {
    "cell_type": "markdown",
+   "id": "4929b713",
    "metadata": {},
    "source": [
     "# Environment Setup\n",
@@ -12,6 +13,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "b27a5f69",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -49,9 +51,60 @@
   },
   {
    "cell_type": "markdown",
+   "id": "05b4c113",
    "metadata": {},
    "source": [
     "Environment information saved to `environment.json`.\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "1dc2b3a4",
+   "metadata": {},
+   "source": [
+    "## Benchmark Circuits\n",
+    "\n",
+    "The table below lists benchmark circuits used in QuASAr."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "1866aa7a",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from benchmarks.circuits import (\n",
+    "    clifford_ec_circuit,\n",
+    "    ripple_add_circuit,\n",
+    "    vqe_chain_circuit,\n",
+    "    random_hybrid_circuit,\n",
+    "    recur_subroutine_circuit,\n",
+    ")\n",
+    "import inspect\n",
+    "from pathlib import Path\n",
+    "from IPython.display import Markdown\n",
+    "\n",
+    "\n",
+    "def src_link(func):\n",
+    "    file = Path(inspect.getsourcefile(func)).relative_to(Path.cwd())\n",
+    "    line = inspect.getsourcelines(func)[1]\n",
+    "    return f\"[generator]({file}#L{line})\"\n",
+    "\n",
+    "circuits = [\n",
+    "    (\"Clifford-EC\", clifford_ec_circuit, \"3-qubit bit-flip error correction\"),\n",
+    "    (\"Ripple-Add\", ripple_add_circuit, \"Ripple-carry adder for two 4-bit registers\"),\n",
+    "    (\"VQE-Chain\", vqe_chain_circuit, \"VQE ansatz with linear entanglement chain\"),\n",
+    "    (\"Random-Hybrid\", random_hybrid_circuit, \"Random mix of Clifford and T gates\"),\n",
+    "    (\"Recur-Subroutine\", recur_subroutine_circuit, \"Circuit with repeated subroutine layers\"),\n",
+    "]\n",
+    "\n",
+    "rows = [\"| Circuit | Qubits | Gates | Description | Source |\", \"|---|---|---|---|---|\"]\n",
+    "for name, fn, desc in circuits:\n",
+    "    circ = fn()\n",
+    "    rows.append(f\"| {name} | {circ.num_qubits} | {circ.num_gates} | {desc} | {src_link(fn)} |\")\n",
+    "Markdown(\"\n",
+    "\".join(rows))\n"
    ]
   }
  ],


### PR DESCRIPTION
## Summary
- add generator functions for Clifford-EC, Ripple-Add, VQE-Chain, Random-Hybrid and Recur-Subroutine circuits
- document circuit sources, qubit counts and gate counts in environment setup notebook

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b5552ea6f8832184e243606fbe78ee