### PR TITLE
Add conversion cost multiplier and switching ablation notebook

### DIFF
--- a/benchmarks/notebooks/03_switching_ablation.ipynb
+++ b/benchmarks/notebooks/03_switching_ablation.ipynb
@@ -1,0 +1,99 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "273821bb",
+   "metadata": {},
+   "source": [
+    "# Switching Ablation\n",
+    "\n",
+    "This notebook studies how scaling conversion costs by a factor $\\alpha$ impacts\n",
+    "QuASAr's backend selection and runtime.  For a small set of representative\n",
+    "circuits we evaluate $\\alpha \\in \\{0.5, 1, 2, 5\\}$ and visualise the resulting\n",
+    "plans.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "a5ca7a70",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import sys, time, pathlib\n",
+    "import pandas as pd\n",
+    "import seaborn as sns\n",
+    "import matplotlib.pyplot as plt\n",
+    "\n",
+    "# Make project root importable\n",
+    "root = pathlib.Path('..', '..').resolve()\n",
+    "sys.path.append(str(root))\n",
+    "\n",
+    "from quasar.planner import Planner\n",
+    "from quasar.simulation_engine import SimulationEngine\n",
+    "from benchmarks.circuits import ghz_circuit, grover_circuit\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "f4f32506",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "alphas = [0.5, 1, 2, 5]\n",
+    "circuits = {\n",
+    "    'GHZ_6': ghz_circuit(6),\n",
+    "    'Grover_3': grover_circuit(3, 1),\n",
+    "}\n",
+    "records = []\n",
+    "for name, circ in circuits.items():\n",
+    "    for alpha in alphas:\n",
+    "        planner = Planner(conversion_cost_multiplier=alpha)\n",
+    "        engine = SimulationEngine(planner=planner)\n",
+    "        start = time.perf_counter()\n",
+    "        result = engine.simulate(circ)\n",
+    "        elapsed = time.perf_counter() - start\n",
+    "        steps = [s.backend.name for s in result.plan.steps]\n",
+    "        records.append({'circuit': name, 'alpha': alpha, 'steps': steps, 'runtime': elapsed})\n",
+    "records\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "8578f7f0",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "for name in circuits:\n",
+    "    subset = [r for r in records if r['circuit'] == name]\n",
+    "    max_frag = max(len(r['steps']) for r in subset)\n",
+    "    heat = pd.DataFrame(index=alphas, columns=range(max_frag))\n",
+    "    for r in subset:\n",
+    "        heat.loc[r['alpha'], :len(r['steps'])] = r['steps']\n",
+    "    backends = sorted({b for row in heat.values for b in row if b is not None})\n",
+    "    mapping = {b: i for i, b in enumerate(backends)}\n",
+    "    heat_numeric = heat.replace(mapping).astype(float)\n",
+    "    plt.figure(figsize=(1.2*max_frag, 1.2*len(alphas)))\n",
+    "    sns.heatmap(heat_numeric, annot=heat, fmt='', cmap='tab10', cbar=False)\n",
+    "    plt.title(f'Backend per fragment for {name}')\n",
+    "    plt.xlabel('Fragment')\n",
+    "    plt.ylabel('α')\n",
+    "    plt.show()\n",
+    "\n",
+    "    runtime_df = pd.DataFrame({'alpha': [r['alpha'] for r in subset],\n",
+    "                               'runtime': [r['runtime'] for r in subset]})\n",
+    "    plt.figure()\n",
+    "    sns.lineplot(data=runtime_df, x='alpha', y='runtime', marker='o')\n",
+    "    plt.title(f'Runtime vs α for {name}')\n",
+    "    plt.xlabel('α')\n",
+    "    plt.ylabel('Runtime (s)')\n",
+    "    plt.show()\n"
+   ]
+  }
+ ],
+ "metadata": {},
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
## Summary
- allow scaling conversion time estimates in `Planner` via new `conversion_cost_multiplier`
- document switching behavior across conversion-cost multipliers in a new benchmark notebook
- test that large conversion penalties discourage backend switching

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b5553f2f2c8321b4501db05f47357f