### PR TITLE
Add simulator demonstration notebooks

### DIFF
--- a/tests/notebooks/mqt_dd_demo.ipynb
+++ b/tests/notebooks/mqt_dd_demo.ipynb
@@ -1,0 +1,87 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "6c7a0eed",
+   "metadata": {},
+   "source": [
+    "# MQT DDSIM Usage Examples\n",
+    "\n",
+    "This notebook demonstrates how to use the MQT DDSIM simulator directly."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "3195dc8e",
+   "metadata": {},
+   "source": [
+    "## Bell State with DDSIM"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "a9539f52",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import numpy as np\n",
+    "from qiskit import QuantumCircuit\n",
+    "from mqt.ddsim import DDSIMProvider\n",
+    "\n",
+    "qc = QuantumCircuit(2)\n",
+    "qc.h(0)\n",
+    "qc.cx(0,1)\n",
+    "\n",
+    "provider = DDSIMProvider()\n",
+    "backend = provider.get_backend(\"statevector_simulator\")\n",
+    "result = backend.run(qc).result()\n",
+    "state = result.get_statevector(qc)\n",
+    "expected = (1/np.sqrt(2))*np.array([1,0,0,1])\n",
+    "np.allclose(state, expected)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "28b2145b",
+   "metadata": {},
+   "source": [
+    "## Amplitude Dictionary"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "e2d2afec",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "amplitudes = {format(i, \"02b\"): amp for i, amp in enumerate(state)}\n",
+    "amplitudes"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "9c1a376b",
+   "metadata": {},
+   "source": [
+    "## Sampling Measurements"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "2d72c58f",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "backend_counts = provider.get_backend(\"qasm_simulator\")\n",
+    "counts = backend_counts.run(qc, shots=1000).result().get_counts(qc)\n",
+    "counts"
+   ]
+  }
+ ],
+ "metadata": {},
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/tests/notebooks/qiskit_aer_demo.ipynb
+++ b/tests/notebooks/qiskit_aer_demo.ipynb
@@ -1,0 +1,92 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "098ab131",
+   "metadata": {},
+   "source": [
+    "# Qiskit Aer Usage Examples\n",
+    "\n",
+    "This notebook showcases basic usage of the Qiskit Aer simulator independently of QuASAr."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "e8b2ee55",
+   "metadata": {},
+   "source": [
+    "## Bell State Simulation"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "468fdb94",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import numpy as np\n",
+    "from qiskit import QuantumCircuit\n",
+    "from qiskit_aer import AerSimulator\n",
+    "\n",
+    "qc = QuantumCircuit(2)\n",
+    "qc.h(0)\n",
+    "qc.cx(0,1)\n",
+    "\n",
+    "sim = AerSimulator(method=\"statevector\")\n",
+    "result = sim.run(qc).result()\n",
+    "state = result.get_statevector(qc)\n",
+    "expected = (1/np.sqrt(2))*np.array([1,0,0,1])\n",
+    "np.allclose(state, expected)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "d29b1008",
+   "metadata": {},
+   "source": [
+    "## Measurement Sampling"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "00bdb87a",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "qc.measure_all()\n",
+    "sim_shots = AerSimulator()\n",
+    "counts = sim_shots.run(qc, shots=1000).result().get_counts(qc)\n",
+    "counts"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "619ada25",
+   "metadata": {},
+   "source": [
+    "## Density Matrix Representation"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "1bc39195",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from qiskit.quantum_info import partial_trace\n",
+    "qc2 = QuantumCircuit(2)\n",
+    "qc2.h(0)\n",
+    "qc2.cx(0,1)\n",
+    "dm_sim = AerSimulator(method=\"density_matrix\")\n",
+    "dm = dm_sim.run(qc2).result().data(0)[\"density_matrix\"]\n",
+    "dm"
+   ]
+  }
+ ],
+ "metadata": {},
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/tests/notebooks/stim_demo.ipynb
+++ b/tests/notebooks/stim_demo.ipynb
@@ -1,0 +1,83 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "dbb364c6",
+   "metadata": {},
+   "source": [
+    "# Stim Usage Examples\n",
+    "\n",
+    "This notebook explores the Stim simulator for stabilizer circuits."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "b534cbdf",
+   "metadata": {},
+   "source": [
+    "## Bell State Sampling"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "1a5b1051",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import stim\n",
+    "circuit = stim.Circuit()\n",
+    "circuit.h(0)\n",
+    "circuit.cx(0,1)\n",
+    "circuit.measure(0)\n",
+    "circuit.measure(1)\n",
+    "sampler = circuit.compile_sampler()\n",
+    "samples = sampler.sample(10)\n",
+    "samples"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "20473239",
+   "metadata": {},
+   "source": [
+    "## Tableau Representation"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "281bedf8",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "bell = stim.Circuit(\"H 0\n",
+    "CX 0 1\")\n",
+    "tableau = bell.compile_tableau()\n",
+    "print(tableau)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "cee236e2",
+   "metadata": {},
+   "source": [
+    "## Detector Error Model"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "ba905d48",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "dem = bell.detector_error_model()\n",
+    "print(dem)"
+   ]
+  }
+ ],
+ "metadata": {},
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
## Summary
- add Qiskit Aer demo notebook showing statevector, sampling, and density matrix features
- add Stim demo notebook exploring stabilizer sampling, tableau, and detector error model
- add MQT DDSIM demo notebook showcasing statevector simulation and measurement sampling

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b7c073bbc08321a017266b9cedb743