### PR TITLE
feat: add tableau to decision diagram conversion

### DIFF
--- a/quasar_convert/__init__.py
+++ b/quasar_convert/__init__.py
@@ -111,6 +111,12 @@ try:  # pragma: no cover - exercised when the extension is available
                 self._ensure_impl()
                 return self._impl.tableau_to_statevector(*args, **kwargs)
 
+        if hasattr(_CEngine, "tableau_to_dd"):
+
+            def tableau_to_dd(self, *args, **kwargs):  # type: ignore[override]
+                self._ensure_impl()
+                return self._impl.tableau_to_dd(*args, **kwargs)
+
         if hasattr(_CEngine, "convert_boundary_to_dd"):
 
             def convert_boundary_to_dd(self, *args, **kwargs):  # type: ignore[override]

--- a/quasar_convert/binding.cpp
+++ b/quasar_convert/binding.cpp
@@ -83,6 +83,14 @@ PYBIND11_MODULE(_conversion_engine, m) {
         .def("try_build_tableau", &quasar::ConversionEngine::try_build_tableau)
         .def("learn_stabilizer", &quasar::ConversionEngine::learn_stabilizer)
 #endif
+#if defined(QUASAR_USE_MQT) && defined(QUASAR_USE_STIM)
+        .def("tableau_to_dd",
+             [](quasar::ConversionEngine& eng, const quasar::StimTableau& tab) {
+                 auto edge = eng.tableau_to_dd(tab);
+                 std::uintptr_t ptr = reinterpret_cast<std::uintptr_t>(edge.p);
+                 return py::make_tuple(tab.num_qubits, ptr);
+             })
+#endif
 #ifdef QUASAR_USE_MQT
         .def("convert_boundary_to_dd", [](quasar::ConversionEngine& eng, const quasar::SSD& ssd) {
             // Expose the decision diagram edge as a lightweight handle.  A

--- a/quasar_convert/conversion_engine.cpp
+++ b/quasar_convert/conversion_engine.cpp
@@ -6,6 +6,9 @@
 #include <complex>
 #include <vector>
 #include <random>
+#ifdef QUASAR_USE_MQT
+#include <dd/StateGeneration.hpp>
+#endif
 
 namespace quasar {
 
@@ -380,6 +383,21 @@ ConversionEngine::dd_to_mps(const dd::vEdge& edge, std::size_t chi) const {
     }
 
     return tensors;
+}
+#endif
+
+#if defined(QUASAR_USE_MQT) && defined(QUASAR_USE_STIM)
+dd::vEdge ConversionEngine::tableau_to_dd(const StimTableau& tableau) const {
+    // Produce a dense statevector for the tableau and construct a decision
+    // diagram representing the same amplitudes.
+    auto vec = tableau_to_statevector(tableau);
+    dd::CVec dd_vec;
+    dd_vec.reserve(vec.size());
+    for (const auto& amp : vec) {
+        dd_vec.emplace_back(static_cast<dd::fp>(amp.real()),
+                            static_cast<dd::fp>(amp.imag()));
+    }
+    return dd::makeStateFromVector(dd_vec, *dd_pkg);
 }
 #endif
 

--- a/quasar_convert/conversion_engine.hpp
+++ b/quasar_convert/conversion_engine.hpp
@@ -128,6 +128,13 @@ class ConversionEngine {
                                                             std::size_t chi = 0) const;
 #endif
 
+#if defined(QUASAR_USE_MQT) && defined(QUASAR_USE_STIM)
+    // Convert a stabilizer tableau into a decision diagram representation by
+    // first materialising the corresponding statevector and then ingesting it
+    // into the DD package.
+    dd::vEdge tableau_to_dd(const StimTableau& tableau) const;
+#endif
+
 #ifdef QUASAR_USE_STIM
     StimTableau convert_boundary_to_tableau(const SSD& ssd) const;
     // Convert a stabilizer tableau into a dense statevector.  The returned

--- a/quasar_convert/tests/test_stim_mqt.py
+++ b/quasar_convert/tests/test_stim_mqt.py
@@ -72,5 +72,18 @@ class OptionalBackendTests(unittest.TestCase):
         else:
             self.skipTest('Stim support not built')
 
+    def test_tableau_to_dd_roundtrip(self):
+        eng = qc.ConversionEngine()
+        if all(hasattr(eng, attr) for attr in ('tableau_to_dd', 'dd_to_statevector', 'tableau_to_statevector')) and hasattr(qc, 'StimTableau'):
+            import numpy as np
+            circuit_text = 'H 0\nCX 0 1\nS 1\n'
+            tab = qc.StimTableau.from_circuit(circuit_text)
+            edge = eng.tableau_to_dd(tab)
+            vec_dd = eng.dd_to_statevector(*edge)
+            vec_tab = eng.tableau_to_statevector(tab)
+            np.testing.assert_allclose(vec_dd, vec_tab, atol=1e-6)
+        else:
+            self.skipTest('Stim or MQT support not built')
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
## Summary
- support converting a Stim tableau directly into an MQT decision diagram
- expose tableau-to-DD conversion in bindings and Python wrapper
- test round-trip tableau → decision diagram → statevector

## Testing
- `pytest quasar_convert/tests/test_stim_mqt.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68b6559639f08321b0af079e789aadff