### PR TITLE
Add decision diagram benchmark support and SSD defaults

### DIFF
--- a/benchmarks/runner.py
+++ b/benchmarks/runner.py
@@ -263,7 +263,7 @@ class BenchmarkRunner:
 
         summary: Dict[str, Any] = {
             "framework": backend_name,
-            "backend": records[0].get("backend", backend_name),
+            "backend": records[0].get("backend") or backend_name,
             "repetitions": len(records),
         }
         if failures:


### PR DESCRIPTION
## Summary
- add benchmark-mode capable DecisionDiagramAdapter mirroring backend usage
- default result extraction to SSD to avoid unnecessary statevector creation
- include backend name in run_multiple summaries

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b86ad23b648321857cfe74ddafddcc