### PR TITLE
Add instrumentation flag for Scheduler timing

### DIFF
--- a/benchmarks/runner.py
+++ b/benchmarks/runner.py
@@ -356,7 +356,7 @@ class BenchmarkRunner:
                     tracemalloc.reset_peak()
 
                 start_run = time.perf_counter()
-                result = scheduler.run(circuit, plan)
+                result = scheduler.run(circuit, plan, instrument=True)
                 if hasattr(result, "partitions") and getattr(result, "partitions"):
                     backend_obj = result.partitions[0].backend
                     backend_choice_name = getattr(backend_obj, "name", str(backend_obj))

--- a/tests/test_benchmark_run_multiple.py
+++ b/tests/test_benchmark_run_multiple.py
@@ -137,8 +137,8 @@ class DummyScheduler:
     def prepare_run(self, circuit, plan=None, *, backend=None):
         return plan if plan is not None else PlanResult(table=[], final_backend=backend, gates=[], explicit_steps=[], explicit_conversions=[], step_costs=[])
 
-    def run(self, circuit, plan, *, monitor=None):
-        self.run_calls.append(plan.final_backend)
+    def run(self, circuit, plan, *, monitor=None, instrument=False):
+        self.run_calls.append((plan.final_backend, instrument))
         return SSD([
             SSDPartition(subsystems=((0,),), backend=plan.final_backend or Backend.STATEVECTOR)
         ])
@@ -166,7 +166,7 @@ def test_run_quasar_multiple_aggregates_statistics():
     assert record["run_time_mean"] == 2.0
     assert math.isclose(record["run_time_std"], math.sqrt(2 / 3))
     assert scheduler.plan_calls == [Backend.TABLEAU] * 3
-    assert scheduler.run_calls == [Backend.TABLEAU] * 3
+    assert scheduler.run_calls == [(Backend.TABLEAU, True)] * 3
     assert record["backend"] == Backend.TABLEAU.name
 
 
@@ -181,7 +181,7 @@ class PlannerErrorScheduler:
     def prepare_run(self, circuit, plan=None, *, backend=None):  # pragma: no cover - unused
         return plan
 
-    def run(self, circuit, plan, *, monitor=None):  # pragma: no cover - unused
+    def run(self, circuit, plan, *, monitor=None, instrument=False):  # pragma: no cover - unused
         return SSD([
             SSDPartition(subsystems=((0,),), backend=plan.final_backend or Backend.STATEVECTOR)
         ])
@@ -207,7 +207,7 @@ class RunErrorScheduler:
     def prepare_run(self, circuit, plan=None, *, backend=None):
         return plan
 
-    def run(self, circuit, plan, *, monitor=None):
+    def run(self, circuit, plan, *, monitor=None, instrument=False):
         raise ValueError("run boom")
 
 

--- a/tests/test_benchmark_runner_memory.py
+++ b/tests/test_benchmark_runner_memory.py
@@ -37,17 +37,21 @@ class DummyPlanner:
 class DummyScheduler:
     def __init__(self):
         self.planner = DummyPlanner()
+        self.instrument_calls = []
     def prepare_run(self, circuit, plan=None, *, backend=None):
         return PlanResult(table=[], final_backend=backend, gates=[], explicit_steps=[], explicit_conversions=[], step_costs=[])
 
-    def run(self, circuit, plan, *, monitor=None):
+    def run(self, circuit, plan, *, monitor=None, instrument=False):
+        self.instrument_calls.append(instrument)
         self._data = [0] * 10000
         return "done"
 
 
 def test_run_quasar_records_memory():
     runner = BenchmarkRunner()
-    record = runner.run_quasar(None, DummyScheduler())
+    scheduler = DummyScheduler()
+    record = runner.run_quasar(None, scheduler)
     assert record["prepare_peak_memory"] > 0
     assert record["run_peak_memory"] > 0
     assert "backend" in record and record["backend"] is None
+    assert scheduler.instrument_calls == [True]

--- a/tests/test_scheduler_instrumentation.py
+++ b/tests/test_scheduler_instrumentation.py
@@ -1,0 +1,49 @@
+from __future__ import annotations
+
+from quasar.circuit import Circuit
+from quasar.scheduler import Scheduler
+from quasar.cost import Backend
+
+
+class DummyBackend:
+    def load(self, n):  # pragma: no cover - trivial
+        pass
+
+    def apply_gate(self, gate, qubits, params):  # pragma: no cover - trivial
+        pass
+
+    def extract_ssd(self):  # pragma: no cover - trivial
+        return None
+
+
+def test_run_skips_instrumentation_by_default(monkeypatch):
+    scheduler = Scheduler(
+        backends={
+            Backend.STATEVECTOR: DummyBackend(),
+            Backend.TABLEAU: DummyBackend(),
+        }
+    )
+    circuit = Circuit([{"gate": "H", "qubits": [0]}])
+    plan = scheduler.prepare_run(circuit)
+
+    perf_called = {"value": False}
+    tm_called = {"value": False}
+
+    def fake_perf_counter():
+        perf_called["value"] = True
+        return 0.0
+
+    def fake_start():
+        tm_called["value"] = True
+
+    monkeypatch.setattr("quasar.scheduler.time.perf_counter", fake_perf_counter)
+    monkeypatch.setattr("quasar.scheduler.tracemalloc.start", fake_start)
+    monkeypatch.setattr(
+        "quasar.scheduler.tracemalloc.get_traced_memory", lambda: (0, 0)
+    )
+    monkeypatch.setattr("quasar.scheduler.tracemalloc.stop", lambda: None)
+
+    scheduler.run(circuit, plan)
+
+    assert perf_called["value"] is False
+    assert tm_called["value"] is False


### PR DESCRIPTION
## Summary
- add `instrument` flag to `Scheduler.run` to toggle performance and memory measurement
- enable instrumentation in `BenchmarkRunner.run_quasar`
- cover instrumentation behaviour with new tests

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b9abca25548321bc21fee0b8c48ad2