### PR TITLE
Track gate execution time for scheduler runs

### DIFF
--- a/tests/test_benchmark_quick_path_prebuild.py
+++ b/tests/test_benchmark_quick_path_prebuild.py
@@ -71,6 +71,7 @@ def test_quick_path_prebuilds_backend():
     assert DummyBackend.applied == 1
     assert DummyBackend.extracted == 1
     assert record["prepare_time"] == pytest.approx(0.0, abs=0.01)
+    assert record["run_time"] == 0.0
     assert record["backend"] == "STATEVECTOR"
     assert not record["failed"]
 

--- a/tests/test_benchmark_runner_memory.py
+++ b/tests/test_benchmark_runner_memory.py
@@ -44,7 +44,7 @@ class DummyScheduler:
     def run(self, circuit, plan, *, monitor=None, instrument=False):
         self.instrument_calls.append(instrument)
         self._data = [0] * 10000
-        return "done"
+        return "done", 0.0
 
 
 def test_run_quasar_records_memory():


### PR DESCRIPTION
## Summary
- expose gate execution time from `Scheduler.run` when instrumentation is enabled
- use scheduler-reported timing in `BenchmarkRunner.run_quasar`
- update benchmark tests for new timing semantics

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b9bb0705008321aff473ce03701f36