### PR TITLE
Add robustness benchmark notebook

### DIFF
--- a/benchmarks/notebooks/05_robustness.ipynb
+++ b/benchmarks/notebooks/05_robustness.ipynb
@@ -1,0 +1,194 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "c929add9",
+   "metadata": {},
+   "source": [
+    "# Robustness to Execution Perturbations\n",
+    "\n",
+    "This notebook evaluates the scheduler's ability to recover from unexpected changes. Two perturbation types are applied during execution:\n",
+    "\n",
+    "* **Gate injection** – extra entangling operations are inserted while the circuit is already running.\n",
+    "* **Cost corruption** – cost model coefficients are perturbed to trigger re-planning.\n",
+    "\n",
+    "For each magnitude we perform multiple repetitions, measuring the time to recover and the runtime overhead. Timelines highlight when re-planning occurs and a table summarises recovery statistics."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "5d6628cd",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import time\n",
+    "import numpy as np\n",
+    "import pandas as pd\n",
+    "import matplotlib.pyplot as plt\n",
+    "\n",
+    "from quasar.circuit import Gate\n",
+    "from quasar.scheduler import Scheduler\n",
+    "from quasar.planner import Planner\n",
+    "from benchmarks import circuits\n",
+    "\n",
+    "plt.rcParams['figure.dpi'] = 120"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "86c9cefd",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Baseline runtime\n",
+    "\n",
+    "def measure_baseline():\n",
+    "    sched = Scheduler(planner=Planner())\n",
+    "    t0 = time.perf_counter()\n",
+    "    sched.run(circuits.ghz_circuit(5))\n",
+    "    return time.perf_counter() - t0\n",
+    "\n",
+    "baseline_time = measure_baseline()\n",
+    "baseline_time"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "587b26fd",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Perturbation helpers\n",
+    "\n",
+    "def run_gate_perturbation(magnitude, repetitions=5):\n",
+    "    records = []\n",
+    "    for _ in range(repetitions):\n",
+    "        circuit = circuits.ghz_circuit(5)\n",
+    "        scheduler = Scheduler(planner=Planner())\n",
+    "        timeline = []\n",
+    "        info = {}\n",
+    "        step_idx = {'i': 0}\n",
+    "        def monitor(step, observed, est):\n",
+    "            now = time.perf_counter() - start\n",
+    "            start_t = timeline[-1]['end'] if timeline else 0.0\n",
+    "            timeline.append({'step': step_idx['i'], 'start': start_t, 'end': now, 'backend': step.backend.name})\n",
+    "            step_idx['i'] += 1\n",
+    "            if 'trigger' not in info:\n",
+    "                circuit.gates[step.end:step.end] = [Gate('CX', [0, 1])] * magnitude\n",
+    "                info['trigger'] = now\n",
+    "                return True\n",
+    "            return False\n",
+    "        start = time.perf_counter()\n",
+    "        scheduler.run(circuit, monitor=monitor)\n",
+    "        total = time.perf_counter() - start\n",
+    "        records.append({'perturb': 'gate', 'magnitude': magnitude, 'total_time': total,\n",
+    "                        'recovery_time': total - info['trigger'], 'overhead': total - baseline_time,\n",
+    "                        'timeline': timeline, 'trigger_time': info['trigger']})\n",
+    "    return records\n",
+    "\n",
+    "\n",
+    "def run_cost_perturbation(factor, repetitions=5):\n",
+    "    records = []\n",
+    "    for _ in range(repetitions):\n",
+    "        circuit = circuits.ghz_circuit(5)\n",
+    "        scheduler = Scheduler(planner=Planner())\n",
+    "        scheduler.planner.estimator.coeff['sv_gate'] *= factor\n",
+    "        timeline = []\n",
+    "        step_idx = {'i': 0}\n",
+    "        def monitor(step, observed, est):\n",
+    "            now = time.perf_counter() - start\n",
+    "            start_t = timeline[-1]['end'] if timeline else 0.0\n",
+    "            timeline.append({'step': step_idx['i'], 'start': start_t, 'end': now, 'backend': step.backend.name})\n",
+    "            step_idx['i'] += 1\n",
+    "            return False\n",
+    "        start = time.perf_counter()\n",
+    "        scheduler.run(circuit, monitor=monitor)\n",
+    "        total = time.perf_counter() - start\n",
+    "        trigger = timeline[0]['end'] if timeline else 0.0\n",
+    "        records.append({'perturb': 'cost', 'magnitude': factor, 'total_time': total,\n",
+    "                        'recovery_time': total - trigger, 'overhead': total - baseline_time,\n",
+    "                        'timeline': timeline, 'trigger_time': trigger})\n",
+    "    return records"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "60f34afd",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Run experiments\n",
+    "\n",
+    "repetitions = 5\n",
+    "\n",
+    "gate_magnitudes = [1, 2, 3]\n",
+    "cost_magnitudes = [1e-6, 1e-7, 1e-8]\n",
+    "\n",
+    "records = []\n",
+    "for m in gate_magnitudes:\n",
+    "    records.extend(run_gate_perturbation(m, repetitions))\n",
+    "for f in cost_magnitudes:\n",
+    "    records.extend(run_cost_perturbation(f, repetitions))\n",
+    "\n",
+    "results = pd.DataFrame(records)\n",
+    "results.head()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "b7aa5959",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Timeline plot for a representative run\n",
+    "\n",
+    "sample = results[(results['perturb']=='gate') & (results['magnitude']==gate_magnitudes[0])].iloc[0]\n",
+    "fig, ax = plt.subplots(figsize=(6, 2))\n",
+    "for seg in sample['timeline']:\n",
+    "    ax.barh(seg['step'], seg['end']-seg['start'], left=seg['start'], color='tab:blue')\n",
+    "ax.axvline(sample['trigger_time'], color='red', linestyle='--', label='re-plan')\n",
+    "ax.set_xlabel('Time (s)')\n",
+    "ax.set_ylabel('Step')\n",
+    "ax.legend()\n",
+    "plt.tight_layout()\n",
+    "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "33bb577d",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Summary table of recovery metrics\n",
+    "\n",
+    "metrics = results.groupby(['perturb', 'magnitude']).agg(\n",
+    "    recovery_mean=('recovery_time', 'mean'),\n",
+    "    recovery_std=('recovery_time', 'std'),\n",
+    "    overhead_mean=('overhead', 'mean'),\n",
+    "    overhead_std=('overhead', 'std')\n",
+    ").reset_index()\n",
+    "metrics"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "version": "3.10"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
## Summary
- add `05_robustness` notebook exploring execution perturbations
- include gate injection and cost corruption experiments with recovery metrics
- plot re-planning timelines and aggregate statistics

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b555451f5c8321b7ccaf0ffccee2e2