### PR TITLE
Add test for default tableau backend on GHZ circuits

### DIFF
--- a/tests/test_backend_selection.py
+++ b/tests/test_backend_selection.py
@@ -1,0 +1,9 @@
+from benchmarks.circuits import ghz_circuit
+from quasar import SimulationEngine, Backend
+
+
+def test_planner_selects_tableau_for_ghz():
+    circuit = ghz_circuit(4)
+    engine = SimulationEngine()
+    plan = engine.planner.plan(circuit)
+    assert plan.final_backend == Backend.TABLEAU


### PR DESCRIPTION
## Summary
- add unit test covering automatic tableau backend selection for GHZ circuits

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b83afad73483219ef9a55e22ab7e21