### PR TITLE
Measure quick path gate execution time

### DIFF
--- a/benchmarks/runner.py
+++ b/benchmarks/runner.py
@@ -328,16 +328,18 @@ class BenchmarkRunner:
                 start_prepare = time.perf_counter()
                 sim = type(scheduler.backends[backend_choice])()
                 sim.load(circuit.num_qubits)
-                for g in getattr(circuit, "gates", []):
-                    sim.apply_gate(g.gate, g.qubits, g.params)
                 prepare_time = time.perf_counter() - start_prepare
                 _, prepare_peak_memory = tracemalloc.get_traced_memory()
                 tracemalloc.reset_peak()
 
+                start_run = time.perf_counter()
+                for g in getattr(circuit, "gates", []):
+                    sim.apply_gate(g.gate, g.qubits, g.params)
+                run_time = time.perf_counter() - start_run
+
                 result = sim.extract_ssd()
                 result = result if result is not None else getattr(circuit, "ssd", None)
                 backend_choice_name = getattr(backend_choice, "name", str(backend_choice))
-                run_time = 0.0
                 _, run_peak_memory = tracemalloc.get_traced_memory()
                 tracemalloc.stop()
             else:

--- a/tests/test_benchmark_quick_path_prebuild.py
+++ b/tests/test_benchmark_quick_path_prebuild.py
@@ -71,7 +71,7 @@ def test_quick_path_prebuilds_backend():
     assert DummyBackend.applied == 1
     assert DummyBackend.extracted == 1
     assert record["prepare_time"] == pytest.approx(0.0, abs=0.01)
-    assert record["run_time"] == 0.0
+    assert record["run_time"] == pytest.approx(0.0, abs=0.01)
     assert record["backend"] == "STATEVECTOR"
     assert not record["failed"]
 


### PR DESCRIPTION
## Summary
- separate gate application timing from simulator instantiation in BenchmarkRunner quick path
- adjust quick path benchmark test to expect non-zero run time

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b9ed26b3788321a8b0fd981b5ff7af