### PR TITLE
Add decision diagram statevector export

### DIFF
--- a/quasar_convert/__init__.py
+++ b/quasar_convert/__init__.py
@@ -110,6 +110,12 @@ try:  # pragma: no cover - exercised when the extension is available
                 self._ensure_impl()
                 return self._impl.convert_boundary_to_dd(*args, **kwargs)
 
+        if hasattr(_CEngine, "dd_to_statevector"):
+
+            def dd_to_statevector(self, *args, **kwargs):  # type: ignore[override]
+                self._ensure_impl()
+                return self._impl.dd_to_statevector(*args, **kwargs)
+
         if hasattr(_CEngine, "learn_stabilizer"):
 
             def learn_stabilizer(self, *args, **kwargs):  # type: ignore[override]

--- a/quasar_convert/binding.cpp
+++ b/quasar_convert/binding.cpp
@@ -85,6 +85,13 @@ PYBIND11_MODULE(_conversion_engine, m) {
             std::uintptr_t ptr = reinterpret_cast<std::uintptr_t>(edge.p);
             return py::make_tuple(ssd.boundary_qubits.size(), ptr);
         })
+        .def("dd_to_statevector", [](quasar::ConversionEngine& eng, std::size_t n, std::uintptr_t ptr) {
+            // Reconstruct the decision diagram edge from the opaque handle and
+            // export its amplitudes as a statevector.
+            dd::vEdge edge{reinterpret_cast<dd::vNode*>(ptr), dd::Complex::one};
+            (void)n;  // number of qubits is implicit in the edge
+            return eng.dd_to_statevector(edge);
+        })
 #endif
         ;
 }

--- a/quasar_convert/conversion_engine.cpp
+++ b/quasar_convert/conversion_engine.cpp
@@ -265,6 +265,26 @@ dd::vEdge ConversionEngine::convert_boundary_to_dd(const SSD& ssd) const {
     // versions without introducing a direct dependency on an internal typedef.
     return dd_pkg->makeZeroState(ssd.boundary_qubits.size());
 }
+
+std::vector<std::complex<double>>
+ConversionEngine::dd_to_statevector(const dd::vEdge& edge) const {
+    // Use the decision diagram package to export the amplitudes represented by
+    // ``edge``.  ``getVector`` returns a flat vector ordered with qubit 0 as the
+    // least significant bit.  Normalise the result to guard against numerical
+    // imprecision in the underlying DD representation.
+    auto vec = dd_pkg->getVector(edge);
+    double norm = 0.0;
+    for (const auto& amp : vec) {
+        norm += std::norm(amp);
+    }
+    norm = std::sqrt(norm);
+    if (norm > 0.0) {
+        for (auto& amp : vec) {
+            amp /= norm;
+        }
+    }
+    return vec;
+}
 #endif
 
 #ifdef QUASAR_USE_STIM

--- a/quasar_convert/conversion_engine.hpp
+++ b/quasar_convert/conversion_engine.hpp
@@ -114,6 +114,11 @@ class ConversionEngine {
     // The decision diagram package exposes `vEdge` at the namespace level,
     // so we use it directly instead of the previous `Package<>::vEdge` alias.
     dd::vEdge convert_boundary_to_dd(const SSD& ssd) const;
+
+    // Export the amplitudes represented by a decision diagram edge as a
+    // normalised statevector.  The returned vector has dimension ``2^n`` where
+    // ``n`` is inferred from the edge's variable index.
+    std::vector<std::complex<double>> dd_to_statevector(const dd::vEdge& edge) const;
 #endif
 
 #ifdef QUASAR_USE_STIM

--- a/quasar_convert/tests/test_stim_mqt.py
+++ b/quasar_convert/tests/test_stim_mqt.py
@@ -15,12 +15,18 @@ class OptionalBackendTests(unittest.TestCase):
 
     def test_dd_conversion(self):
         eng = qc.ConversionEngine()
-        if hasattr(eng, 'convert_boundary_to_dd'):
+        if hasattr(eng, 'convert_boundary_to_dd') and hasattr(eng, 'dd_to_statevector'):
             ssd = qc.SSD()
             ssd.boundary_qubits = [0, 1]
             ssd.top_s = 2
             edge = eng.convert_boundary_to_dd(ssd)
             self.assertIsNotNone(edge)
+            # Round-trip from decision diagram back to a concrete statevector.
+            vec = eng.dd_to_statevector(*edge)
+            self.assertEqual(len(vec), 4)
+            self.assertAlmostEqual(vec[0], 1.0 + 0.0j)
+            for amp in vec[1:]:
+                self.assertAlmostEqual(abs(amp), 0.0)
         else:
             self.skipTest('MQT DD support not built')
 


### PR DESCRIPTION
## Summary
- add `dd_to_statevector` to `ConversionEngine` for exporting decision diagrams as normalised statevectors
- expose new helper in Python bindings and wrapper
- test round-trip conversion via MQT decision diagrams

## Testing
- `pytest quasar_convert/tests/test_stim_mqt.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68b5b4e242448321b772c3ab8ba8b864