### PR TITLE
Add benchmark execution for MPS backend

### DIFF
--- a/quasar/scheduler.py
+++ b/quasar/scheduler.py
@@ -426,6 +426,14 @@ class Scheduler:
                 ):
                     sim_obj.load(circuit.num_qubits)
                 if current_sim is not None:
+                    if instrument and hasattr(current_sim, "run_benchmark"):
+                        tracemalloc.start()
+                        start_time = time.perf_counter()
+                        current_sim.run_benchmark()
+                        elapsed = time.perf_counter() - start_time
+                        total_gate_time += elapsed
+                        tracemalloc.get_traced_memory()
+                        tracemalloc.stop()
                     current_ssd = current_sim.extract_ssd()
                     layer = None
                     if conv_idx < len(conv_layers):
@@ -543,6 +551,14 @@ class Scheduler:
             parts: List[SSDPartition] = []
             used_qubits = set()
             for sim in sims.values():
+                if instrument and hasattr(sim, "run_benchmark"):
+                    tracemalloc.start()
+                    start_time = time.perf_counter()
+                    sim.run_benchmark()
+                    elapsed = time.perf_counter() - start_time
+                    total_gate_time += elapsed
+                    tracemalloc.get_traced_memory()
+                    tracemalloc.stop()
                 ssd = sim.extract_ssd()
                 if ssd is None:
                     continue

--- a/tests/test_scheduler_benchmark_mps.py
+++ b/tests/test_scheduler_benchmark_mps.py
@@ -1,0 +1,28 @@
+import numpy as np
+
+from quasar.circuit import Circuit
+from quasar.scheduler import Scheduler
+from quasar.cost import Backend
+from quasar.backends import MPSBackend
+
+
+def test_scheduler_uses_run_benchmark(monkeypatch):
+    calls = {"count": 0}
+
+    def fake_run_benchmark(self):
+        calls["count"] += 1
+        self._benchmark_state = np.array([1.0, 0.0])
+        return self._benchmark_state
+
+    def fake_run(self):  # pragma: no cover - should not be called
+        raise AssertionError("_run should not be invoked")
+
+    monkeypatch.setattr(MPSBackend, "run_benchmark", fake_run_benchmark)
+    monkeypatch.setattr(MPSBackend, "_run", fake_run)
+
+    scheduler = Scheduler(backends={Backend.MPS: MPSBackend()})
+    circuit = Circuit([{"gate": "H", "qubits": [0]}])
+    plan = scheduler.prepare_run(circuit, backend=Backend.MPS)
+    scheduler.run(circuit, plan, instrument=True)
+
+    assert calls["count"] == 1


### PR DESCRIPTION
## Summary
- add run_benchmark to MPS backend and cache the result state
- invoke backend run_benchmark in Scheduler to measure execution time
- test MPS benchmark caching and scheduler integration

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b9ee80cf78832199198f500ee209bd