### PR TITLE
Handle unsupported backends in benchmarks

### DIFF
--- a/benchmarks/plot_utils.py
+++ b/benchmarks/plot_utils.py
@@ -34,6 +34,8 @@ def compute_baseline_best(
         raise ValueError("results DataFrame is empty")
 
     baselines = df[df["framework"] != "quasar"]
+    if "unsupported" in baselines.columns:
+        baselines = baselines[~baselines["unsupported"].fillna(False)]
     if baselines.empty:
         raise ValueError("no baseline entries in results")
 
@@ -79,6 +81,10 @@ def plot_quasar_vs_baseline_best(
 
     baseline_best = compute_baseline_best(df, metrics=[metric])
     quasar = df[df["framework"] == "quasar"]
+    if "unsupported" in df.columns:
+        unsupported = df[df["unsupported"].fillna(False)]
+    else:
+        unsupported = df.iloc[0:0]
 
     x_col = "qubits" if "qubits" in df.columns else "circuit"
     ax.plot(
@@ -93,6 +99,14 @@ def plot_quasar_vs_baseline_best(
         marker="o",
         label="QuASAr",
     )
+    if not unsupported.empty:
+        ax.scatter(
+            unsupported[x_col],
+            [0] * len(unsupported),
+            marker="x",
+            label="not supported",
+            color="red",
+        )
 
     if annotate_backend and "backend" in quasar.columns:
         for _, row in quasar.iterrows():
@@ -102,6 +116,7 @@ def plot_quasar_vs_baseline_best(
 
     ax.set_xlabel(x_col)
     ax.set_ylabel(metric.replace("_", " "))
+    ax.set_ylim(bottom=0)
     ax.legend()
     return ax
 

--- a/tests/test_benchmark_run_failure.py
+++ b/tests/test_benchmark_run_failure.py
@@ -15,3 +15,19 @@ def test_run_returns_failure_record_on_exception():
     assert "boom" in record["error"]
     assert record["framework"] == "error"
     assert runner.results[0] == record
+
+
+class NotImplementedBackend:
+    name = "unsupported"
+
+    def run(self, circuit, **_):
+        raise NotImplementedError("nyi")
+
+
+def test_run_returns_unsupported_record_on_not_implemented():
+    runner = BenchmarkRunner()
+    record = runner.run("circ", NotImplementedBackend())
+    assert record["failed"] is False
+    assert record["unsupported"] is True
+    assert "nyi" in record["error"]
+    assert record["framework"] == "unsupported"

--- a/tests/test_benchmark_run_multiple.py
+++ b/tests/test_benchmark_run_multiple.py
@@ -99,6 +99,22 @@ def test_run_multiple_skips_failed_runs():
     assert record["run_time_std"] == 1.0
 
 
+class UnsupportedBackend:
+    name = "unsupported"
+
+    def run(self, circuit, **_):
+        raise NotImplementedError("nyi")
+
+
+def test_run_multiple_records_unsupported():
+    runner = BenchmarkRunner()
+    record = runner.run_multiple(None, UnsupportedBackend(), repetitions=3)
+    assert record["unsupported"] is True
+    assert record["repetitions"] == 0
+    assert "nyi" in record["comment"]
+    assert record["framework"] == "unsupported"
+
+
 class DummyScheduler:
     def __init__(self):
         self.plan_calls = []

--- a/tests/test_plot_utils.py
+++ b/tests/test_plot_utils.py
@@ -33,3 +33,18 @@ def test_plot_quasar_vs_baseline_best_annotations():
     assert "mps" in texts
     assert "sv" in texts
     assert len(ax.lines) == 2
+
+
+def test_compute_baseline_best_handles_unsupported():
+    df = sample_df()
+    df.loc[df["framework"] == "sv", "unsupported"] = True
+    best = compute_baseline_best(df)
+    assert set(best["circuit"]) == {"c1"}
+
+
+def test_plot_marks_unsupported():
+    df = sample_df()
+    df.loc[df["framework"] == "sv", "unsupported"] = True
+    ax = plot_quasar_vs_baseline_best(df)
+    legend_labels = [t.get_text() for t in ax.get_legend().get_texts()]
+    assert "not supported" in legend_labels


### PR DESCRIPTION
## Summary
- classify NotImplementedError in BenchmarkRunner as unsupported instead of failed
- keep unsupported backends in `run_multiple` summaries and mark them unsupported
- annotate unsupported backends in benchmark plots

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b7c0a2a1c88321957cfff2c5250fb9