### PR TITLE
Refine conversion cost models

### DIFF
--- a/quasar_convert/binding.cpp
+++ b/quasar_convert/binding.cpp
@@ -82,6 +82,7 @@ PYBIND11_MODULE(_conversion_engine, m) {
 
     py::class_<quasar::ConversionEngine>(m, "ConversionEngine")
         .def(py::init<>())
+        .def_readwrite("st_chi_cap", &quasar::ConversionEngine::st_chi_cap)
         .def("estimate_cost", &quasar::ConversionEngine::estimate_cost)
         .def("extract_ssd", &quasar::ConversionEngine::extract_ssd)
         .def("extract_boundary_ssd", &quasar::ConversionEngine::extract_boundary_ssd)

--- a/quasar_convert/conversion_engine.cpp
+++ b/quasar_convert/conversion_engine.cpp
@@ -177,11 +177,12 @@ ConversionResult ConversionEngine::convert(const SSD& ssd) const {
     // ignore memory for now since the conversion planner only compares runtime.
     const std::size_t window = std::min<std::size_t>(boundary, 4);
     const std::size_t dense = 1ULL << window;  // dense window size for LW
-    const std::size_t chi_tilde = std::min<std::size_t>(rank, 16);  // staged cap
+    const std::size_t chi_tilde = std::min<std::size_t>(rank, st_chi_cap);  // staged cap
     const std::size_t full = 1ULL << std::min<std::size_t>(boundary, 16);
 
-    const double cost_b2b = std::pow(static_cast<double>(rank), 3) +
-                            static_cast<double>(boundary) * rank * rank +
+    const double svd_cost = std::min<double>(boundary * rank * rank,
+                                             rank * boundary * boundary);
+    const double cost_b2b = svd_cost + static_cast<double>(boundary) * rank * rank +
                             rank * rank;  // ingest
     const double cost_lw = static_cast<double>(dense) * 2.0;  // extract + ingest
     const double cost_st = std::pow(static_cast<double>(chi_tilde), 3) +

--- a/quasar_convert/conversion_engine.hpp
+++ b/quasar_convert/conversion_engine.hpp
@@ -73,6 +73,7 @@ struct ConversionResult {
 class ConversionEngine {
   public:
     ConversionEngine();
+    std::size_t st_chi_cap = 16;
 
     std::pair<double, double> estimate_cost(std::size_t fragment_size, Backend backend) const;
 

--- a/tests/test_cost.py
+++ b/tests/test_cost.py
@@ -91,6 +91,28 @@ def test_conversion_primitive_selection():
     assert large.cost.log_depth == math.log2(16)
 
 
+def test_lw_gate_counts_increase_time():
+    est = CostEstimator()
+    base = est.conversion(
+        Backend.TABLEAU,
+        Backend.MPS,
+        num_qubits=4,
+        rank=16,
+        frontier=0,
+        window=2,
+    )
+    with_gates = est.conversion(
+        Backend.TABLEAU,
+        Backend.MPS,
+        num_qubits=4,
+        rank=16,
+        frontier=0,
+        window=2,
+        window_1q_gates=5,
+    )
+    assert with_gates.cost.time > base.cost.time
+
+
 def test_conversion_caps():
     est = CostEstimator(q_max=2, r_max=2, s_max=4)
     res = est.conversion(


### PR DESCRIPTION
## Summary
- reflect SVD complexity in B2B cost model using `min(q*s^2, s*q^2)`
- add configurable `st_chi_cap` to tune staged conversion rank cap
- include gate counts for dense windows in LW cost estimation

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b987a276f083219c31d4ee708e2162