### PR TITLE
Refine statevector cost model

### DIFF
--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -105,7 +105,11 @@ from quasar import CostEstimator
 
 with open("results/ghz.json") as f:
     data = json.load(f)
-coeff = {"sv_gate": data[0]["avg_time"] / len(circuit.gates)}
+coeff = {
+    "sv_gate_1q": data[0]["avg_time"] / len(circuit.gates),
+    "sv_gate_2q": data[0]["avg_time"] / len(circuit.gates),
+    "sv_meas": data[0]["avg_time"] / len(circuit.gates),
+}
 
 est = CostEstimator()
 est.update_coefficients(coeff)

--- a/quasar/analyzer.py
+++ b/quasar/analyzer.py
@@ -114,11 +114,24 @@ class CircuitAnalyzer:
 
         num_qubits = self.circuit.num_qubits
         num_gates = len(self.circuit.gates)
+        num_meas = sum(
+            1 for g in self.circuit.gates if g.gate.upper() in {"MEASURE", "RESET"}
+        )
+        num_1q = sum(
+            1
+            for g in self.circuit.gates
+            if len(g.qubits) == 1 and g.gate.upper() not in {"MEASURE", "RESET"}
+        )
+        num_2q = num_gates - num_1q - num_meas
         estimates: Dict[Backend, Cost] = {
-            Backend.STATEVECTOR: self.estimator.statevector(num_qubits, num_gates),
+            Backend.STATEVECTOR: self.estimator.statevector(
+                num_qubits, num_1q, num_2q, num_meas
+            ),
             Backend.TABLEAU: self.estimator.tableau(num_qubits, num_gates),
             Backend.MPS: self.estimator.mps(num_qubits, num_gates, chi=self.chi),
-            Backend.DECISION_DIAGRAM: self.estimator.decision_diagram(num_gates=num_gates, frontier=num_qubits),
+            Backend.DECISION_DIAGRAM: self.estimator.decision_diagram(
+                num_gates=num_gates, frontier=num_qubits
+            ),
         }
         return estimates
 

--- a/quasar/calibration.py
+++ b/quasar/calibration.py
@@ -36,8 +36,11 @@ def benchmark_statevector(num_qubits: int = 8, num_gates: int = 50) -> Dict[str,
     amp = 1 << num_qubits
     # Simulate state update on a dense vector
     elapsed = _bench_loop(amp * num_gates)
+    coeff = elapsed / (num_gates * amp)
     return {
-        "sv_gate": elapsed / (num_gates * amp),
+        "sv_gate_1q": coeff,
+        "sv_gate_2q": coeff,
+        "sv_meas": coeff,
         "sv_mem": 16.0,  # Rough bytes per amplitude for complex128
     }
 

--- a/quasar/cost.py
+++ b/quasar/cost.py
@@ -60,7 +60,9 @@ class CostEstimator:
     ):
         # Baseline coefficients; tuned empirically in a full system.
         self.coeff: Dict[str, float] = {
-            "sv_gate": 1.0,
+            "sv_gate_1q": 1.0,
+            "sv_gate_2q": 1.0,
+            "sv_meas": 1.0,
             "sv_mem": 1.0,
             "tab_gate": 1.0,
             "tab_mem": 1.0,
@@ -106,9 +108,20 @@ class CostEstimator:
             coeff = json.load(fh)
         return cls(coeff=coeff)
 
-    def statevector(self, num_qubits: int, num_gates: int) -> Cost:
+    def statevector(
+        self,
+        num_qubits: int,
+        num_1q_gates: int,
+        num_2q_gates: int,
+        num_meas: int,
+    ) -> Cost:
         amp = 2 ** num_qubits
-        time = self.coeff["sv_gate"] * num_gates * amp
+        gate_time = (
+            self.coeff["sv_gate_1q"] * num_1q_gates
+            + self.coeff["sv_gate_2q"] * num_2q_gates
+            + self.coeff["sv_meas"] * num_meas
+        )
+        time = gate_time * amp
         memory = self.coeff["sv_mem"] * amp
         depth = math.log2(num_qubits) if num_qubits > 0 else 0.0
         return Cost(time=time, memory=memory, log_depth=depth)

--- a/tests/test_cost.py
+++ b/tests/test_cost.py
@@ -4,8 +4,8 @@ import math
 
 def test_statevector_scaling():
     est = CostEstimator()
-    small = est.statevector(num_qubits=3, num_gates=1)
-    large = est.statevector(num_qubits=4, num_gates=1)
+    small = est.statevector(num_qubits=3, num_1q_gates=1, num_2q_gates=0, num_meas=0)
+    large = est.statevector(num_qubits=4, num_1q_gates=1, num_2q_gates=0, num_meas=0)
     assert large.time == 2 * small.time
     assert large.memory == 2 * small.memory
     assert small.log_depth == math.log2(3)

--- a/tests/test_planner.py
+++ b/tests/test_planner.py
@@ -88,7 +88,9 @@ def test_conversion_cost_multiplier_discourages_switch():
     ]
     circ = Circuit.from_dict(gates)
     coeff = {
-        "sv_gate": 1.0,
+        "sv_gate_1q": 1.0,
+        "sv_gate_2q": 1.0,
+        "sv_meas": 1.0,
         "tab_gate": 0.1,
         "b2b_svd": 0.0,
         "b2b_copy": 0.0,

--- a/tests/test_planner_scheduler_conversions.py
+++ b/tests/test_planner_scheduler_conversions.py
@@ -86,7 +86,9 @@ def test_planner_conversions_used():
         ]
     )
     planner = Planner(
-        estimator=CostEstimator(coeff={"sv_gate": 1e6}),
+        estimator=CostEstimator(
+            coeff={"sv_gate_1q": 1e6, "sv_gate_2q": 1e6, "sv_meas": 1e6}
+        ),
         conversion_cost_multiplier=0.0,
         quick_max_qubits=None,
         quick_max_gates=None,

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -543,9 +543,9 @@ def test_cost_noise_does_not_loop_replanning():
             return SSD([])
 
     class UnderEstimator(CostEstimator):
-        def statevector(self, n, m):  # type: ignore[override]
+        def statevector(self, n, g1, g2, meas):  # type: ignore[override]
             # Slightly underestimate time so observed cost is within tolerance
-            base = super().statevector(n, m)
+            base = super().statevector(n, g1, g2, meas)
             return Cost(time=base.time * 0.99, memory=base.memory)
 
     planner = SingleStepPlanner()


### PR DESCRIPTION
## Summary
- model statevector costs with distinct coefficients for 1q, 2q, and measurement operations
- update planner, scheduler, analyzer, and partitioner to track gate-type counts
- add measurement coefficient to calibration utilities and docs

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b97dfa31c483218089d9e8086d8b6a