### PR TITLE
Cache statevector results during benchmarking

### DIFF
--- a/tests/backends/test_statevector.py
+++ b/tests/backends/test_statevector.py
@@ -1,0 +1,22 @@
+import numpy as np
+import pytest
+from quasar.backends import StatevectorBackend
+
+
+def test_statevector_benchmark_uses_cached_state(monkeypatch):
+    backend = StatevectorBackend()
+    backend.load(1)
+    backend.prepare_benchmark()
+    backend.apply_gate("H", [0])
+    state = backend.run_benchmark()
+
+    def fail_run():  # pragma: no cover - should not be called
+        raise AssertionError("_run invoked despite cached state")
+
+    monkeypatch.setattr(backend, "_run", fail_run)
+
+    ssd = backend.extract_ssd()
+    np.testing.assert_allclose(ssd.partitions[0].state, state)
+
+    vec = backend.statevector()
+    np.testing.assert_allclose(vec, state)


### PR DESCRIPTION
## Summary
- Add cached state handling to the statevector backend and disable benchmark-mode buffering.
- Implement dedicated `prepare_benchmark`/`run_benchmark` that execute the circuit once and store the result.
- Update `extract_ssd` and `statevector` to reuse cached state; add regression test.

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68ba4fa7f0ac8321a724bb7969e0bae2