### PR TITLE
Use mean metric names in stim backend notebook

### DIFF
--- a/benchmarks/notebooks/stim_backend.ipynb
+++ b/benchmarks/notebooks/stim_backend.ipynb
@@ -44,7 +44,7 @@
     "    res[\"circuit\"] = name\n",
     "\n",
     "df = runner.dataframe()\n",
-    "df[[\"circuit\", \"prepare_time\", \"run_time\", \"total_time\", \"prepare_peak_memory\", \"run_peak_memory\"]]\n"
+    "df[[\"circuit\", \"prepare_time_mean\", \"run_time_mean\", \"total_time_mean\", \"prepare_peak_memory_mean\", \"run_peak_memory_mean\"]]\n"
    ]
   },
   {


### PR DESCRIPTION
## Summary
- Display mean timing and memory metrics in stim backend notebook

## Testing
- `PYTHONPATH=/workspace/QuASAr python - <<'PY'
from benchmarks.backends import StimAdapter
from benchmarks.runner import BenchmarkRunner
from benchmarks import circuits
import pandas as pd

circuits_to_run = [
    ("GHZ", circuits.ghz_circuit(5)),
]

runner = BenchmarkRunner()
backend = StimAdapter()
for name, circ in circuits_to_run:
    res = runner.run_multiple(circ, backend, return_state=False, repetitions=3)
    res["circuit"] = name

df = runner.dataframe()
print(df[["circuit", "prepare_time_mean", "run_time_mean", "total_time_mean", "prepare_peak_memory_mean", "run_peak_memory_mean"]])
PY`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b5778d1b248321bf5814ca92ab1313