### PR TITLE
Add end-to-end benchmarking notebook

### DIFF
--- a/benchmarks/notebooks/02_end_to_end.ipynb
+++ b/benchmarks/notebooks/02_end_to_end.ipynb
@@ -1,0 +1,158 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "91c52cd8",
+   "metadata": {},
+   "source": [
+    "# End-to-End Benchmark"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "92a560a2",
+   "metadata": {},
+   "source": [
+    "Run QuASAr and baseline backends on benchmark circuits and compare performance."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "6cd7de37",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import pandas as pd\n",
+    "from benchmarks.runner import BenchmarkRunner\n",
+    "from benchmarks.backends import StatevectorAdapter, DecisionDiagramAdapter, MPSAdapter, StimAdapter\n",
+    "from benchmarks import circuits\n",
+    "from quasar.simulation_engine import SimulationEngine\n",
+    "from quasar_convert import ConversionEngine\n",
+    "import time, matplotlib.pyplot as plt"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "7867559b",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "class TrackingConversionEngine(ConversionEngine):\n",
+    "    def __init__(self):\n",
+    "        super().__init__()\n",
+    "        self.total_time = 0.0\n",
+    "    def _timeit(self, func, *args, **kwargs):\n",
+    "        start = time.perf_counter()\n",
+    "        res = func(*args, **kwargs)\n",
+    "        self.total_time += time.perf_counter() - start\n",
+    "        return res\n",
+    "    def convert_boundary_to_statevector(self, ssd):\n",
+    "        return self._timeit(super().convert_boundary_to_statevector, ssd)\n",
+    "    def convert_boundary_to_tableau(self, ssd):\n",
+    "        if hasattr(super(), \"convert_boundary_to_tableau\"):\n",
+    "            return self._timeit(super().convert_boundary_to_tableau, ssd)\n",
+    "        raise AttributeError\n",
+    "    def convert_boundary_to_dd(self, ssd):\n",
+    "        if hasattr(super(), \"convert_boundary_to_dd\"):\n",
+    "            return self._timeit(super().convert_boundary_to_dd, ssd)\n",
+    "        raise AttributeError\n",
+    "    def extract_local_window(self, state, qubits):\n",
+    "        return self._timeit(super().extract_local_window, state, qubits)\n",
+    "    def build_bridge_tensor(self, left, right):\n",
+    "        return self._timeit(super().build_bridge_tensor, left, right)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "bbbea786",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "circuit_fns = {\n",
+    "    'ghz': circuits.ghz_circuit,\n",
+    "    'qft': circuits.qft_circuit,\n",
+    "    'w_state': circuits.w_state_circuit,\n",
+    "    'grover': circuits.grover_circuit,\n",
+    "}\n",
+    "backends = {\n",
+    "    'statevector': StatevectorAdapter(),\n",
+    "    'mqt_dd': DecisionDiagramAdapter(),\n",
+    "    'mps': MPSAdapter(),\n",
+    "    'stim': StimAdapter(),\n",
+    "}\n",
+    "REPETITIONS = 5\n",
+    "NUM_QUBITS = 2\n",
+    "records = []\n",
+    "for cname, cfn in circuit_fns.items():\n",
+    "    circuit = cfn(NUM_QUBITS)\n",
+    "    for bname, backend in backends.items():\n",
+    "        for _ in range(REPETITIONS):\n",
+    "            runner = BenchmarkRunner()\n",
+    "            try:\n",
+    "                rec = runner.run(circuit, backend, return_state=False)\n",
+    "            except NotImplementedError:\n",
+    "                continue\n",
+    "            rec.update({'circuit': cname, 'backend_switches': 0, 'conversion_time': 0.0})\n",
+    "            records.append(rec)\n",
+    "    for _ in range(REPETITIONS):\n",
+    "        ce = TrackingConversionEngine()\n",
+    "        runner = BenchmarkRunner()\n",
+    "        engine = SimulationEngine(conversion_engine=ce)\n",
+    "        rec = runner.run_quasar(circuit, engine)\n",
+    "        rec.update({'circuit': cname,\n",
+    "                    'backend_switches': len(rec['result'].conversions),\n",
+    "                    'conversion_time': ce.total_time})\n",
+    "        records.append(rec)\n",
+    "df = pd.DataFrame(records)\n",
+    "df['runtime'] = df['total_time']\n",
+    "df['peak_memory'] = df[['prepare_peak_memory','run_peak_memory']].max(axis=1)\n",
+    "summary = df.groupby(['circuit','framework']).agg(\n",
+    "    runtime_mean=('runtime','mean'), runtime_std=('runtime','std'),\n",
+    "    peak_memory_mean=('peak_memory','mean'), peak_memory_std=('peak_memory','std'),\n",
+    "    backend_switches_mean=('backend_switches','mean'),\n",
+    "    backend_switches_std=('backend_switches','std'),\n",
+    "    conversion_time_mean=('conversion_time','mean'),\n",
+    "    conversion_time_std=('conversion_time','std')\n",
+    ").reset_index()\n",
+    "summary"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "edd6aa5f",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "speedup = []\n",
+    "for cname in circuit_fns:\n",
+    "    quasar_time = summary[(summary.circuit==cname)&(summary.framework=='quasar')]['runtime_mean'].iloc[0]\n",
+    "    baseline_times = summary[(summary.circuit==cname)&(summary.framework!='quasar')]['runtime_mean']\n",
+    "    if not baseline_times.empty:\n",
+    "        best_baseline = baseline_times.min()\n",
+    "        speedup.append({'circuit': cname, 'speedup': best_baseline/quasar_time})\n",
+    "speedup_df = pd.DataFrame(speedup)\n",
+    "speedup_df"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "7d4e4c5c",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "ax = speedup_df.plot.bar(x='circuit', y='speedup', legend=False)\n",
+    "ax.set_ylabel('QuASAr speedup over best baseline')\n",
+    "ax.set_xlabel('Circuit')\n",
+    "plt.tight_layout()"
+   ]
+  }
+ ],
+ "metadata": {},
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
## Summary
- Add an end-to-end benchmarking notebook that runs QuASAr and baseline backends on common circuits
- Capture runtime, memory, backend switches, and conversion time across multiple repetitions
- Compute summary statistics and visualize QuASAr speedup over best baseline

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b5553b435c8321bd54af5b8af596a8