### PR TITLE
Cache statevector for MPS backend benchmark

### DIFF
--- a/quasar/backends/mps.py
+++ b/quasar/backends/mps.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 """Matrix product state backend using Qiskit's MPS simulator."""
 
 from dataclasses import dataclass, field
-from typing import Dict, Sequence, List, Tuple
+from typing import Any, Dict, Sequence, List, Tuple
 import numpy as np
 from qiskit import QuantumCircuit
 from qiskit.circuit.library import U2Gate, UGate, standard_gates
@@ -37,6 +37,7 @@ class MPSBackend(Backend):
     _benchmark_ops: List[Tuple[str, Sequence[int], Dict[str, float] | None]] = field(
         default_factory=list, init=False
     )
+    _cached_state: np.ndarray | None = field(default=None, init=False)
 
     def __post_init__(self) -> None:  # pragma: no cover - trivial
         available = AerSimulator().available_methods()
@@ -51,6 +52,7 @@ class MPSBackend(Backend):
         self.chi = int(kwargs.get("chi", 16))
         self.circuit = QuantumCircuit(num_qubits)
         self.history.clear()
+        self._cached_state = None
 
     def ingest(
         self,
@@ -80,6 +82,7 @@ class MPSBackend(Backend):
         be = data.reshape([2] * n).transpose(*reversed(range(n))).reshape(-1)
         self.circuit.initialize(be, mapping)
         self.history.clear()
+        self._cached_state = None
 
     # ------------------------------------------------------------------
     def _param(self, params: Dict[str, float] | None, idx: int) -> float:
@@ -142,6 +145,34 @@ class MPSBackend(Backend):
             if method is None:
                 raise NotImplementedError(f"Unsupported gate {name}")
             method(*qubits)
+        self._cached_state = None
+
+    # ------------------------------------------------------------------
+    def prepare_benchmark(self, circuit: Any | None = None) -> None:
+        """Prepare the backend for benchmarking.
+
+        Gates applied after this call are immediately appended to the
+        internal circuit and the simulation is executed exactly once during
+        :meth:`run_benchmark`.
+        """
+        if circuit is not None:
+            self.circuit = circuit.copy()
+            self.num_qubits = circuit.num_qubits
+        elif self.circuit is None:
+            if not self.num_qubits:
+                raise RuntimeError("Backend not initialised; call 'load' first")
+            self.circuit = QuantumCircuit(self.num_qubits)
+        self.history.clear()
+        self._benchmark_mode = False
+        self._benchmark_ops = []
+        self._cached_state = None
+
+    def run_benchmark(self) -> np.ndarray:
+        """Execute the prepared circuit once and cache the resulting state."""
+        self._benchmark_mode = False
+        state = self._run()
+        self._cached_state = state
+        return state
 
     # ------------------------------------------------------------------
     def _run(self) -> np.ndarray:
@@ -158,7 +189,8 @@ class MPSBackend(Backend):
         return np.asarray(vec).reshape([2] * n).transpose(*reversed(range(n))).reshape(-1)
 
     def extract_ssd(self) -> SSD:
-        state = self._run()
+        state = self._cached_state if self._cached_state is not None else self._run()
+        self._cached_state = state
         part = SSDPartition(
             subsystems=(tuple(range(self.num_qubits)),),
             history=tuple(self.history),
@@ -170,7 +202,9 @@ class MPSBackend(Backend):
     # ------------------------------------------------------------------
     def statevector(self) -> np.ndarray:
         """Return a dense statevector corresponding to the circuit."""
-        return self._run()
+        if self._cached_state is None:
+            self._cached_state = self._run()
+        return self._cached_state
 
 
 class AerMPSBackend(MPSBackend):

--- a/tests/backends/test_mps.py
+++ b/tests/backends/test_mps.py
@@ -22,3 +22,36 @@ def test_mps_controlled_gates_match_statevector_backend():
     sv.apply_gate("CRZ", [0, 1], crz_params)
     np.testing.assert_allclose(mps.statevector(), sv.statevector(), atol=1e-12)
 
+
+def test_mps_benchmark_uses_cached_state(monkeypatch):
+    backend = MPSBackend()
+    backend.load(1)
+    backend.prepare_benchmark()
+    backend.apply_gate("H", [0])
+
+    def fail_apply(*_: object, **__: object) -> None:  # pragma: no cover - should not run
+        raise AssertionError("apply_gate called during run_benchmark")
+
+    monkeypatch.setattr(backend, "apply_gate", fail_apply)
+
+    original_run = backend._run
+    calls = {"n": 0}
+
+    def run_spy() -> np.ndarray:
+        calls["n"] += 1
+        return original_run()
+
+    monkeypatch.setattr(backend, "_run", run_spy)
+    state = backend.run_benchmark()
+    assert calls["n"] == 1
+
+    def fail_run() -> np.ndarray:  # pragma: no cover - should not run
+        raise AssertionError("_run invoked despite cached state")
+
+    monkeypatch.setattr(backend, "_run", fail_run)
+
+    ssd = backend.extract_ssd()
+    np.testing.assert_allclose(ssd.partitions[0].state, state)
+    vec = backend.statevector()
+    np.testing.assert_allclose(vec, state)
+

--- a/tests/test_backend_roundtrip.py
+++ b/tests/test_backend_roundtrip.py
@@ -27,6 +27,7 @@ def test_statevector_roundtrip():
 def test_mps_roundtrip():
     b1 = _prepare_backend(MPSBackend())
     state = b1.extract_ssd().partitions[0].state
+    assert isinstance(state, (list, tuple))
     b2 = MPSBackend()
     b2.ingest(state)
     assert np.allclose(b1.statevector(), b2.statevector())


### PR DESCRIPTION
## Summary
- cache MPS simulator state after benchmark execution
- reuse cached state in extract_ssd and statevector
- test MPS benchmark caching and avoidance of rerun

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68ba51bf5be48321b1f3f8c253e0ee6b