### PR TITLE
Add notebook demonstrating QuASAr API usage

### DIFF
--- a/tests/notebooks/quasar_api_demo.ipynb
+++ b/tests/notebooks/quasar_api_demo.ipynb
@@ -1,0 +1,159 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "e8acec23",
+   "metadata": {},
+   "source": [
+    "# QuASAr API Usage Examples\n",
+    "\n",
+    "This notebook demonstrates several ways to use the QuASAr library and verifies results on small circuits."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "083212cb",
+   "metadata": {},
+   "source": [
+    "## Bell State with SimulationEngine"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "0d555a2c",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import numpy as np\n",
+    "from quasar import Circuit, SimulationEngine, Backend\n",
+    "\n",
+    "bell = Circuit([\n",
+    "    {\"gate\": \"H\", \"qubits\": [0]},\n",
+    "    {\"gate\": \"CX\", \"qubits\": [0, 1]},\n",
+    "])\n",
+    "engine = SimulationEngine()\n",
+    "result = engine.simulate(bell, backend=Backend.STATEVECTOR)\n",
+    "state = result.ssd.extract_state(0)\n",
+    "expected = (1/np.sqrt(2)) * np.array([1,0,0,1])\n",
+    "np.allclose(state, expected)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "078d6c25",
+   "metadata": {},
+   "source": [
+    "## Building from Qiskit"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "e7b7c06c",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from qiskit import QuantumCircuit\n",
+    "from qiskit.quantum_info import Statevector\n",
+    "\n",
+    "qc = QuantumCircuit(3)\n",
+    "qc.h(0)\n",
+    "qc.cx(0,1)\n",
+    "qc.cx(0,2)\n",
+    "quasar_circuit = Circuit.from_qiskit(qc)\n",
+    "result = engine.simulate(quasar_circuit, backend=Backend.STATEVECTOR)\n",
+    "state = result.ssd.extract_state(0)\n",
+    "expected = Statevector.from_instruction(qc).data\n",
+    "expected_le = expected.reshape([2]*3).transpose(*reversed(range(3))).reshape(-1)\n",
+    "np.allclose(state, expected_le)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "80cdc13f",
+   "metadata": {},
+   "source": [
+    "## Direct Backend Usage"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "48d83c23",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from quasar import StatevectorBackend\n",
+    "\n",
+    "backend = StatevectorBackend()\n",
+    "backend.load(2)\n",
+    "backend.apply_gate(\"H\", [0])\n",
+    "backend.apply_gate(\"CX\", [0,1])\n",
+    "backend.statevector()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "0f1d7464",
+   "metadata": {},
+   "source": [
+    "## Circuit Analysis and Planning"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "e01fddf8",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from quasar import CircuitAnalyzer, Planner\n",
+    "\n",
+    "analyzer = CircuitAnalyzer(quasar_circuit)\n",
+    "estimates = analyzer.resource_estimates()\n",
+    "planner = Planner()\n",
+    "plan = planner.plan(quasar_circuit, backend=Backend.STATEVECTOR)\n",
+    "estimates, plan"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "bfe50266",
+   "metadata": {},
+   "source": [
+    "## Random Circuit Comparison"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "33797107",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import numpy as np\n",
+    "from qiskit import QuantumCircuit\n",
+    "from qiskit.quantum_info import Statevector\n",
+    "\n",
+    "np.random.seed(0)\n",
+    "rc = QuantumCircuit(2)\n",
+    "rc.rx(0.3,0)\n",
+    "rc.ry(0.2,1)\n",
+    "rc.cz(0,1)\n",
+    "rc.rz(0.1,0)\n",
+    "rc.h(1)\n",
+    "\n",
+    "rand_circuit = Circuit.from_qiskit(rc)\n",
+    "result = engine.simulate(rand_circuit, backend=Backend.STATEVECTOR)\n",
+    "quasar_state = result.ssd.extract_state(0)\n",
+    "expected = Statevector.from_instruction(rc).data\n",
+    "expected_le = expected.reshape([2]*2).transpose(*reversed(range(2))).reshape(-1)\n",
+    "np.allclose(quasar_state, expected_le)"
+   ]
+  }
+ ],
+ "metadata": {},
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
## Summary
- add a notebook exercising the QuASAr API on various circuits
- showcase SimulationEngine, direct backend usage, and resource analysis

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b6e7c4e52883218a4a85372fe10d13