### PR TITLE
Refine MPS cost estimation and calibration

### DIFF
--- a/CALIBRATION.md
+++ b/CALIBRATION.md
@@ -5,6 +5,12 @@ scale simple analytical models to the actual performance of the machine
 where conversions are executed.  The values can be tuned using small
 micro‑benchmarks bundled with the project.
 
+The matrix product state (MPS) calibration distinguishes between costs
+for single- and two-qubit gates and an additional optional
+singular-value-decomposition (SVD) truncation step.  Separate
+coefficients for these components are produced by the calibration
+script.
+
 ## Running the benchmarks
 
 Run the calibration script to measure the cost of the supported

--- a/quasar/analyzer.py
+++ b/quasar/analyzer.py
@@ -128,7 +128,13 @@ class CircuitAnalyzer:
                 num_qubits, num_1q, num_2q, num_meas
             ),
             Backend.TABLEAU: self.estimator.tableau(num_qubits, num_gates),
-            Backend.MPS: self.estimator.mps(num_qubits, num_gates, chi=self.chi),
+            Backend.MPS: self.estimator.mps(
+                num_qubits,
+                num_1q + num_meas,
+                num_2q,
+                chi=self.chi,
+                svd=True,
+            ),
             Backend.DECISION_DIAGRAM: self.estimator.decision_diagram(
                 num_gates=num_gates, frontier=num_qubits
             ),

--- a/quasar/partitioner.py
+++ b/quasar/partitioner.py
@@ -120,7 +120,12 @@ class Partitioner:
                 if backend_trial == Backend.TABLEAU:
                     current_cost = self.estimator.tableau(len(current_qubits), 1)
                 elif backend_trial == Backend.MPS:
-                    current_cost = self.estimator.mps(len(current_qubits), 1, chi=4)
+                    is_meas = gate.gate.upper() in {"MEASURE", "RESET"}
+                    num_1q = 1 if len(gate.qubits) == 1 or is_meas else 0
+                    num_2q = 1 if len(gate.qubits) > 1 else 0
+                    current_cost = self.estimator.mps(
+                        len(current_qubits), num_1q, num_2q, chi=4, svd=True
+                    )
                 elif backend_trial == Backend.DECISION_DIAGRAM:
                     current_cost = self.estimator.decision_diagram(
                         num_gates=1, frontier=len(current_qubits)
@@ -235,7 +240,13 @@ class Partitioner:
 
         if local:
             backend = Backend.MPS
-            cost = self.estimator.mps(num_qubits, num_gates, chi=4)
+            cost = self.estimator.mps(
+                num_qubits,
+                num_1q + num_meas,
+                num_2q,
+                chi=4,
+                svd=True,
+            )
             return backend, cost
 
         backend = Backend.STATEVECTOR

--- a/quasar/planner.py
+++ b/quasar/planner.py
@@ -216,7 +216,13 @@ def _simulation_cost(
     if backend == Backend.TABLEAU:
         return estimator.tableau(num_qubits, num_gates)
     if backend == Backend.MPS:
-        return estimator.mps(num_qubits, num_gates, chi=4)
+        return estimator.mps(
+            num_qubits,
+            num_1q_gates + num_meas,
+            num_2q_gates,
+            chi=4,
+            svd=True,
+        )
     if backend == Backend.DECISION_DIAGRAM:
         return estimator.decision_diagram(num_gates=num_gates, frontier=num_qubits)
     return estimator.statevector(num_qubits, num_1q_gates, num_2q_gates, num_meas)

--- a/quasar/scheduler.py
+++ b/quasar/scheduler.py
@@ -246,7 +246,10 @@ class Scheduler:
 
                 coeff = {
                     Backend.STATEVECTOR: (["sv_gate_1q", "sv_gate_2q", "sv_meas"], "sv_mem"),
-                    Backend.MPS: (["mps_gate"], "mps_mem"),
+                    Backend.MPS: (
+                        ["mps_gate_1q", "mps_gate_2q", "mps_trunc"],
+                        "mps_mem",
+                    ),
                     Backend.TABLEAU: (["tab_gate"], "tab_mem"),
                     Backend.DECISION_DIAGRAM: (["dd_gate"], "dd_mem"),
                 }[target]
@@ -418,7 +421,10 @@ class Scheduler:
             # Update cost model based on observation
             coeff = {
                 Backend.STATEVECTOR: (["sv_gate_1q", "sv_gate_2q", "sv_meas"], "sv_mem"),
-                Backend.MPS: (["mps_gate"], "mps_mem"),
+                Backend.MPS: (
+                    ["mps_gate_1q", "mps_gate_2q", "mps_trunc"],
+                    "mps_mem",
+                ),
                 Backend.TABLEAU: (["tab_gate"], "tab_mem"),
                 Backend.DECISION_DIAGRAM: (["dd_gate"], "dd_mem"),
             }[target]
@@ -483,7 +489,13 @@ class Scheduler:
         if backend == Backend.TABLEAU:
             return est.tableau(n, m)
         if backend == Backend.MPS:
-            return est.mps(n, m, chi=4)
+            return est.mps(
+                n,
+                num_1q + num_meas,
+                num_2q,
+                chi=4,
+                svd=True,
+            )
         if backend == Backend.DECISION_DIAGRAM:
             return est.decision_diagram(num_gates=m, frontier=n)
         return est.statevector(n, num_1q, num_2q, num_meas)

--- a/tests/test_cost.py
+++ b/tests/test_cost.py
@@ -21,10 +21,30 @@ def test_tableau_quadratic():
 
 def test_mps_chi_dependence():
     est = CostEstimator()
-    chi2 = est.mps(num_qubits=4, num_gates=1, chi=2)
-    chi4 = est.mps(num_qubits=4, num_gates=1, chi=4)
+    chi2 = est.mps(num_qubits=4, num_1q_gates=0, num_2q_gates=1, chi=2)
+    chi4 = est.mps(num_qubits=4, num_1q_gates=0, num_2q_gates=1, chi=4)
     assert chi4.time == chi2.time * (4 ** 3) / (2 ** 3)
     assert chi4.memory == chi2.memory * (4 ** 2) / (2 ** 2)
+
+
+def test_mps_gate_scaling():
+    est = CostEstimator()
+    one = est.mps(num_qubits=4, num_1q_gates=1, num_2q_gates=0, chi=4)
+    two = est.mps(num_qubits=4, num_1q_gates=0, num_2q_gates=1, chi=4)
+    assert two.time == one.time * 4
+
+
+def test_mps_svd_cost():
+    est = CostEstimator()
+    base = est.mps(num_qubits=4, num_1q_gates=0, num_2q_gates=1, chi=4)
+    with_svd = est.mps(
+        num_qubits=4,
+        num_1q_gates=0,
+        num_2q_gates=1,
+        chi=4,
+        svd=True,
+    )
+    assert with_svd.time == base.time + 4 * (4 ** 3) * math.log2(4)
 
 
 def test_decision_diagram_linear():


### PR DESCRIPTION
## Summary
- Distinguish single- and two-qubit gate costs in the MPS estimator and optionally account for truncation SVD steps.
- Calibrate new MPS coefficients via updated microbenchmark harness.
- Propagate refined MPS interface through analysis, planning, partitioning, and scheduling.

## Testing
- `python -m quasar.calibration --output coeff.json`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b9828330608321959c3fe1cba1fd90