### PR TITLE
Add circuit symmetry heuristic

### DIFF
--- a/quasar/circuit.py
+++ b/quasar/circuit.py
@@ -12,6 +12,7 @@ from qiskit_qasm3_import import api as qasm3_api
 
 from .ssd import SSD, SSDPartition
 from .cost import Cost
+from .symmetry import symmetry_score
 
 
 @dataclass
@@ -37,6 +38,7 @@ class Circuit:
         self._num_gates = len(self.gates)
         self._num_qubits = self._infer_qubit_count()
         self._depth = self._compute_depth()
+        self.symmetry = symmetry_score(self)
         self.ssd = self._create_ssd()
         self.cost_estimates = self._estimate_costs()
 

--- a/quasar/symmetry.py
+++ b/quasar/symmetry.py
@@ -1,0 +1,41 @@
+"""Symmetry heuristics for quantum circuits."""
+
+from __future__ import annotations
+
+from collections import Counter
+from typing import TYPE_CHECKING, Tuple
+
+if TYPE_CHECKING:  # pragma: no cover - used for type hints only
+    from .circuit import Circuit, Gate
+
+
+def _gate_key(gate: "Gate") -> Tuple[str, Tuple[Tuple[str, object], ...]]:
+    """Return a hashable description of a gate's type and parameters."""
+    return gate.gate, tuple(sorted(gate.params.items()))
+
+
+def symmetry_score(circuit: "Circuit") -> float:
+    """Compute a simple symmetry score for ``circuit``.
+
+    The score measures the fraction of gates that share their type and
+    parameter values with at least one other gate in the circuit. Higher
+    scores indicate more structural repetition across qubits and layers.
+
+    Parameters
+    ----------
+    circuit:
+        Circuit to analyse.
+
+    Returns
+    -------
+    float
+        Symmetry score in the range ``[0, 1]``.
+    """
+
+    gates = getattr(circuit, "gates", None)
+    if not gates:
+        return 1.0
+
+    counts = Counter(_gate_key(g) for g in gates)
+    repeated = sum(count for count in counts.values() if count > 1)
+    return repeated / len(gates)

--- a/tests/test_symmetry.py
+++ b/tests/test_symmetry.py
@@ -1,0 +1,38 @@
+import math
+import random
+
+from benchmarks.circuits import qft_circuit, w_state_circuit
+from quasar.circuit import Circuit, Gate
+
+
+def random_circuit(n_qubits: int, depth: int, seed: int = 0) -> Circuit:
+    random.seed(seed)
+    gates = []
+    for _ in range(depth):
+        gate = random.choice(["RX", "RY", "RZ", "CRX", "CRY", "CRZ"])
+        angle = random.random() * math.pi
+        if gate.startswith("C"):
+            q1 = random.randrange(n_qubits)
+            q2 = random.randrange(n_qubits)
+            while q2 == q1:
+                q2 = random.randrange(n_qubits)
+            gates.append(Gate(gate, [q1, q2], {"theta": angle}))
+        else:
+            q = random.randrange(n_qubits)
+            gates.append(Gate(gate, [q], {"theta": angle}))
+    return Circuit(gates)
+
+
+def test_qft_has_high_symmetry():
+    circ = qft_circuit(5)
+    assert circ.symmetry > 0.7
+
+
+def test_w_state_has_high_symmetry():
+    circ = w_state_circuit(5)
+    assert circ.symmetry > 0.3
+
+
+def test_random_circuit_has_low_symmetry():
+    circ = random_circuit(5, 20, seed=123)
+    assert circ.symmetry < 0.2


### PR DESCRIPTION
## Summary
- add `symmetry_score` helper computing repeated gate pattern ratio
- expose symmetry value on `Circuit` instances
- test symmetry heuristic on QFT, W-state, and random circuits

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68baa39570b88321a751756d6bf189a7