### PR TITLE
Handle backend failures in BenchmarkRunner

### DIFF
--- a/tests/test_benchmark_run_failure.py
+++ b/tests/test_benchmark_run_failure.py
@@ -1,0 +1,17 @@
+from benchmarks.runner import BenchmarkRunner
+
+
+class ErrorBackend:
+    name = "error"
+
+    def run(self, circuit, **_):
+        raise ValueError("boom")
+
+
+def test_run_returns_failure_record_on_exception():
+    runner = BenchmarkRunner()
+    record = runner.run("circ", ErrorBackend())
+    assert record["failed"] is True
+    assert "boom" in record["error"]
+    assert record["framework"] == "error"
+    assert runner.results[0] == record


### PR DESCRIPTION
## Summary
- Guard backend execution with try/except, logging circuit and backend on failure and recording the run as failed
- Skip failed runs in aggregation and note how many runs were excluded
- Add tests for backend errors and aggregation behavior

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b55c500a38832185bb12a68be6d9ce