### PR TITLE
Add circuit sparsity tests

### DIFF
--- a/tests/test_sparsity.py
+++ b/tests/test_sparsity.py
@@ -1,6 +1,9 @@
 import pytest
+from qiskit import transpile
+from qiskit.circuit.random import random_circuit as qiskit_random_circuit
 
-from quasar.circuit import Gate, Circuit
+from benchmarks.circuits import qft_circuit, w_state_circuit
+from quasar.circuit import Circuit, Gate
 from quasar.sparsity import sparsity_estimate
 
 
@@ -27,3 +30,18 @@ def test_h_then_cx():
 def test_clamp_to_full_dimension():
     circ = Circuit([Gate("H", [0]), Gate("H", [0])])
     assert sparsity_estimate(circ) == 0.0
+
+
+def test_w_state_sparsity():
+    assert w_state_circuit(5).sparsity > 0.8
+
+
+def test_qft_sparsity():
+    assert qft_circuit(5).sparsity < 0.2
+
+
+def test_random_circuit_sparsity():
+    qc = qiskit_random_circuit(5, depth=20, seed=123)
+    qc = transpile(qc, basis_gates=["u", "p", "cx", "h", "x"])
+    circ = Circuit.from_qiskit(qc)
+    assert circ.sparsity < 0.2


### PR DESCRIPTION
## Summary
- add tests ensuring W-state, QFT, and random circuits have expected sparsity ranges

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68bab523d78c83219920087cc85384ce