### PR TITLE
Add configurable parallel execution and tests

### DIFF
--- a/benchmarks/notebooks/07_parallelism.ipynb
+++ b/benchmarks/notebooks/07_parallelism.ipynb
@@ -1,0 +1,72 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Parallelism Benchmarks\n",
+    "This notebook illustrates the effect of enabling scheduler parallel execution across backends."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from quasar import Circuit, Scheduler\n",
+    "from quasar.cost import Backend\n",
+    "from quasar.planner import Planner\n",
+    "import time\n",
+    "\n",
+    "circuit = Circuit([\n",
+    "    {\"gate\": \"T\", \"qubits\": [0]},\n",
+    "    {\"gate\": \"T\", \"qubits\": [1]},\n",
+    "    {\"gate\": \"H\", \"qubits\": [0]},\n",
+    "    {\"gate\": \"H\", \"qubits\": [1]},\n",
+    "])\n",
+    "\n",
+    "class SleepBackend:\n",
+    "    def load(self, n):\n",
+    "        pass\n",
+    "    def apply_gate(self, gate, qubits, params):\n",
+    "        time.sleep(0.05)\n",
+    "    def extract_ssd(self):\n",
+    "        return None\n",
+    "\n",
+    "scheduler_p = Scheduler(\n",
+    "    backends={Backend.STATEVECTOR: SleepBackend()},\n",
+    "    planner=Planner(),\n",
+    "    quick_max_qubits=None,\n",
+    "    quick_max_gates=None,\n",
+    "    quick_max_depth=None,\n",
+    "    parallel_backends=[Backend.STATEVECTOR],\n",
+    ")\n",
+    "start = time.time(); scheduler_p.run(circuit); par = time.time() - start\n",
+    "\n",
+    "scheduler_s = Scheduler(\n",
+    "    backends={Backend.STATEVECTOR: SleepBackend()},\n",
+    "    planner=Planner(),\n",
+    "    quick_max_qubits=None,\n",
+    "    quick_max_gates=None,\n",
+    "    quick_max_depth=None,\n",
+    "    parallel_backends=[],\n",
+    ")\n",
+    "start = time.time(); scheduler_s.run(circuit); ser = time.time() - start\n",
+    "print(f\"parallel {par:.3f}s vs serial {ser:.3f}s\")\n"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/quasar/config.py
+++ b/quasar/config.py
@@ -33,6 +33,11 @@ def _order_from_env(name: str, default: List[Backend]) -> List[Backend]:
     return order or list(default)
 
 
+def _backends_from_env(name: str, default: List[Backend]) -> List[Backend]:
+    """Return a list of backends parsed from the comma-separated env var."""
+    return _order_from_env(name, default)
+
+
 @dataclass
 class Config:
     """Runtime configuration defaults for QuASAr.
@@ -48,6 +53,12 @@ class Config:
         default_factory=lambda: _order_from_env(
             "QUASAR_BACKEND_ORDER",
             [Backend.MPS, Backend.DECISION_DIAGRAM, Backend.STATEVECTOR, Backend.TABLEAU],
+        )
+    )
+    parallel_backends: List[Backend] = field(
+        default_factory=lambda: _backends_from_env(
+            "QUASAR_PARALLEL_BACKENDS",
+            [Backend.STATEVECTOR, Backend.MPS],
         )
     )
 


### PR DESCRIPTION
## Summary
- introduce `parallel_backends` configuration to toggle backend-level parallelism
- allow scheduler to split independent qubit groups across threads and backends
- add regression test and benchmarking notebook for parallel execution

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b5581ae84483219542e20e5dfcf9fb