### PR TITLE
Add benchmark preparation for Stim backend and backend summaries

### DIFF
--- a/benchmarks/runner.py
+++ b/benchmarks/runner.py
@@ -244,9 +244,11 @@ class BenchmarkRunner:
             if timeout is not None and (time.perf_counter() - start) > timeout:
                 break
 
+        backend_name = getattr(backend, "name", backend.__class__.__name__)
         if unsupported_comment is not None:
             summary = {
-                "framework": getattr(backend, "name", backend.__class__.__name__),
+                "framework": backend_name,
+                "backend": backend_name,
                 "repetitions": 0,
                 "unsupported": True,
                 "comment": unsupported_comment,
@@ -257,7 +259,8 @@ class BenchmarkRunner:
             raise RuntimeError("no runs executed")
 
         summary: Dict[str, Any] = {
-            "framework": getattr(backend, "name", backend.__class__.__name__),
+            "framework": backend_name,
+            "backend": backend_name,
             "repetitions": len(records),
         }
         if failures:

--- a/tests/test_benchmark_run_multiple.py
+++ b/tests/test_benchmark_run_multiple.py
@@ -38,6 +38,7 @@ def test_run_multiple_aggregates_statistics():
     assert record["repetitions"] == 3
     assert record["run_time_mean"] == 2.0
     assert math.isclose(record["run_time_std"], math.sqrt(2 / 3))
+    assert record["backend"] == "dummy"
 
 
 class SleepBackend:
@@ -62,6 +63,7 @@ def test_run_multiple_timeout_records_failure():
     assert "failed_runs" in record and len(record["failed_runs"]) == 1
     assert "timed out" in record["failed_runs"][0]
     assert "comment" in record and "excluded" in record["comment"]
+    assert record["backend"] == "sleep"
 
 
 class FlakyBackend:
@@ -97,6 +99,7 @@ def test_run_multiple_skips_failed_runs():
     assert "comment" in record and "excluded" in record["comment"]
     assert record["run_time_mean"] == 2.0
     assert record["run_time_std"] == 1.0
+    assert record["backend"] == "flaky"
 
 
 class UnsupportedBackend:
@@ -113,6 +116,7 @@ def test_run_multiple_records_unsupported():
     assert record["repetitions"] == 0
     assert "nyi" in record["comment"]
     assert record["framework"] == "unsupported"
+    assert record["backend"] == "unsupported"
 
 
 class DummyScheduler:

--- a/tests/test_stim_adapter.py
+++ b/tests/test_stim_adapter.py
@@ -1,0 +1,12 @@
+from benchmarks.backends import StimAdapter
+from quasar.circuit import Circuit
+from quasar.ssd import SSD
+
+
+def test_stim_adapter_run_defaults_to_ssd_and_supports_statevector():
+    circ = Circuit.from_dict([{"gate": "H", "qubits": [0]}])
+    backend = StimAdapter()
+    ssd = backend.run(circ)
+    assert isinstance(ssd, SSD)
+    vec = backend.run(circ, statevector=True)
+    assert len(vec) == 2


### PR DESCRIPTION
## Summary
- support prepare/run split for Stim benchmarking with default SSD extraction
- include backend field in `run_multiple` summaries
- default Stim adapter to extract SSD unless statevector explicitly requested

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b8498985b48321b991a204a4c374d1