### PR TITLE
Implement internal QFT and W-state circuits

### DIFF
--- a/quasar/backends/mps.py
+++ b/quasar/backends/mps.py
@@ -110,6 +110,12 @@ class MPSBackend(Backend):
                 self._param(params, 2),
             )
             self.circuit.append(gate, [qubits[0]])
+        elif lname == "CP":
+            k = float(params.get("k", 0)) if params else 0.0
+            theta = 2 * np.pi / (2 ** k)
+            self.circuit.cp(theta, qubits[0], qubits[1])
+        elif lname == "CRY":
+            self.circuit.cry(self._param(params, 0), qubits[0], qubits[1])
         else:
             method = getattr(self.circuit, lname.lower(), None)
             if method is None:

--- a/quasar/backends/statevector.py
+++ b/quasar/backends/statevector.py
@@ -109,6 +109,12 @@ class StatevectorBackend(Backend):
                 self._param(params, 2),
             )
             self.circuit.append(gate, [qubits[0]])
+        elif lname == "CP":
+            k = float(params.get("k", 0)) if params else 0.0
+            theta = 2 * np.pi / (2 ** k)
+            self.circuit.cp(theta, qubits[0], qubits[1])
+        elif lname == "CRY":
+            self.circuit.cry(self._param(params, 0), qubits[0], qubits[1])
         else:
             method = getattr(self.circuit, lname.lower(), None)
             if method is None:


### PR DESCRIPTION
## Summary
- build QFT and W-state circuits from native gate dictionaries instead of Qiskit templates
- support CP(k) and CRY(theta) gates in statevector, MPS, and decision diagram backends

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b87765e99c8321b81587ecb8b7bd15