### PR TITLE
Add Stim tableau→statevector conversion with tests

### DIFF
--- a/quasar_convert/__init__.py
+++ b/quasar_convert/__init__.py
@@ -17,6 +17,7 @@ try:  # pragma: no cover - exercised when the extension is available
         Primitive,
         ConversionResult,
         StnTensor,
+        StimTableau,
         ConversionEngine as _CEngine,
     )
 
@@ -104,6 +105,12 @@ try:  # pragma: no cover - exercised when the extension is available
                 self._ensure_impl()
                 return self._impl.convert_boundary_to_tableau(*args, **kwargs)
 
+        if hasattr(_CEngine, "tableau_to_statevector"):
+
+            def tableau_to_statevector(self, *args, **kwargs):  # type: ignore[override]
+                self._ensure_impl()
+                return self._impl.tableau_to_statevector(*args, **kwargs)
+
         if hasattr(_CEngine, "convert_boundary_to_dd"):
 
             def convert_boundary_to_dd(self, *args, **kwargs):  # type: ignore[override]
@@ -134,6 +141,7 @@ try:  # pragma: no cover - exercised when the extension is available
         "Primitive",
         "ConversionResult",
         "StnTensor",
+        "StimTableau",
         "ConversionEngine",
     ]
 except Exception:  # pragma: no cover - exercised when extension missing

--- a/quasar_convert/binding.cpp
+++ b/quasar_convert/binding.cpp
@@ -3,6 +3,7 @@
 #include <pybind11/complex.h>
 
 #include <cstdint>
+#include <string>
 
 #include "conversion_engine.hpp"
 
@@ -33,7 +34,14 @@ PYBIND11_MODULE(_conversion_engine, m) {
 #ifdef QUASAR_USE_STIM
     py::class_<quasar::StimTableau>(m, "StimTableau")
         .def(py::init<size_t>())
-        .def_readwrite("num_qubits", &quasar::StimTableau::num_qubits);
+        .def_readwrite("num_qubits", &quasar::StimTableau::num_qubits)
+        .def_static(
+            "from_circuit",
+            [](const std::string &text) {
+                stim::Circuit c(text);
+                return stim::circuit_to_tableau<stim::MAX_BITWORD_WIDTH>(c, false, false, false);
+            },
+            py::arg("circuit"));
 #endif
 
     py::enum_<quasar::Backend>(m, "Backend")
@@ -71,6 +79,7 @@ PYBIND11_MODULE(_conversion_engine, m) {
         .def("convert_boundary_to_stn", &quasar::ConversionEngine::convert_boundary_to_stn)
 #ifdef QUASAR_USE_STIM
         .def("convert_boundary_to_tableau", &quasar::ConversionEngine::convert_boundary_to_tableau)
+        .def("tableau_to_statevector", &quasar::ConversionEngine::tableau_to_statevector)
         .def("try_build_tableau", &quasar::ConversionEngine::try_build_tableau)
         .def("learn_stabilizer", &quasar::ConversionEngine::learn_stabilizer)
 #endif

--- a/quasar_convert/conversion_engine.hpp
+++ b/quasar_convert/conversion_engine.hpp
@@ -130,6 +130,9 @@ class ConversionEngine {
 
 #ifdef QUASAR_USE_STIM
     StimTableau convert_boundary_to_tableau(const SSD& ssd) const;
+    // Convert a stabilizer tableau into a dense statevector.  The returned
+    // vector has dimension ``2^n`` with qubit 0 as the least significant bit.
+    std::vector<std::complex<double>> tableau_to_statevector(const StimTableau& tableau) const;
     std::optional<StimTableau> try_build_tableau(const std::vector<std::complex<double>>& state) const;
     // Attempt to learn a stabilizer tableau from an arbitrary state vector.
     // Simple analytic checks recognise computational basis states and uniform

--- a/quasar_convert/tests/test_stim_mqt.py
+++ b/quasar_convert/tests/test_stim_mqt.py
@@ -59,5 +59,18 @@ class OptionalBackendTests(unittest.TestCase):
         else:
             self.skipTest('MQT DD support not built')
 
+    def test_tableau_to_statevector(self):
+        eng = qc.ConversionEngine()
+        if hasattr(eng, 'tableau_to_statevector') and hasattr(qc, 'StimTableau'):
+            import stim
+            import numpy as np
+            circuit_text = 'H 0\nCX 0 1\nS 1\n'
+            tab = qc.StimTableau.from_circuit(circuit_text)
+            vec_cpp = eng.tableau_to_statevector(tab)
+            vec_stim = stim.Tableau.from_circuit(stim.Circuit(circuit_text)).to_state_vector(endian='little')
+            np.testing.assert_allclose(vec_cpp, vec_stim, atol=1e-6)
+        else:
+            self.skipTest('Stim support not built')
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
## Summary
- implement Stim tableau to statevector conversion via TableauSimulator
- expose Stim tableau utilities and new method in Python bindings
- add regression test comparing tableau-to-statevector against Stim

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b5e142e4cc8321885b83111f06964a