### PR TITLE
Add circuit sparsity estimate

### DIFF
--- a/quasar/circuit.py
+++ b/quasar/circuit.py
@@ -30,6 +30,12 @@ class Circuit:
     ----------
     gates:
         Iterable of :class:`Gate` or dictionaries describing gates.
+
+    Attributes
+    ----------
+    sparsity:
+        Estimated sparsity of the circuit's state vector.  This is a heuristic
+        and should not be taken as an exact metric.
     """
 
     def __init__(self, gates: Iterable[Dict[str, Any] | Gate]):
@@ -39,6 +45,8 @@ class Circuit:
         self._depth = self._compute_depth()
         self.ssd = self._create_ssd()
         self.cost_estimates = self._estimate_costs()
+        from .sparsity import sparsity_estimate
+        self.sparsity = sparsity_estimate(self)
 
     # ------------------------------------------------------------------
     # Construction helpers

--- a/tests/test_circuit.py
+++ b/tests/test_circuit.py
@@ -33,3 +33,11 @@ def test_qubit_inference_from_one_based_indexing():
         {"gate": "CX", "qubits": [1, 2]},
     ])
     assert circ.num_qubits == 2
+
+
+def test_sparsity_attribute():
+    circ = Circuit.from_dict([
+        {"gate": "H", "qubits": [0]},
+        {"gate": "X", "qubits": [1]},
+    ])
+    assert circ.sparsity == 0.5


### PR DESCRIPTION
## Summary
- estimate circuit sparsity during initialization
- document sparsity attribute on `Circuit`
- test sparsity heuristic is attached to circuits

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68bab26c12b083218d121dae84f8502b