### PR TITLE
Initialize Stim backend with explicit qubit allocation

### DIFF
--- a/quasar/backends/stim_backend.py
+++ b/quasar/backends/stim_backend.py
@@ -39,7 +39,9 @@ class StimBackend(Backend):
     )
 
     def load(self, num_qubits: int, **_: dict) -> None:
+        """Initialise the Stim simulator with a given number of qubits."""
         self.simulator = stim.TableauSimulator()
+        self.simulator.do_tableau(stim.Tableau(num_qubits), list(range(num_qubits)))
         self.num_qubits = num_qubits
         self.history.clear()
 

--- a/tests/backends/test_stim_backend.py
+++ b/tests/backends/test_stim_backend.py
@@ -1,0 +1,13 @@
+"""Tests for the Stim backend initialisation."""
+
+from quasar.backends.stim_backend import StimBackend
+
+
+def test_load_and_apply_highest_qubit() -> None:
+    """Loading three qubits allows operations on the highest index."""
+    backend = StimBackend()
+    backend.load(3)
+    backend.apply_gate("X", [2])
+    assert backend.simulator is not None
+    assert backend.simulator.num_qubits == 3
+


### PR DESCRIPTION
## Summary
- Initialize Stim backend simulator with an explicit number of qubits
- Cover Stim backend initialization with a unit test that applies a gate to the highest qubit index

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b9b90ec5748321bcc06e460be6e763