### PR TITLE
Unify time metrics in benchmark summary notebook

### DIFF
--- a/benchmarks/notebooks/summary.ipynb
+++ b/benchmarks/notebooks/summary.ipynb
@@ -23,7 +23,7 @@
     "    w_state_circuit, graph_state_circuit,\n",
     ")\n",
     "from benchmarks.backends import (\n",
-    "    StatevectorAdapter, StimAdapter, MPSAdapter,\n",
+    "    StatevectorAdapter, StimAdapter, MPSAdapter, DecisionDiagramAdapter,\n",
     ")\n",
     "from benchmarks.runner import BenchmarkRunner\n",
     "from quasar import SimulationEngine\n",
@@ -62,6 +62,7 @@
     "        for b in backends:\n",
     "            try:\n",
     "                rec = runner.run_multiple(circ, b, return_state=False, repetitions=3)\n",
+    "                rec['time'] = rec['total_time_mean']\n",
     "                rec['qubits'] = n\n",
     "                rec['family'] = name\n",
     "                rec['selected_backend'] = None\n",
@@ -69,6 +70,7 @@
     "                continue\n",
     "        try:\n",
     "            rec = runner.run_quasar(circ, engine)\n",
+    "            rec['time'] = rec['total_time']\n",
     "            rec['qubits'] = n\n",
     "            rec['family'] = name\n",
     "            rec['selected_backend'] = backend\n",
@@ -89,7 +91,7 @@
     "    change = best[best['framework'] != best['framework'].shift()].copy()\n",
     "    return change\n",
     "crossover = df.groupby('family').apply(find_crossover)\n",
-    "crossover\n"
+    "crossover"
    ]
   },
   {


### PR DESCRIPTION
## Summary
- Add missing `DecisionDiagramAdapter` import
- Record a unified `time` field for `run_multiple` and `run_quasar` results in summary notebook

## Testing
- `pytest -q`
- `jupyter nbconvert --execute benchmarks/notebooks/summary.ipynb` *(fails: KeyboardInterrupt during heavy benchmark execution)*

------
https://chatgpt.com/codex/tasks/task_e_68b5779014848321ab94c803be2f5edb