### PR TITLE
Refine decision diagram cost model

### DIFF
--- a/quasar/cost.py
+++ b/quasar/cost.py
@@ -186,8 +186,19 @@ class CostEstimator:
         return Cost(time=time, memory=memory, log_depth=depth)
 
     def decision_diagram(self, num_gates: int, frontier: int) -> Cost:
-        time = self.coeff["dd_gate"] * num_gates * frontier
-        memory = self.coeff["dd_mem"] * frontier
+        """Estimate cost for decision diagram simulation.
+
+        The active node count is approximated by ``frontier * log2(frontier)``
+        with a linear fallback for small frontiers.
+        """
+
+        threshold = 2
+        if frontier < threshold:
+            active_nodes = frontier
+        else:
+            active_nodes = frontier * math.log2(frontier)
+        time = self.coeff["dd_gate"] * num_gates * active_nodes
+        memory = self.coeff["dd_mem"] * active_nodes
         depth = math.log2(frontier) if frontier > 0 else 0.0
         return Cost(time=time, memory=memory, log_depth=depth)
 

--- a/tests/test_cost.py
+++ b/tests/test_cost.py
@@ -47,14 +47,23 @@ def test_mps_svd_cost():
     assert with_svd.time == base.time + 4 * (4 ** 3) * math.log2(4)
 
 
-def test_decision_diagram_linear():
+def test_decision_diagram_log_scaling():
     est = CostEstimator()
     c1 = est.decision_diagram(num_gates=10, frontier=5)
     c2 = est.decision_diagram(num_gates=10, frontier=10)
-    assert c2.time == 2 * c1.time
-    assert c2.memory == 2 * c1.memory
+    ratio = (10 * math.log2(10)) / (5 * math.log2(5))
+    assert c2.time == c1.time * ratio
+    assert c2.memory == c1.memory * ratio
     assert c1.log_depth == math.log2(5)
     assert c2.log_depth == math.log2(10)
+
+
+def test_decision_diagram_small_frontier_linear():
+    est = CostEstimator()
+    c1 = est.decision_diagram(num_gates=5, frontier=1)
+    c2 = est.decision_diagram(num_gates=5, frontier=2)
+    assert c2.time == 2 * c1.time
+    assert c2.memory == 2 * c1.memory
 
 
 def test_conversion_primitive_selection():


### PR DESCRIPTION
## Summary
- model decision diagram active nodes as `frontier * log2(frontier)` with linear fallback for small frontiers
- update cost estimator tests for log-based scaling

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b9856b2d4883218153e2c283de9959