### PR TITLE
Use mean timing and memory metrics in MPS benchmark notebook

### DIFF
--- a/benchmarks/notebooks/mps_backend.ipynb
+++ b/benchmarks/notebooks/mps_backend.ipynb
@@ -44,7 +44,7 @@
     "    res[\"circuit\"] = name\n",
     "\n",
     "df = runner.dataframe()\n",
-    "df[[\"circuit\", \"prepare_time\", \"run_time\", \"total_time\", \"prepare_peak_memory\", \"run_peak_memory\"]]\n"
+    "df[[\"circuit\", \"prepare_time_mean\", \"run_time_mean\", \"total_time_mean\", \"prepare_peak_memory_mean\", \"run_peak_memory_mean\"]]\n"
    ]
   },
   {


### PR DESCRIPTION
## Summary
- Show mean time and memory statistics in the MPS backend benchmark notebook

## Testing
- `python -m jupyter nbconvert --to notebook --execute benchmarks/notebooks/mps_backend.ipynb --stdout --ExecutePreprocessor.allow_errors=True`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b5778a03d8832182c65b9c20e45065