### PR TITLE
Add plan cache benchmark notebook

### DIFF
--- a/benchmarks/notebooks/06_plan_cache.ipynb
+++ b/benchmarks/notebooks/06_plan_cache.ipynb
@@ -1,0 +1,381 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "0ef58702",
+   "metadata": {},
+   "source": [
+    "# Plan Cache Exploration\n",
+    "This notebook demonstrates QuASAr's plan cache when executing a parameterized circuit multiple times. It records cache hit rates, cumulative speedup from warm vs cold cache runs, and reuse within the conversion engine."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "bae9429b",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2025-09-01T08:16:46.299000Z",
+     "iopub.status.busy": "2025-09-01T08:16:46.298532Z",
+     "iopub.status.idle": "2025-09-01T08:16:48.742971Z",
+     "shell.execute_reply": "2025-09-01T08:16:48.741167Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "import time\n",
+    "import pandas as pd\n",
+    "import matplotlib.pyplot as plt\n",
+    "plt.switch_backend('Agg')\n",
+    "from qiskit import QuantumCircuit\n",
+    "import quasar\n",
+    "import quasar_convert as qc\n",
+    "from quasar.planner import Planner"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "ec61f0e1",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2025-09-01T08:16:48.757134Z",
+     "iopub.status.busy": "2025-09-01T08:16:48.756224Z",
+     "iopub.status.idle": "2025-09-01T08:16:48.764645Z",
+     "shell.execute_reply": "2025-09-01T08:16:48.762998Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "def build_circuit(theta1, theta2):\n",
+    "    qc = QuantumCircuit(2)\n",
+    "    qc.rx(theta1, 0)\n",
+    "    qc.cx(0, 1)\n",
+    "    qc.ry(theta2, 1)\n",
+    "    return quasar.Circuit.from_qiskit(qc)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "3362d6b6",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2025-09-01T08:16:48.769160Z",
+     "iopub.status.busy": "2025-09-01T08:16:48.768626Z",
+     "iopub.status.idle": "2025-09-01T08:16:48.823374Z",
+     "shell.execute_reply": "2025-09-01T08:16:48.822179Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>run</th>\n",
+       "      <th>hit_rate</th>\n",
+       "      <th>conversion_reuse</th>\n",
+       "      <th>cumulative_speedup</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>1</td>\n",
+       "      <td>0.000000</td>\n",
+       "      <td>0</td>\n",
+       "      <td>1.623250</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>2</td>\n",
+       "      <td>0.000000</td>\n",
+       "      <td>1</td>\n",
+       "      <td>1.414026</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2</th>\n",
+       "      <td>3</td>\n",
+       "      <td>0.000000</td>\n",
+       "      <td>2</td>\n",
+       "      <td>1.477839</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>3</th>\n",
+       "      <td>4</td>\n",
+       "      <td>0.250000</td>\n",
+       "      <td>3</td>\n",
+       "      <td>2.373004</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>4</th>\n",
+       "      <td>5</td>\n",
+       "      <td>0.400000</td>\n",
+       "      <td>4</td>\n",
+       "      <td>2.904808</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>5</th>\n",
+       "      <td>6</td>\n",
+       "      <td>0.500000</td>\n",
+       "      <td>5</td>\n",
+       "      <td>3.202413</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>6</th>\n",
+       "      <td>7</td>\n",
+       "      <td>0.571429</td>\n",
+       "      <td>6</td>\n",
+       "      <td>3.508449</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>7</th>\n",
+       "      <td>8</td>\n",
+       "      <td>0.625000</td>\n",
+       "      <td>7</td>\n",
+       "      <td>3.864758</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>8</th>\n",
+       "      <td>9</td>\n",
+       "      <td>0.666667</td>\n",
+       "      <td>8</td>\n",
+       "      <td>4.152397</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "   run  hit_rate  conversion_reuse  cumulative_speedup\n",
+       "0    1  0.000000                 0            1.623250\n",
+       "1    2  0.000000                 1            1.414026\n",
+       "2    3  0.000000                 2            1.477839\n",
+       "3    4  0.250000                 3            2.373004\n",
+       "4    5  0.400000                 4            2.904808\n",
+       "5    6  0.500000                 5            3.202413\n",
+       "6    7  0.571429                 6            3.508449\n",
+       "7    8  0.625000                 7            3.864758\n",
+       "8    9  0.666667                 8            4.152397"
+      ]
+     },
+     "execution_count": 3,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "angles = [(0.1,0.2), (0.3,0.4), (0.5,0.6)] * 3\n",
+    "planner_cold = Planner(quick_max_qubits=0)\n",
+    "planner_warm = Planner(quick_max_qubits=0)\n",
+    "engine = qc.ConversionEngine()\n",
+    "metrics = []\n",
+    "cold_times = []\n",
+    "warm_times = []\n",
+    "for idx, (a,b) in enumerate(angles, start=1):\n",
+    "    circ = build_circuit(a,b)\n",
+    "    engine.extract_ssd([0,1], 2)\n",
+    "    t0 = time.time(); planner_cold.plan(circ, use_cache=False); cold_times.append(time.time()-t0)\n",
+    "    t0 = time.time(); planner_warm.plan(circ, use_cache=True); warm_times.append(time.time()-t0)\n",
+    "    metrics.append({'run': idx,\n",
+    "                    'cache_hits': planner_warm.cache_hits,\n",
+    "                    'hit_rate': planner_warm.cache_hits/idx,\n",
+    "                    'conversion_reuse': idx - len(engine._ssd_cache),\n",
+    "                    'cold_time': cold_times[-1],\n",
+    "                    'warm_time': warm_times[-1]})\n",
+    "\n",
+    "df = pd.DataFrame(metrics)\n",
+    "df['cum_cold'] = df['cold_time'].cumsum()\n",
+    "df['cum_warm'] = df['warm_time'].cumsum()\n",
+    "df['cumulative_speedup'] = df['cum_cold']/df['cum_warm']\n",
+    "df[['run','hit_rate','conversion_reuse','cumulative_speedup']]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "d99f396d",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2025-09-01T08:16:48.827822Z",
+     "iopub.status.busy": "2025-09-01T08:16:48.827408Z",
+     "iopub.status.idle": "2025-09-01T08:16:48.842409Z",
+     "shell.execute_reply": "2025-09-01T08:16:48.841219Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>run</th>\n",
+       "      <th>hit_rate</th>\n",
+       "      <th>conversion_reuse</th>\n",
+       "      <th>cumulative_speedup</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>1</td>\n",
+       "      <td>0.000000</td>\n",
+       "      <td>0</td>\n",
+       "      <td>1.623250</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>2</td>\n",
+       "      <td>0.000000</td>\n",
+       "      <td>1</td>\n",
+       "      <td>1.414026</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2</th>\n",
+       "      <td>3</td>\n",
+       "      <td>0.000000</td>\n",
+       "      <td>2</td>\n",
+       "      <td>1.477839</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>3</th>\n",
+       "      <td>4</td>\n",
+       "      <td>0.250000</td>\n",
+       "      <td>3</td>\n",
+       "      <td>2.373004</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>4</th>\n",
+       "      <td>5</td>\n",
+       "      <td>0.400000</td>\n",
+       "      <td>4</td>\n",
+       "      <td>2.904808</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>5</th>\n",
+       "      <td>6</td>\n",
+       "      <td>0.500000</td>\n",
+       "      <td>5</td>\n",
+       "      <td>3.202413</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>6</th>\n",
+       "      <td>7</td>\n",
+       "      <td>0.571429</td>\n",
+       "      <td>6</td>\n",
+       "      <td>3.508449</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>7</th>\n",
+       "      <td>8</td>\n",
+       "      <td>0.625000</td>\n",
+       "      <td>7</td>\n",
+       "      <td>3.864758</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>8</th>\n",
+       "      <td>9</td>\n",
+       "      <td>0.666667</td>\n",
+       "      <td>8</td>\n",
+       "      <td>4.152397</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "   run  hit_rate  conversion_reuse  cumulative_speedup\n",
+       "0    1  0.000000                 0            1.623250\n",
+       "1    2  0.000000                 1            1.414026\n",
+       "2    3  0.000000                 2            1.477839\n",
+       "3    4  0.250000                 3            2.373004\n",
+       "4    5  0.400000                 4            2.904808\n",
+       "5    6  0.500000                 5            3.202413\n",
+       "6    7  0.571429                 6            3.508449\n",
+       "7    8  0.625000                 7            3.864758\n",
+       "8    9  0.666667                 8            4.152397"
+      ]
+     },
+     "execution_count": 4,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "df[['run','hit_rate','conversion_reuse','cumulative_speedup']]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "e4d9ee98",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2025-09-01T08:16:48.865487Z",
+     "iopub.status.busy": "2025-09-01T08:16:48.864950Z",
+     "iopub.status.idle": "2025-09-01T08:16:48.894297Z",
+     "shell.execute_reply": "2025-09-01T08:16:48.892924Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "plt.figure(figsize=(6,4))\n",
+    "plt.plot(df['run'], df['cumulative_speedup'], marker='o')\n",
+    "plt.xlabel('Run')\n",
+    "plt.ylabel('Cumulative Cold/Warm Time')\n",
+    "plt.title('Cumulative Speedup from Plan Cache')\n",
+    "plt.grid(True)\n",
+    "plt.show()"
+   ]
+  }
+ ],
+ "metadata": {
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.12.10"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
## Summary
- Demonstrate plan cache effects by running a parameterized circuit with repeated angles.
- Track cache hit rates, conversion reuse, and cumulative speedup between cold and warm runs.
- Plot cumulative speedup and show table of hit rates across repetitions.

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b555487f108321993e1f8aff2387d0