### PR TITLE
Use mean metrics in DD benchmark notebook

### DIFF
--- a/benchmarks/notebooks/mqt_dd_backend.ipynb
+++ b/benchmarks/notebooks/mqt_dd_backend.ipynb
@@ -44,7 +44,7 @@
     "    res[\"circuit\"] = name\n",
     "\n",
     "df = runner.dataframe()\n",
-    "df[[\"circuit\", \"prepare_time\", \"run_time\", \"total_time\", \"prepare_peak_memory\", \"run_peak_memory\"]]\n"
+    "df[[\"circuit\", \"prepare_time_mean\", \"run_time_mean\", \"total_time_mean\", \"prepare_peak_memory_mean\", \"run_peak_memory_mean\"]]\n"
    ]
   },
   {


### PR DESCRIPTION
## Summary
- Show mean performance metrics in `mqt_dd_backend` benchmark

## Testing
- `python - <<'PY' ...` (execute DD backend benchmark and print dataframe)
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b5778a951483219125cc4d4a32eee4