### PR TITLE
Add MPS to statevector conversion

### DIFF
--- a/quasar_convert/binding.cpp
+++ b/quasar_convert/binding.cpp
@@ -67,6 +67,19 @@ PYBIND11_MODULE(_conversion_engine, m) {
 #endif
         ;
 
+    py::class_<quasar::MPS>(m, "MPS")
+        .def(py::init([](std::vector<std::vector<std::complex<double>>> tensors,
+                         std::vector<std::size_t> bond_dims) {
+                 quasar::MPS m;
+                 m.tensors = std::move(tensors);
+                 m.bond_dims = std::move(bond_dims);
+                 return m;
+             }),
+             py::arg("tensors") = std::vector<std::vector<std::complex<double>>>{},
+             py::arg("bond_dims") = std::vector<std::size_t>{})
+        .def_readwrite("tensors", &quasar::MPS::tensors)
+        .def_readwrite("bond_dims", &quasar::MPS::bond_dims);
+
     py::class_<quasar::ConversionEngine>(m, "ConversionEngine")
         .def(py::init<>())
         .def("estimate_cost", &quasar::ConversionEngine::estimate_cost)
@@ -77,6 +90,7 @@ PYBIND11_MODULE(_conversion_engine, m) {
         .def("build_bridge_tensor", &quasar::ConversionEngine::build_bridge_tensor)
         .def("convert_boundary_to_statevector", &quasar::ConversionEngine::convert_boundary_to_statevector)
         .def("convert_boundary_to_stn", &quasar::ConversionEngine::convert_boundary_to_stn)
+        .def("mps_to_statevector", &quasar::ConversionEngine::mps_to_statevector)
 #ifdef QUASAR_USE_STIM
         .def("convert_boundary_to_tableau", &quasar::ConversionEngine::convert_boundary_to_tableau)
         .def("tableau_to_statevector", &quasar::ConversionEngine::tableau_to_statevector)

--- a/quasar_convert/conversion_engine.hpp
+++ b/quasar_convert/conversion_engine.hpp
@@ -32,6 +32,15 @@ struct StnTensor {
 #endif
 };
 
+// Simple matrix product state container.  Each tensor is stored as a flat
+// vector with dimensions ``(left, 2, right)``.  The ``bond_dims`` entry lists
+// the intermediate bond dimensions so that the dense state can be reconstructed
+// without re-inferring the sizes from the flattened tensors.
+struct MPS {
+    std::vector<std::vector<std::complex<double>>> tensors;
+    std::vector<std::size_t> bond_dims;
+};
+
 struct SSD {
     std::vector<uint32_t> boundary_qubits;  // indices of qubits on the boundary
     std::size_t top_s;                      // number of Schmidt vectors kept
@@ -109,6 +118,13 @@ class ConversionEngine {
     // The amplitude vector is always populated while the optional tableau is
     // provided when the boundary admits a stabilizer description.
     StnTensor convert_boundary_to_stn(const SSD& ssd) const;
+
+    // Contract a matrix product state into a dense statevector.  Each tensor is
+    // stored as a flat vector with dimensions ``(left, 2, right)`` and the
+    // optional ``bond_dims`` list contains the bond dimensions along the chain
+    // with length ``n + 1`` for ``n`` tensors.  When ``bond_dims`` is empty the
+    // dimensions are inferred from the tensor sizes.
+    std::vector<std::complex<double>> mps_to_statevector(const MPS& mps) const;
 
 #ifdef QUASAR_USE_MQT
     // The decision diagram package exposes `vEdge` at the namespace level,

--- a/quasar_convert/tests/test_mps_to_statevector.py
+++ b/quasar_convert/tests/test_mps_to_statevector.py
@@ -1,0 +1,24 @@
+import numpy as np
+from qiskit import QuantumCircuit
+from qiskit.quantum_info import Statevector
+
+import quasar_convert as qc
+
+
+def test_mps_to_statevector_contracts_to_expected_statevector():
+    eng = qc.ConversionEngine()
+
+    inv_sqrt2 = 1 / np.sqrt(2)
+    t1 = [inv_sqrt2, 0, 0, inv_sqrt2]
+    t2 = [1.0, 0.0, 0.0, 1.0]
+    mps = qc.MPS(tensors=[t1, t2], bond_dims=[1, 2, 1])
+
+    state = eng.mps_to_statevector(mps)
+
+    circ = QuantumCircuit(2)
+    circ.h(0)
+    circ.cx(0, 1)
+    expected = Statevector.from_instruction(circ).data
+    expected = np.asarray(expected).reshape([2, 2]).transpose(1, 0).reshape(-1)
+
+    assert np.allclose(state, expected)


### PR DESCRIPTION
## Summary
- define an MPS container with bond dimensions
- add `mps_to_statevector` to contract an MPS into a full statevector
- expose new container and converter to Python and test against Qiskit's `Statevector`

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b69e102ba483219c6f5d9e66df2f1d