### PR TITLE
Fix planner quality notebook serialization

### DIFF
--- a/benchmarks/notebooks/04_planner_quality.ipynb
+++ b/benchmarks/notebooks/04_planner_quality.ipynb
@@ -7,7 +7,7 @@
    "source": [
     "# Planner quality\n",
     "\n",
-    "This notebook compares planning strategies on small circuits (≤ 20 qubits)."
+    "This notebook compares planning strategies on small circuits (\u2264 20 qubits)."
    ]
   },
   {
@@ -225,14 +225,14 @@
     "}\n",
     "pathlib.Path('../results').mkdir(exist_ok=True)\n",
     "with open(f\"../results/{nb_name}_params.json\", 'w') as f:\n",
-    "    json.dump(_params, f, indent=2)\n",
+    "    json.dump(_params, f, indent=2, default=str)\n",
     "if 'results' in globals():\n",
     "    try:\n",
     "        with open(f\"../results/{nb_name}_results.json\", 'w') as f:\n",
-    "            json.dump(results, f, indent=2)\n",
+    "            json.dump(results, f, indent=2, default=str)\n",
     "    except TypeError:\n",
     "        pass\n",
-    "print(json.dumps(_params, indent=2))\n"
+    "print(json.dumps(_params, indent=2, default=str))\n"
    ]
   }
  ],


### PR DESCRIPTION
## Summary
- Ensure planner quality notebook can dump parameters and results by converting non-serializable objects to strings
- Executed planner quality notebook successfully, rendering CDF plot of cost gaps

## Testing
- `python -m jupyter nbconvert --to notebook --execute benchmarks/notebooks/04_planner_quality.ipynb --output executed_notebook.ipynb`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b5665ee8b48321b76ad25d68e91bc4