### PR TITLE
Fix heatmap indexing in switching ablation notebook

### DIFF
--- a/benchmarks/notebooks/03_switching_ablation.ipynb
+++ b/benchmarks/notebooks/03_switching_ablation.ipynb
@@ -71,7 +71,7 @@
     "    max_frag = max(len(r['steps']) for r in subset)\n",
     "    heat = pd.DataFrame(index=alphas, columns=range(max_frag))\n",
     "    for r in subset:\n",
-    "        heat.loc[r['alpha'], :len(r['steps'])] = r['steps']\n",
+    "        heat.loc[r['alpha'], :len(r['steps'])-1] = r['steps']\n",
     "    backends = sorted({b for row in heat.values for b in row if b is not None})\n",
     "    mapping = {b: i for i, b in enumerate(backends)}\n",
     "    heat_numeric = heat.replace(mapping).astype(float)\n",


### PR DESCRIPTION
## Summary
- Fix off-by-one error when populating switching ablation heatmap

## Testing
- `jupyter nbconvert --to notebook --execute benchmarks/notebooks/03_switching_ablation.ipynb --output /tmp/03_switching_ablation_executed.ipynb --ExecutePreprocessor.allow_errors=True`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b5665dc5c883219749e247bcfb24f4