### PR TITLE
Add decision diagram to MPS conversion utility

### DIFF
--- a/quasar_convert/__init__.py
+++ b/quasar_convert/__init__.py
@@ -116,6 +116,12 @@ try:  # pragma: no cover - exercised when the extension is available
                 self._ensure_impl()
                 return self._impl.dd_to_statevector(*args, **kwargs)
 
+        if hasattr(_CEngine, "dd_to_mps"):
+
+            def dd_to_mps(self, *args, **kwargs):  # type: ignore[override]
+                self._ensure_impl()
+                return self._impl.dd_to_mps(*args, **kwargs)
+
         if hasattr(_CEngine, "learn_stabilizer"):
 
             def learn_stabilizer(self, *args, **kwargs):  # type: ignore[override]

--- a/quasar_convert/binding.cpp
+++ b/quasar_convert/binding.cpp
@@ -92,6 +92,17 @@ PYBIND11_MODULE(_conversion_engine, m) {
             (void)n;  // number of qubits is implicit in the edge
             return eng.dd_to_statevector(edge);
         })
+        .def("dd_to_mps",
+             [](quasar::ConversionEngine& eng, std::size_t n, std::uintptr_t ptr, std::size_t chi) {
+                 // Reconstruct the decision diagram edge from the opaque handle
+                 // and factor it into a chain of MPS tensors.
+                 dd::vEdge edge{reinterpret_cast<dd::vNode*>(ptr), dd::Complex::one};
+                 (void)n;  // number of qubits is implicit in the edge
+                 return eng.dd_to_mps(edge, chi);
+             },
+             py::arg("n"),
+             py::arg("ptr"),
+             py::arg("chi") = 0)
 #endif
         ;
 }

--- a/quasar_convert/conversion_engine.cpp
+++ b/quasar_convert/conversion_engine.cpp
@@ -285,6 +285,101 @@ ConversionEngine::dd_to_statevector(const dd::vEdge& edge) const {
     }
     return vec;
 }
+
+std::vector<std::vector<std::complex<double>>>
+ConversionEngine::dd_to_mps(const dd::vEdge& edge, std::size_t chi) const {
+    // Start from the dense statevector representation and perform a simple
+    // left-to-right QR factorisation.  Each step yields an isometry reshaped
+    // into a rank-3 tensor ``(left, physical, right)``.  When ``chi`` is
+    // specified the intermediate bond dimensions are truncated to at most
+    // ``chi``.
+    auto state = dd_to_statevector(edge);
+    const std::size_t dim = state.size();
+    if (dim == 0) {
+        return {};
+    }
+    const std::size_t n = static_cast<std::size_t>(std::log2(dim));
+
+    std::vector<std::vector<std::complex<double>>> tensors;
+    std::vector<std::complex<double>> current = std::move(state);
+    std::size_t left_dim = 1;
+
+    for (std::size_t qubit = 0; qubit < n; ++qubit) {
+        const std::size_t cols = 1ULL << (n - qubit - 1);
+        const std::size_t rows = left_dim * 2;
+
+        // Rank after truncation.
+        std::size_t rank = std::min(rows, cols);
+        if (chi != 0) {
+            rank = std::min(rank, chi);
+        }
+
+        std::vector<std::complex<double>> Q(rows * rank, {0.0, 0.0});
+        std::vector<std::complex<double>> R(rank * cols, {0.0, 0.0});
+
+        // Classical Gram-Schmidt orthogonalisation on the column space.
+        for (std::size_t k = 0; k < rank; ++k) {
+            // Copy k-th column of the working matrix into Q.
+            for (std::size_t r = 0; r < rows; ++r) {
+                Q[r * rank + k] = current[r * cols + k];
+            }
+            // Orthogonalise against previous columns.
+            for (std::size_t j = 0; j < k; ++j) {
+                std::complex<double> dot = {0.0, 0.0};
+                for (std::size_t r = 0; r < rows; ++r) {
+                    dot += std::conj(Q[r * rank + j]) * Q[r * rank + k];
+                }
+                for (std::size_t r = 0; r < rows; ++r) {
+                    Q[r * rank + k] -= dot * Q[r * rank + j];
+                }
+                R[j * cols + k] = dot;
+            }
+            // Normalise the new column.
+            double norm = 0.0;
+            for (std::size_t r = 0; r < rows; ++r) {
+                norm += std::norm(Q[r * rank + k]);
+            }
+            norm = std::sqrt(norm);
+            if (norm > 0.0) {
+                for (std::size_t r = 0; r < rows; ++r) {
+                    Q[r * rank + k] /= norm;
+                }
+            }
+            R[k * cols + k] = norm;
+
+            // Update remaining columns of the working matrix and compute
+            // the corresponding ``R`` entries.
+            for (std::size_t c = k + 1; c < cols; ++c) {
+                std::complex<double> dot = {0.0, 0.0};
+                for (std::size_t r = 0; r < rows; ++r) {
+                    dot += std::conj(Q[r * rank + k]) * current[r * cols + c];
+                }
+                R[k * cols + c] = dot;
+                for (std::size_t r = 0; r < rows; ++r) {
+                    current[r * cols + c] -= dot * Q[r * rank + k];
+                }
+            }
+        }
+
+        // Reshape Q into a rank-3 tensor ``(left_dim, 2, rank)`` and append to
+        // the MPS chain.
+        std::vector<std::complex<double>> tensor(left_dim * 2 * rank);
+        for (std::size_t l = 0; l < left_dim; ++l) {
+            for (std::size_t p = 0; p < 2; ++p) {
+                for (std::size_t r = 0; r < rank; ++r) {
+                    tensor[(l * 2 + p) * rank + r] = Q[(l * 2 + p) * rank + r];
+                }
+            }
+        }
+        tensors.push_back(std::move(tensor));
+
+        // Prepare the matrix for the next iteration using the accumulated R.
+        current.assign(R.begin(), R.begin() + rank * cols);
+        left_dim = rank;
+    }
+
+    return tensors;
+}
 #endif
 
 #ifdef QUASAR_USE_STIM

--- a/quasar_convert/conversion_engine.hpp
+++ b/quasar_convert/conversion_engine.hpp
@@ -119,6 +119,13 @@ class ConversionEngine {
     // normalised statevector.  The returned vector has dimension ``2^n`` where
     // ``n`` is inferred from the edge's variable index.
     std::vector<std::complex<double>> dd_to_statevector(const dd::vEdge& edge) const;
+
+    // Factor the amplitudes represented by a decision diagram edge into a
+    // matrix product state.  The returned chain stores each tensor as a flat
+    // vector with dimensions ``(left, 2, right)``.  When ``chi`` is non-zero the
+    // intermediate bond dimensions are truncated to ``chi``.
+    std::vector<std::vector<std::complex<double>>> dd_to_mps(const dd::vEdge& edge,
+                                                            std::size_t chi = 0) const;
 #endif
 
 #ifdef QUASAR_USE_STIM


### PR DESCRIPTION
## Summary
- convert decision diagram amplitudes into an MPS chain with optional bond-dimension cap
- expose `dd_to_mps` through the Python bindings
- exercise conversion by reconstructing zero state using the MPS backend

## Testing
- `pytest quasar_convert/tests/test_stim_mqt.py::OptionalBackendTests::test_dd_to_mps_conversion -q`


------
https://chatgpt.com/codex/tasks/task_e_68b5bc3fd5b883218f121e1198a83eb8