### PR TITLE
Ensure Stim backend uses full register during conversions

### DIFF
--- a/quasar/scheduler.py
+++ b/quasar/scheduler.py
@@ -419,6 +419,12 @@ class Scheduler:
             sim_obj = sims[key]
 
             if sim_obj is not current_sim:
+                if (
+                    getattr(sim_obj, "backend", None) == Backend.TABLEAU
+                    and getattr(sim_obj, "num_qubits", circuit.num_qubits)
+                    != circuit.num_qubits
+                ):
+                    sim_obj.load(circuit.num_qubits)
                 if current_sim is not None:
                     current_ssd = current_sim.extract_ssd()
                     layer = None

--- a/tests/test_scheduler_wide_stim.py
+++ b/tests/test_scheduler_wide_stim.py
@@ -1,0 +1,15 @@
+import pytest
+from benchmarks.runner import BenchmarkRunner
+from benchmarks import circuits
+from quasar import SimulationEngine
+
+
+def test_run_wide_circuit_no_index_error():
+    """Ensure wide circuits ingest into Stim without index errors."""
+    runner = BenchmarkRunner()
+    engine = SimulationEngine()
+    circuit = circuits.w_state_circuit(13)
+    try:
+        runner.run_quasar_multiple(circuit, engine, repetitions=1)
+    except IndexError as exc:  # pragma: no cover - regression guard
+        pytest.fail(f"Unexpected index error: {exc}")


### PR DESCRIPTION
## Summary
- Guarantee Stim backend reloads with complete register when switching during scheduled runs
- Add regression test running a 13-qubit circuit in auto mode to guard against index errors

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b9e24ef2c8832188c3ee635926bd1d