### PR TITLE
Bridge vecs2pauli fallback for stabilizer learning

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,6 +17,7 @@ dependencies = [
     "qiskit-aer==0.17.1",
     "qiskit-qasm3-import==0.6.0",
     "stim==1.15.0",
+    "vecs2pauli==0.0.1",
     "networkx",
     "pytest==8.4.1",
 ]

--- a/quasar_convert/tests/test_primitives.py
+++ b/quasar_convert/tests/test_primitives.py
@@ -1,4 +1,6 @@
 import unittest
+from unittest import mock
+import numpy as np
 import quasar_convert as qc
 
 class PrimitiveHelperTests(unittest.TestCase):
@@ -44,6 +46,20 @@ class PrimitiveHelperTests(unittest.TestCase):
         if hasattr(self.eng, 'learn_stabilizer'):
             state = [0.5+0j, 0.5+0j, 0.5+0j, 0.5+0j]
             tab = self.eng.learn_stabilizer(state)
+            self.assertIsNotNone(tab)
+            self.assertEqual(tab.num_qubits, 2)
+        else:
+            self.skipTest('Stim support not built')
+
+    def test_vecs2pauli_fallback(self):
+        if hasattr(self.eng, 'learn_stabilizer'):
+            state = [1/np.sqrt(2), 0, 0, 1/np.sqrt(2)]
+            try:
+                import stim
+            except Exception:
+                self.skipTest('Stim not available')
+            with mock.patch('stim.Tableau.from_state_vector', side_effect=ValueError):
+                tab = self.eng.learn_stabilizer(state)
             self.assertIsNotNone(tab)
             self.assertEqual(tab.num_qubits, 2)
         else:


### PR DESCRIPTION
## Summary
- model exponential O(n·2^n) vecs2pauli runtime in estimate_cost
- call vecs2pauli when Stim's stabilizer recovery fails and convert its output to Stim tableaux
- add dependency and tests for vecs2pauli fallback

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b577755dd48321822bf1829804ffcc