### PR TITLE
Add notebook for large-scale circuit benchmarking

### DIFF
--- a/benchmarks/notebooks/large_scale_circuits.ipynb
+++ b/benchmarks/notebooks/large_scale_circuits.ipynb
@@ -1,0 +1,300 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "d86fc06c",
+   "metadata": {},
+   "source": [
+    "\n",
+    "# Large-scale circuit benchmarks\n",
+    "\n",
+    "This notebook benchmarks complex circuit generators on multiple backends and QuASAr's planner. Small and large instances highlight when hybrid planning outperforms single-method simulations.\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c338fc07",
+   "metadata": {},
+   "source": [
+    "\n",
+    "## Environment\n",
+    "\n",
+    "Install required packages and load repository root so that `benchmarks` utilities are importable.\n",
+    "\n",
+    "```bash\n",
+    "pip install -e .[test]\n",
+    "pip install pandas seaborn jupyter\n",
+    "```\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "77b96ec3",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "\n",
+    "import sys, platform, quasar\n",
+    "print('Python', sys.version)\n",
+    "print('Platform', platform.platform())\n",
+    "print('QuASAr', quasar.__version__)\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "f343362b",
+   "metadata": {},
+   "source": [
+    "\n",
+    "## Benchmark setup\n",
+    "\n",
+    "Each circuit generator from `large_scale_circuits.py` is instantiated at two scales. The circuits are executed on pure backends – dense statevector, Stim's tableau simulator, the tensor-network MPS backend and the decision-diagram backend – and via QuASAr's planner. Runtimes and memory consumption are recorded for comparison.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "2c215c62",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "\n",
+    "from __future__ import annotations\n",
+    "from pathlib import Path\n",
+    "import pandas as pd\n",
+    "import seaborn as sns\n",
+    "import matplotlib.pyplot as plt\n",
+    "import networkx as nx\n",
+    "\n",
+    "from runner import BenchmarkRunner\n",
+    "from backends import (\n",
+    "    StatevectorAdapter,\n",
+    "    StimAdapter,\n",
+    "    MPSAdapter,\n",
+    "    DecisionDiagramAdapter,\n",
+    ")\n",
+    "from quasar import SimulationEngine\n",
+    "import large_scale_circuits as lsc\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "1f2ae13b",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "\n",
+    "# Circuit configurations: small and large parameter sets\n",
+    "circuit_builders = {\n",
+    "    'ripple_carry': lsc.ripple_carry_modular_circuit,\n",
+    "    'surface_code': lsc.surface_code_cycle,\n",
+    "    'grover': lsc.grover_with_oracle_circuit,\n",
+    "    'qaoa': lsc.deep_qaoa_circuit,\n",
+    "    'phase_est': lsc.phase_estimation_classical_unitary,\n",
+    "}\n",
+    "\n",
+    "configurations = {\n",
+    "    'ripple_carry': {\n",
+    "        'small': dict(bit_width=4, modulus=None, arithmetic='cdkm'),\n",
+    "        'large': dict(bit_width=8, modulus=None, arithmetic='cdkm'),\n",
+    "    },\n",
+    "    'surface_code': {\n",
+    "        'small': dict(distance=3, rounds=1),\n",
+    "        'large': dict(distance=5, rounds=2),\n",
+    "    },\n",
+    "    'grover': {\n",
+    "        'small': dict(n_qubits=4, oracle_depth=2, iterations=1),\n",
+    "        'large': dict(n_qubits=8, oracle_depth=4, iterations=1),\n",
+    "    },\n",
+    "    'qaoa': {\n",
+    "        'small': dict(graph=nx.cycle_graph(4), p_layers=2),\n",
+    "        'large': dict(graph=nx.cycle_graph(8), p_layers=4),\n",
+    "    },\n",
+    "    'phase_est': {\n",
+    "        'small': dict(eigen_qubits=2, precision_qubits=2, classical_depth=1),\n",
+    "        'large': dict(eigen_qubits=3, precision_qubits=3, classical_depth=2),\n",
+    "    },\n",
+    "}\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "f41092ea",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "\n",
+    "# Initialise backends, skipping those that are unavailable\n",
+    "backends = []\n",
+    "backends.append(StatevectorAdapter())\n",
+    "for adapter in (StimAdapter, MPSAdapter, DecisionDiagramAdapter):\n",
+    "    try:\n",
+    "        backends.append(adapter())\n",
+    "    except Exception as exc:\n",
+    "        print(f'Skipping {adapter.__name__}: {exc}')\n",
+    "\n",
+    "runner = BenchmarkRunner()\n",
+    "engine = SimulationEngine()\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "5fdce930",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "\n",
+    "records = []\n",
+    "for name, builder in circuit_builders.items():\n",
+    "    for size, params in configurations[name].items():\n",
+    "        circ = builder(**params)\n",
+    "        for backend in backends:\n",
+    "            rec = runner.run_multiple(circ, backend, return_state=False, repetitions=3)\n",
+    "            rec.update({'circuit': name, 'size': size, 'qubits': circ.num_qubits})\n",
+    "            records.append(rec)\n",
+    "        rec = runner.run_quasar_multiple(circ, engine, repetitions=3)\n",
+    "        rec.update({'circuit': name, 'size': size, 'qubits': circ.num_qubits})\n",
+    "        records.append(rec)\n",
+    "\n",
+    "df = pd.DataFrame(records)\n",
+    "df\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "73a7987e",
+   "metadata": {},
+   "source": [
+    "\n",
+    "### Runtime and memory comparison\n",
+    "\n",
+    "Lines connect the small and large instances for each circuit family. Cross-over points mark where QuASAr becomes faster than a single-method backend.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "e89a2d5e",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "\n",
+    "sns.set_theme(style='whitegrid')\n",
+    "\n",
+    "# Plot runtime\n",
+    "runtime_plot = sns.relplot(\n",
+    "    data=df,\n",
+    "    x='qubits', y='run_time_mean', hue='framework', style='framework',\n",
+    "    col='circuit', col_wrap=2, kind='line', facet_kws={'sharey': False}, marker='o'\n",
+    ")\n",
+    "runtime_plot.set(xscale='log', yscale='log')\n",
+    "plt.show()\n",
+    "\n",
+    "# Plot peak memory during run phase\n",
+    "memory_plot = sns.relplot(\n",
+    "    data=df,\n",
+    "    x='qubits', y='run_peak_memory_mean', hue='framework', style='framework',\n",
+    "    col='circuit', col_wrap=2, kind='line', facet_kws={'sharey': False}, marker='o'\n",
+    ")\n",
+    "memory_plot.set(xscale='log', yscale='log')\n",
+    "plt.show()\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "f1f76555",
+   "metadata": {},
+   "source": [
+    "\n",
+    "### Cross-over estimation\n",
+    "\n",
+    "For each circuit family we estimate the qubit count at which QuASAr outperforms a given backend. The estimate assumes linear scaling between the sampled small and large sizes.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "c1ca1ba4",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "\n",
+    "crossovers = []\n",
+    "for name in circuit_builders:\n",
+    "    sub = df[(df['circuit'] == name)].pivot_table(\n",
+    "        index='framework', columns='size', values=['run_time_mean', 'qubits']\n",
+    "    )\n",
+    "    if ('run_time_mean', 'small') not in sub.columns:\n",
+    "        continue\n",
+    "    q_small = sub['qubits', 'small'].iloc[0]\n",
+    "    q_large = sub['qubits', 'large'].iloc[0]\n",
+    "    for backend in sub.index:\n",
+    "        if backend == 'quasar':\n",
+    "            continue\n",
+    "        if ('run_time_mean', 'large') not in sub.loc[[backend, 'quasar'], :].columns:\n",
+    "            continue\n",
+    "        qs = sub.loc['quasar', ('run_time_mean', 'small')]\n",
+    "        ql = sub.loc['quasar', ('run_time_mean', 'large')]\n",
+    "        bs = sub.loc[backend, ('run_time_mean', 'small')]\n",
+    "        bl = sub.loc[backend, ('run_time_mean', 'large')]\n",
+    "        diff_small = qs - bs\n",
+    "        diff_large = ql - bl\n",
+    "        if diff_small > 0 and diff_large < 0:\n",
+    "            cross_q = q_small + (q_large - q_small) * diff_small / (diff_small - diff_large)\n",
+    "            crossovers.append({'circuit': name, 'backend': backend, 'crossover_qubits': cross_q})\n",
+    "\n",
+    "crossovers_df = pd.DataFrame(crossovers)\n",
+    "crossovers_df\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "d102c0ea",
+   "metadata": {},
+   "source": [
+    "\n",
+    "## Save results\n",
+    "\n",
+    "Raw benchmark data and crossover estimates are stored in `benchmarks/results/` for reproducibility.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "87e031c4",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "\n",
+    "result_dir = Path('../results')\n",
+    "result_dir.mkdir(exist_ok=True)\n",
+    "\n",
+    "df.to_json(result_dir / 'large_scale_circuits_results.json', orient='records', indent=2)\n",
+    "if not crossovers_df.empty:\n",
+    "    crossovers_df.to_csv(result_dir / 'large_scale_circuits_crossovers.csv', index=False)\n",
+    "\n",
+    "{'results_path': str(result_dir.resolve())}\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "5b5729e8",
+   "metadata": {},
+   "source": [
+    "\n",
+    "## Reproducing this notebook\n",
+    "\n",
+    "1. Install dependencies as described in the *Environment* section.\n",
+    "2. Start Jupyter and open `benchmarks/notebooks/large_scale_circuits.ipynb`.\n",
+    "3. Run all cells to generate the results and plots.\n"
+   ]
+  }
+ ],
+ "metadata": {},
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
## Summary
- Add `large_scale_circuits.ipynb` to benchmark large-scale circuits on multiple simulation backends and QuASAr's planner
- Record runtime and memory for statevector, tableau, MPS, decision diagram, and planner executions
- Estimate crossover points where hybrid planning outperforms single-method approaches and save benchmark results

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b6c169a0c88321b85fc8a3a6e2ee0c