### PR TITLE
docs: preserve native backend representations

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,6 +11,7 @@
 - Follow existing style: PEP8 formatting, descriptive docstrings and type annotations.
 - Document new user‑facing behaviour in `docs/` or relevant notebooks.
 - Unsupported gates should be implemented natively without decomposing into other operations.
+- Backend `run` methods should return native representations; only convert to a statevector (or other format) when explicitly required by a conversion layer.
 
 ## Testing
 - Run the full test suite with:


### PR DESCRIPTION
## Summary
- note that backend run methods should keep native representations and only convert when needed

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68ba8d7de80083218970a1636f679520