### PR TITLE
Use MQT's dd package in demo notebook

### DIFF
--- a/tests/notebooks/mqt_dd_demo.ipynb
+++ b/tests/notebooks/mqt_dd_demo.ipynb
@@ -5,9 +5,9 @@
    "id": "6c7a0eed",
    "metadata": {},
    "source": [
-    "# MQT DDSIM Usage Examples\n",
+    "# MQT DD Package Usage Examples\n",
     "\n",
-    "This notebook demonstrates how to use the MQT DDSIM simulator directly."
+    "This notebook demonstrates how to use the MQT decision diagram simulator directly, matching QuASAr's backend usage."
    ]
   },
   {
@@ -15,7 +15,7 @@
    "id": "3195dc8e",
    "metadata": {},
    "source": [
-    "## Bell State with DDSIM"
+    "## Bell State with MQT's DD Package"
    ]
   },
   {
@@ -26,19 +26,21 @@
    "outputs": [],
    "source": [
     "import numpy as np\n",
-    "from qiskit import QuantumCircuit\n",
-    "from mqt.ddsim import DDSIMProvider\n",
+    "from mqt.core import dd\n",
+    "from mqt.core.ir import operations\n",
     "\n",
-    "qc = QuantumCircuit(2)\n",
-    "qc.h(0)\n",
-    "qc.cx(0,1)\n",
-    "\n",
-    "provider = DDSIMProvider()\n",
-    "backend = provider.get_backend(\"statevector_simulator\")\n",
-    "result = backend.run(qc).result()\n",
-    "state = result.get_statevector(qc)\n",
+    "pkg = dd.DDPackage(2)\n",
+    "state = pkg.zero_state(2)\n",
+    "pkg.inc_ref_vec(state)\n",
+    "h = operations.StandardOperation([0], operations.OpType.h)\n",
+    "state = pkg.apply_unitary_operation(state, h)\n",
+    "pkg.inc_ref_vec(state)\n",
+    "cx = operations.StandardOperation({operations.Control(0)}, 1, operations.OpType.x)\n",
+    "state = pkg.apply_unitary_operation(state, cx)\n",
+    "pkg.inc_ref_vec(state)\n",
+    "amplitudes = [state[i] for i in range(4)]\n",
     "expected = (1/np.sqrt(2))*np.array([1,0,0,1])\n",
-    "np.allclose(state, expected)"
+    "np.allclose(amplitudes, expected)\n"
    ]
   },
   {
@@ -56,8 +58,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "amplitudes = {format(i, \"02b\"): amp for i, amp in enumerate(state)}\n",
-    "amplitudes"
+    "amplitudes = {format(i, '02b'): state[i] for i in range(4)}\n",
+    "amplitudes\n"
    ]
   },
   {
@@ -75,9 +77,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "backend_counts = provider.get_backend(\"qasm_simulator\")\n",
-    "counts = backend_counts.run(qc, shots=1000).result().get_counts(qc)\n",
-    "counts"
+    "from collections import Counter\n",
+    "counts = Counter(pkg.measure_all(state) for _ in range(1000))\n",
+    "counts\n"
    ]
   }
  ],


### PR DESCRIPTION
## Summary
- Replace DDSIM-based example with direct use of MQT's decision diagram and IR packages
- Showcase amplitude extraction and measurement sampling to mirror backend usage

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b7c7b2a5d08321bb6f8e7d827d61e9