### PR TITLE
Add benchmarking hook for Stim backend and timing updates

### DIFF
--- a/benchmarks/runner.py
+++ b/benchmarks/runner.py
@@ -75,13 +75,14 @@ class BenchmarkRunner:
         tracemalloc.start()
 
         try:
-            if hasattr(backend, "prepare_benchmark") and hasattr(backend, "run_benchmark"):
+            if hasattr(backend, "run_benchmark"):
                 start_prepare = time.perf_counter()
-                if hasattr(backend, "load") and getattr(circuit, "num_qubits", None) is not None:
-                    backend.load(circuit.num_qubits)
-                backend.prepare_benchmark(circuit)
-                for g in getattr(circuit, "gates", []):
-                    backend.apply_gate(g.gate, g.qubits, g.params)
+                if hasattr(backend, "prepare_benchmark"):
+                    if hasattr(backend, "load") and getattr(circuit, "num_qubits", None) is not None:
+                        backend.load(circuit.num_qubits)
+                    backend.prepare_benchmark(circuit)
+                    for g in getattr(circuit, "gates", []):
+                        backend.apply_gate(g.gate, g.qubits, g.params)
                 prepare_time = time.perf_counter() - start_prepare
                 _, prepare_peak_memory = tracemalloc.get_traced_memory()
                 tracemalloc.reset_peak()

--- a/quasar/backends/stim_backend.py
+++ b/quasar/backends/stim_backend.py
@@ -119,6 +119,17 @@ class StimBackend(Backend):
         for name, qubits, params in ops:
             self.apply_gate(name, qubits, params)
 
+    def run_benchmark(self) -> SSD | Sequence[complex] | None:
+        """Execute queued operations and return a state representation."""
+        self.run()
+        try:
+            return self.statevector()
+        except Exception:
+            try:
+                return self.extract_ssd()
+            except Exception:
+                return None
+
     def extract_ssd(self) -> SSD:
         self.run()
         tableau = None

--- a/tests/backends/test_stim_backend.py
+++ b/tests/backends/test_stim_backend.py
@@ -1,6 +1,8 @@
 """Tests for the Stim backend initialisation."""
 
 from quasar.backends.stim_backend import StimBackend
+from quasar.circuit import Circuit
+from benchmarks.runner import BenchmarkRunner
 
 
 def test_load_and_apply_highest_qubit() -> None:
@@ -10,4 +12,13 @@ def test_load_and_apply_highest_qubit() -> None:
     backend.apply_gate("X", [2])
     assert backend.simulator is not None
     assert backend.simulator.num_qubits == 3
+
+
+def test_run_benchmark_reports_time() -> None:
+    """Queued gates trigger runtime measurement via run_benchmark."""
+    backend = StimBackend()
+    runner = BenchmarkRunner()
+    circuit = Circuit([{"gate": "H", "qubits": [0]}])
+    rec = runner.run(circuit, backend)
+    assert rec["run_time"] > 0
 


### PR DESCRIPTION
## Summary
- expose `StimBackend.run_benchmark` to execute queued gates and return the resulting state
- make `BenchmarkRunner` and `Scheduler` time `run_benchmark` when available
- test that Stim backend reports non-zero runtime when gates are queued

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68b9ee83d9788321885a1a2a834a7ffb