### PR TITLE
Document sparsity heuristic and branching examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,18 @@ respectively.  Custom backend instances can be supplied to :class:`Scheduler`
 or :class:`SimulationEngine` via their ``backends`` argument to control the
 simulation method.
 
+## Sparsity heuristic
+
+Every :class:`~quasar.circuit.Circuit` computes a ``sparsity`` estimate for the
+state produced from ``|0…0>``.  The value lies in ``[0, 1]`` with ``0``
+representing a fully dense state and ``1`` indicating maximal sparsity.  The
+estimator performs a single ``O(num_gates)`` pass over the circuit, treating
+``H``, ``RX``, ``RY``, ``U``, ``U2`` and ``U3`` as branching gates.  Uncontrolled
+branching gates double the number of non‑zero amplitudes while controlled
+versions add one.  Consequently, an ``n``‑qubit W‑state yields a high sparsity
+of ``1 - n / 2**n`` whereas the quantum Fourier transform drives the estimate
+to ``0``.  See [docs/sparsity.md](docs/sparsity.md) for details.
+
 ## Configuration
 
 QuASAr exposes a small set of tunables that influence planning heuristics.  The

--- a/docs/sparsity.md
+++ b/docs/sparsity.md
@@ -1,0 +1,30 @@
+# Sparsity heuristic
+
+The `Circuit` class exposes a `sparsity` attribute estimating how many zero
+amplitudes remain after running the circuit on `|0…0>`.  It returns a value
+between 0 and 1: `0` denotes a fully dense state with all `2**n` amplitudes
+non-zero, while `1` indicates maximal sparsity where only a single basis state
+is populated.
+
+The estimator performs a single pass over the circuit, tracking an
+approximate count `nnz` of non-zero amplitudes and computing `1 - nnz / 2**n`,
+where `n` is the number of qubits.
+
+## Branching-gate heuristic
+
+Only a small set of single-qubit gates are treated as *branching* operations:
+`H`, `RX`, `RY`, `U`, `U2`, and `U3`.  An uncontrolled branching gate doubles
+`nnz`.  A controlled version adds just one extra amplitude, reflecting that the
+new branch appears only when the control qubit is `|1⟩`.  The count is clamped
+to `2**n`, yielding an overall complexity of `O(num_gates)`.
+
+## Examples
+
+*W-state:* an `n`-qubit W-state contains exactly `n` non-zero amplitudes, so
+the heuristic reports a sparsity of `1 - n / 2**n`, approaching 1 as `n`
+grows.
+
+*QFT:* the quantum Fourier transform applies repeated Hadamards and
+controlled-phase rotations that drive `nnz` to `2**n`, producing a sparsity of
+`0`—a maximally dense state.
+


### PR DESCRIPTION
## Summary
- Document definition and range of circuit `sparsity`
- Explain branching-gate heuristic with complexity `O(num_gates)`
- Contrast W-state and QFT as sparse vs dense examples

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68bab53724208321a1749e5369ac0916