### PR TITLE
Enable statevector benchmark mode and backend reporting

### DIFF
--- a/benchmarks/backends.py
+++ b/benchmarks/backends.py
@@ -114,6 +114,92 @@ class StatevectorAdapter(BackendAdapter):
         super().__init__(
             name="statevector", backend_cls=StatevectorBackend, defer_build=False
         )
+        self._backend: StatevectorBackend | None = None
+
+    # ------------------------------------------------------------------
+    def load(self, num_qubits: int, **kwargs: Any) -> None:
+        """Initialise the underlying :class:`StatevectorBackend`."""
+
+        self._backend = self.backend_cls()
+        self._backend.load(num_qubits, **kwargs)
+
+    def prepare_benchmark(self, circuit: Circuit | None = None) -> None:
+        """Enable benchmark mode so gate applications are deferred."""
+
+        if self._backend is None and circuit is not None:
+            self.load(circuit.num_qubits)
+        if self._backend is not None:
+            self._backend.prepare_benchmark(circuit)
+
+    def apply_gate(
+        self,
+        name: str,
+        qubits: Sequence[int],
+        params: Dict[str, float] | None = None,
+    ) -> None:
+        if self._backend is None:
+            raise RuntimeError("backend not initialised; call 'load' first")
+        self._backend.apply_gate(name, qubits, params)
+
+    def _extract_state(self, backend: StatevectorBackend, *, statevector: bool) -> Any:
+        if statevector:
+            try:
+                return backend.statevector()
+            except Exception:
+                try:
+                    return backend.extract_ssd()
+                except Exception:
+                    return None
+        try:
+            return backend.extract_ssd()
+        except Exception:
+            try:
+                return backend.statevector()
+            except Exception:
+                return None
+
+    def run_benchmark(
+        self,
+        *,
+        return_state: bool = True,
+        statevector: bool = True,
+    ) -> Any:
+        if self._backend is None:
+            raise RuntimeError("backend not initialised; call 'load' first")
+        ops = getattr(self._backend, "_benchmark_ops", [])
+        self._backend._benchmark_mode = False  # type: ignore[attr-defined]
+        for name, qubits, params in ops:
+            self._backend.apply_gate(name, qubits, params)
+        self._backend._benchmark_ops = []  # type: ignore[attr-defined]
+        if not return_state:
+            self._extract_state(self._backend, statevector=statevector)
+            return self._backend
+        return self._extract_state(self._backend, statevector=statevector)
+
+    # ------------------------------------------------------------------
+    def run(
+        self,
+        circuit: Any,
+        *,
+        return_state: bool = True,
+        statevector: bool = True,
+    ) -> Any:
+        if self.defer_build:
+            if isinstance(circuit, Circuit):
+                num_qubits, ops = self.prepare(circuit)
+            else:
+                num_qubits, ops = circuit  # type: ignore[misc]
+            backend = self.backend_cls()
+            backend.load(num_qubits)
+            for name, qubits, params in ops:
+                backend.apply_gate(name, qubits, params)
+        else:
+            backend = circuit if not isinstance(circuit, Circuit) else self.prepare(circuit)
+
+        if not return_state:
+            self._extract_state(backend, statevector=statevector)
+            return backend
+        return self._extract_state(backend, statevector=statevector)
 
 
 class StimAdapter(BackendAdapter):

--- a/benchmarks/runner.py
+++ b/benchmarks/runner.py
@@ -110,6 +110,7 @@ class BenchmarkRunner:
             tracemalloc.stop()
             record = {
                 "framework": getattr(backend, "name", backend.__class__.__name__),
+                "backend": getattr(backend, "name", backend.__class__.__name__),
                 "prepare_time": prepare_time,
                 "run_time": run_time,
                 "total_time": prepare_time + run_time,
@@ -127,6 +128,7 @@ class BenchmarkRunner:
             tracemalloc.stop()
             record = {
                 "framework": getattr(backend, "name", backend.__class__.__name__),
+                "backend": getattr(backend, "name", backend.__class__.__name__),
                 "prepare_time": prepare_time,
                 "run_time": run_time,
                 "total_time": prepare_time + run_time,
@@ -141,6 +143,7 @@ class BenchmarkRunner:
 
         record = {
             "framework": getattr(backend, "name", backend.__class__.__name__),
+            "backend": getattr(backend, "name", backend.__class__.__name__),
             "prepare_time": prepare_time,
             "run_time": run_time,
             "total_time": prepare_time + run_time,

--- a/tests/test_benchmark_run_multiple.py
+++ b/tests/test_benchmark_run_multiple.py
@@ -222,9 +222,18 @@ def test_statevector_and_quasar_runtime_agree():
     circuit = ghz_circuit(3)
     runner = BenchmarkRunner()
 
-    direct = runner.run_multiple(circuit, StatevectorAdapter(), repetitions=3)
+    direct = runner.run_multiple(
+        circuit, StatevectorAdapter(), repetitions=3, statevector=False
+    )
     quasar = runner.run_quasar_multiple(
         circuit, SimulationEngine(), backend=Backend.STATEVECTOR, repetitions=3
     )
 
     assert abs(direct["run_time_mean"] - quasar["run_time_mean"]) < 0.01
+
+
+def test_statevector_adapter_returns_ssd():
+    circuit = ghz_circuit(2)
+    runner = BenchmarkRunner()
+    record = runner.run(circuit, StatevectorAdapter(), statevector=False)
+    assert isinstance(record["result"], SSD)


### PR DESCRIPTION
## Summary
- allow StatevectorAdapter to run through backend benchmarking mode and optionally return an SSD
- expose backend names in BenchmarkRunner records
- exercise SSD extraction in statevector benchmarks and tests

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b84bf590c883218c7b6a066487bdf1