### PR TITLE
Record scheduler backend in benchmark results

### DIFF
--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -35,6 +35,8 @@ phases as well as their sum:
   compilation that happens before execution.
 - **run_time** – execution of the prepared circuit on the backend.
 - **total_time** – combined runtime of both phases.
+- For QuASAr runs, **backend** – the simulator backend selected by the
+  scheduler.
 
 Adapters are expected to perform heavy translation work in the preparation
 phase so that `run_time` reflects only the actual simulation cost.

--- a/tests/test_benchmark_run_multiple.py
+++ b/tests/test_benchmark_run_multiple.py
@@ -112,7 +112,9 @@ class DummyScheduler:
 
     def run(self, circuit, *, backend=None):
         self.run_calls.append(backend)
-        return SSD([SSDPartition(subsystems=((0,),))])
+        return SSD([
+            SSDPartition(subsystems=((0,),), backend=backend or Backend.STATEVECTOR)
+        ])
 
 
 def test_run_quasar_multiple_aggregates_statistics():
@@ -138,6 +140,7 @@ def test_run_quasar_multiple_aggregates_statistics():
     assert math.isclose(record["run_time_std"], math.sqrt(2 / 3))
     assert scheduler.plan_calls == [Backend.TABLEAU] * 3
     assert scheduler.run_calls == [Backend.TABLEAU] * 3
+    assert record["backend"] == Backend.TABLEAU.name
 
 
 class PlannerErrorScheduler:
@@ -149,7 +152,9 @@ class PlannerErrorScheduler:
         self.planner = Planner()
 
     def run(self, circuit, *, backend=None):
-        return SSD([SSDPartition(subsystems=((0,),))])
+        return SSD([
+            SSDPartition(subsystems=((0,),), backend=backend or Backend.STATEVECTOR)
+        ])
 
 
 def test_run_quasar_returns_failure_record_on_planner_error():
@@ -158,6 +163,7 @@ def test_run_quasar_returns_failure_record_on_planner_error():
     record = runner.run_quasar(None, scheduler)
     assert record["failed"] is True
     assert "plan boom" in record["error"]
+    assert record["backend"] is None
 
 
 class RunErrorScheduler:
@@ -178,6 +184,7 @@ def test_run_quasar_returns_failure_record_on_run_error():
     record = runner.run_quasar(None, scheduler)
     assert record["failed"] is True
     assert "run boom" in record["error"]
+    assert record["backend"] is None
 
 
 def test_run_quasar_multiple_raises_runtime_error_with_failures():

--- a/tests/test_benchmark_runner_memory.py
+++ b/tests/test_benchmark_runner_memory.py
@@ -47,3 +47,4 @@ def test_run_quasar_records_memory():
     record = runner.run_quasar(None, DummyScheduler())
     assert record["prepare_peak_memory"] > 0
     assert record["run_peak_memory"] > 0
+    assert "backend" in record and record["backend"] is None


### PR DESCRIPTION
## Summary
- include scheduler backend in `run_quasar` results
- surface backend in `run_quasar_multiple` summaries
- document new field and extend tests

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b6d82685d48321ada24a5bb6460f7a