### PR TITLE
Add benchmark run support and reuse state

### DIFF
--- a/benchmarks/runner.py
+++ b/benchmarks/runner.py
@@ -87,8 +87,9 @@ class BenchmarkRunner:
                 tracemalloc.reset_peak()
 
                 start_run = time.perf_counter()
-                result = backend.run_benchmark(**kwargs)
+                backend.run_benchmark(**kwargs)
                 run_time = time.perf_counter() - start_run
+                result = None
                 _, run_peak_memory = tracemalloc.get_traced_memory()
                 tracemalloc.stop()
             else:

--- a/quasar/scheduler.py
+++ b/quasar/scheduler.py
@@ -426,6 +426,17 @@ class Scheduler:
                 ):
                     sim_obj.load(circuit.num_qubits)
                 if current_sim is not None:
+                    if hasattr(current_sim, "run_benchmark"):
+                        if instrument:
+                            tracemalloc.start()
+                            start_time = time.perf_counter()
+                            current_sim.run_benchmark()
+                            elapsed = time.perf_counter() - start_time
+                            total_gate_time += elapsed
+                            _, _ = tracemalloc.get_traced_memory()
+                            tracemalloc.stop()
+                        else:
+                            current_sim.run_benchmark()
                     current_ssd = current_sim.extract_ssd()
                     layer = None
                     if conv_idx < len(conv_layers):
@@ -543,6 +554,17 @@ class Scheduler:
             parts: List[SSDPartition] = []
             used_qubits = set()
             for sim in sims.values():
+                if hasattr(sim, "run_benchmark"):
+                    if instrument:
+                        tracemalloc.start()
+                        start_time = time.perf_counter()
+                        sim.run_benchmark()
+                        elapsed = time.perf_counter() - start_time
+                        total_gate_time += elapsed
+                        _, _ = tracemalloc.get_traced_memory()
+                        tracemalloc.stop()
+                    else:
+                        sim.run_benchmark()
                 ssd = sim.extract_ssd()
                 if ssd is None:
                     continue


### PR DESCRIPTION
## Summary
- add benchmarking run method to statevector backend that caches execution
- teach scheduler and runner to time `run_benchmark` when available
- avoid redundant simulator runs by reusing benchmarked state during SSD extraction

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b9ee7e9acc8321857e2e0dd1c0cee0