### PR TITLE
Allow forcing backend in benchmark runner

### DIFF
--- a/tests/test_benchmark_runner_memory.py
+++ b/tests/test_benchmark_runner_memory.py
@@ -29,7 +29,7 @@ def test_run_records_memory():
 
 
 class DummyPlanner:
-    def plan(self, circuit):
+    def plan(self, circuit, *, backend=None):
         self._data = [0] * 10000
 
 
@@ -37,7 +37,7 @@ class DummyScheduler:
     def __init__(self):
         self.planner = DummyPlanner()
 
-    def run(self, circuit):
+    def run(self, circuit, *, backend=None):
         self._data = [0] * 10000
         return "done"
 


### PR DESCRIPTION
## Summary
- allow BenchmarkRunner.run_quasar and run_quasar_multiple to accept an optional backend
- forward backend to planner.plan and scheduler.run
- add tests ensuring forced backend is passed through

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b6d548e4ac8321950986f0805e95a8