### PR TITLE
Instrument SSD extraction

### DIFF
--- a/benchmarks/runner.py
+++ b/benchmarks/runner.py
@@ -357,7 +357,8 @@ class BenchmarkRunner:
                     _, prepare_peak_memory = tracemalloc.get_traced_memory()
                     tracemalloc.reset_peak()
 
-                result, run_time = scheduler.run(circuit, plan, instrument=True)
+                result, run_cost = scheduler.run(circuit, plan, instrument=True)
+                run_time = run_cost.time
                 if hasattr(result, "partitions") and getattr(result, "partitions"):
                     backend_obj = result.partitions[0].backend
                     backend_choice_name = getattr(backend_obj, "name", str(backend_obj))
@@ -367,6 +368,7 @@ class BenchmarkRunner:
                     pass
                 _, run_peak_memory = tracemalloc.get_traced_memory()
                 tracemalloc.stop()
+                run_peak_memory = max(run_peak_memory, int(run_cost.memory))
         except Exception as exc:  # pragma: no cover - exercised in tests
             _, run_peak_memory = tracemalloc.get_traced_memory()
             tracemalloc.stop()

--- a/tests/test_benchmark_run_multiple.py
+++ b/tests/test_benchmark_run_multiple.py
@@ -8,7 +8,7 @@ from benchmarks.circuits import ghz_circuit
 from benchmarks.runner import BenchmarkRunner
 from quasar import SimulationEngine
 from quasar.ssd import SSD, SSDPartition
-from quasar.cost import Backend
+from quasar.cost import Backend, Cost
 from quasar.planner import PlanResult
 
 
@@ -167,7 +167,7 @@ class DummyScheduler:
                 )
             ]
         )
-        return ssd, runtime
+        return ssd, Cost(time=runtime, memory=0.0)
 
 
 def test_run_quasar_multiple_aggregates_statistics():
@@ -201,7 +201,7 @@ class PlannerErrorScheduler:
         ssd = SSD([
             SSDPartition(subsystems=((0,),), backend=plan.final_backend or Backend.STATEVECTOR)
         ])
-        return ssd, 0.0
+        return ssd, Cost(time=0.0, memory=0.0)
 
 
 def test_run_quasar_returns_failure_record_on_planner_error():

--- a/tests/test_benchmark_runner_memory.py
+++ b/tests/test_benchmark_runner_memory.py
@@ -1,5 +1,6 @@
 from benchmarks.runner import BenchmarkRunner
 from quasar.planner import PlanResult
+from quasar.cost import Cost
 
 
 class DummyBackend:
@@ -44,7 +45,7 @@ class DummyScheduler:
     def run(self, circuit, plan, *, monitor=None, instrument=False):
         self.instrument_calls.append(instrument)
         self._data = [0] * 10000
-        return "done", 0.0
+        return "done", Cost(time=0.0, memory=0.0)
 
 
 def test_run_quasar_records_memory():


### PR DESCRIPTION
## Summary
- profile `extract_ssd` calls using `time.perf_counter` and `tracemalloc` when instrumentation is enabled
- accumulate runtime and peak memory in `Scheduler`'s returned cost
- adapt benchmark runner and tests for the new cost object and add a test verifying nontrivial circuits report runtime

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b9ee31298c8321b106484551586b1b