### PR TITLE
Add STN tensor conversion and stabilizer detection

### DIFF
--- a/docs/STN_PROTOTYPE.md
+++ b/docs/STN_PROTOTYPE.md
@@ -1,0 +1,39 @@
+# Stabilizer Tensor Network Prototype
+
+This document sketches the data structures and algorithms required to support
+stabilizer tensor networks (STNs) within QuASAr's C++ code base.
+
+## Contraction rules
+
+* STN tensors represent stabilizer fragments and are contracted using
+  log-depth Clifford circuits.
+* Bridges between fragments only fuse when both sides represent stabilizer
+  states.
+* Contraction proceeds by repeatedly merging compatible stabilizer nodes while
+  respecting tensor indices and preserving overall parity.
+
+## Providing STN tensors
+
+`conversion_engine.hpp` exposes `convert_boundary_to_statevector`, which
+produces a phase-factorable stabilizer state for the boundary qubits.  The
+helper `convert_boundary_to_stn` wraps this dense vector together with an
+optional stabilizer tableau, yielding an explicit `StnTensor` that downstream
+contraction routines can consume directly.
+
+## Detecting stabilizer-only bridges
+
+`learn_stabilizer` attempts to recognise simple stabilizer states from raw
+amplitudes.  A bridge tensor is STN-compatible if this routine succeeds on the
+state produced by `convert_boundary_to_statevector`.  In that case the resulting
+Tableau is attached to the `StnTensor` emitted by `convert_boundary_to_stn`
+instead of materialising a dense tensor.
+
+## Core data structures
+
+* **`StnTensor`** – holds a stabilizer tableau alongside index labels.
+* **`StnEdge`** – lightweight reference connecting two tensor indices.
+* **`StnNetwork`** – container managing tensors and performing log-depth
+  contractions.
+
+These structures enable a future C++ prototype to interoperate with existing
+conversion paths while capturing STN-specific complexity metrics.

--- a/quasar/planner.py
+++ b/quasar/planner.py
@@ -135,7 +135,11 @@ def _add_cost(a: Cost, b: Cost) -> Cost:
     dominated by the larger of the two contributions.
     """
 
-    return Cost(time=a.time + b.time, memory=max(a.memory, b.memory))
+    return Cost(
+        time=a.time + b.time,
+        memory=max(a.memory, b.memory),
+        log_depth=max(a.log_depth, b.log_depth),
+    )
 
 
 def _better(a: Cost, b: Cost) -> bool:

--- a/quasar_convert/binding.cpp
+++ b/quasar_convert/binding.cpp
@@ -51,6 +51,14 @@ PYBIND11_MODULE(_conversion_engine, m) {
         .def_readonly("cost", &quasar::ConversionResult::cost)
         .def_readonly("fidelity", &quasar::ConversionResult::fidelity);
 
+    py::class_<quasar::StnTensor>(m, "StnTensor")
+        .def(py::init<>())
+        .def_readwrite("amplitudes", &quasar::StnTensor::amplitudes)
+#ifdef QUASAR_USE_STIM
+        .def_readwrite("tableau", &quasar::StnTensor::tableau)
+#endif
+        ;
+
     py::class_<quasar::ConversionEngine>(m, "ConversionEngine")
         .def(py::init<>())
         .def("estimate_cost", &quasar::ConversionEngine::estimate_cost)
@@ -60,6 +68,7 @@ PYBIND11_MODULE(_conversion_engine, m) {
         .def("convert", &quasar::ConversionEngine::convert)
         .def("build_bridge_tensor", &quasar::ConversionEngine::build_bridge_tensor)
         .def("convert_boundary_to_statevector", &quasar::ConversionEngine::convert_boundary_to_statevector)
+        .def("convert_boundary_to_stn", &quasar::ConversionEngine::convert_boundary_to_stn)
 #ifdef QUASAR_USE_STIM
         .def("convert_boundary_to_tableau", &quasar::ConversionEngine::convert_boundary_to_tableau)
         .def("try_build_tableau", &quasar::ConversionEngine::try_build_tableau)

--- a/tests/test_cost.py
+++ b/tests/test_cost.py
@@ -8,6 +8,8 @@ def test_statevector_scaling():
     large = est.statevector(num_qubits=4, num_gates=1)
     assert large.time == 2 * small.time
     assert large.memory == 2 * small.memory
+    assert small.log_depth == math.log2(3)
+    assert large.log_depth == math.log2(4)
 
 
 def test_tableau_quadratic():
@@ -31,6 +33,8 @@ def test_decision_diagram_linear():
     c2 = est.decision_diagram(num_gates=10, frontier=10)
     assert c2.time == 2 * c1.time
     assert c2.memory == 2 * c1.memory
+    assert c1.log_depth == math.log2(5)
+    assert c2.log_depth == math.log2(10)
 
 
 def test_conversion_primitive_selection():
@@ -54,6 +58,8 @@ def test_conversion_primitive_selection():
     )
     assert large.primitive == "LW"
     assert large.cost.time > small.cost.time
+    assert small.cost.log_depth == math.log2(2)
+    assert large.cost.log_depth == math.log2(16)
 
 
 def test_conversion_caps():


### PR DESCRIPTION
## Summary
- synthesize stabilizer boundary states and expose StnTensor API
- support STN conversion via `convert_boundary_to_stn` with optional tableau
- enhance stabilizer learning for phase-factorable states and update docs

## Testing
- `pytest tests/test_cost.py tests/test_planner_batch_pruning.py tests/test_scheduler.py tests/test_state_conversion.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68b59526ef688321b185c1e4fac1cdc8