### PR TITLE
Ensure backend dependencies and add DD statevector extraction

### DIFF
--- a/quasar/backends/__init__.py
+++ b/quasar/backends/__init__.py
@@ -1,79 +1,45 @@
 """Simulation backend adapters for QuASAr."""
 
+from importlib.util import find_spec
+
 from .base import Backend
-from ..cost import Backend as BackendType
+
+
+def _require(package: str, backend: str) -> None:
+    """Ensure that *package* is available.
+
+    Parameters
+    ----------
+    package:
+        Name of the Python package providing the backend.
+    backend:
+        Name of the backend class that depends on ``package``.
+
+    Raises
+    ------
+    ImportError
+        If the requested ``package`` cannot be found.
+    """
+
+    if find_spec(package) is None:  # pragma: no cover - environment specific
+        raise ImportError(
+            f"{backend} requires the '{package}' package. Install it to use this backend."
+        )
+
 
 # Core backends -----------------------------------------------------------
-try:  # pragma: no cover - optional dependency
-    from .statevector import StatevectorBackend, AerStatevectorBackend
-except ImportError as exc:  # pragma: no cover - executed when qiskit is missing
-    class StatevectorBackend(Backend):
-        """Stub when Qiskit Aer is not installed."""
+_require("qiskit_aer", "StatevectorBackend")
+from .statevector import StatevectorBackend, AerStatevectorBackend
 
-        backend: BackendType = BackendType.STATEVECTOR
-
-        def _unavailable(self, *_, **__):
-            raise ImportError(
-                "StatevectorBackend requires the 'qiskit-aer' package. "
-                "Install it to use this backend."
-            ) from exc
-
-        load = ingest = apply_gate = extract_ssd = statevector = _unavailable
-
-    class AerStatevectorBackend(StatevectorBackend):
-        pass
-
-try:  # pragma: no cover - optional dependency
-    from .mps import MPSBackend, AerMPSBackend
-except ImportError as exc:  # pragma: no cover - executed when qiskit is missing
-    class MPSBackend(Backend):
-        """Stub when Qiskit Aer is not installed."""
-
-        backend: BackendType = BackendType.MPS
-
-        def _unavailable(self, *_, **__):
-            raise ImportError(
-                "MPSBackend requires the 'qiskit-aer' package. "
-                "Install it to use this backend."
-            ) from exc
-
-        load = ingest = apply_gate = extract_ssd = statevector = _unavailable
-
-    class AerMPSBackend(MPSBackend):
-        pass
+_require("qiskit_aer", "MPSBackend")
+from .mps import MPSBackend, AerMPSBackend
 
 # Optional backends -------------------------------------------------------
-try:  # pragma: no cover - optional dependency
-    from .stim_backend import StimBackend
-except ImportError as exc:  # pragma: no cover - executed when stim missing
-    class StimBackend(Backend):
-        """Stub used when the optional ``stim`` dependency is missing."""
+_require("stim", "StimBackend")
+from .stim_backend import StimBackend
 
-        backend: BackendType = BackendType.TABLEAU
-
-        def _unavailable(self, *_, **__):
-            raise ImportError(
-                "Stim backend requires the 'stim' package. "
-                "Install 'stim' to use this backend."
-            ) from exc
-
-        load = ingest = apply_gate = extract_ssd = _unavailable
-
-try:  # pragma: no cover - optional dependency
-    from .mqt_dd import DecisionDiagramBackend
-except ImportError as exc:  # pragma: no cover - executed when MQT libraries missing
-    class DecisionDiagramBackend(Backend):
-        """Stub for the decision diagram backend when MQT packages are missing."""
-
-        backend: BackendType = BackendType.DECISION_DIAGRAM
-
-        def _unavailable(self, *_, **__):
-            raise ImportError(
-                "DecisionDiagramBackend requires the 'mqt.core' package. "
-                "Install it to use this backend."
-            ) from exc
-
-        load = ingest = apply_gate = extract_ssd = _unavailable
+_require("mqt.core", "DecisionDiagramBackend")
+from .mqt_dd import DecisionDiagramBackend
 
 __all__ = [
     "Backend",
@@ -84,3 +50,4 @@ __all__ = [
     "StimBackend",
     "DecisionDiagramBackend",
 ]
+

--- a/quasar/backends/mqt_dd.py
+++ b/quasar/backends/mqt_dd.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass, field
 from typing import Dict, List, Sequence, Tuple
+import numpy as np
 
 from mqt.core import dd
 from mqt.core.ir import operations
@@ -120,7 +121,14 @@ class DecisionDiagramBackend(Backend):
         return SSD([part])
 
     # ------------------------------------------------------------------
-    def statevector(self) -> Sequence[complex]:
+    def statevector(self) -> np.ndarray:
+        """Return a dense statevector for the current decision diagram state."""
+
         self.run()
-        raise NotImplementedError("Statevector extraction not supported")
+        if self.package is None or self.state is None:
+            raise RuntimeError("Backend not initialised; call 'load' first")
+        if not isinstance(self.state, dd.VectorDD):
+            raise TypeError("Backend state is not a VectorDD")
+        vec = self.state.get_vector()
+        return np.array(vec, dtype=complex)
 


### PR DESCRIPTION
## Summary
- replace backend stubs with import-time dependency checks
- implement statevector extraction for decision diagram backend
- scan repository for placeholder implementations

## Testing
- `python -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b7c869aa108321b32e719444bb5d9e