### PR TITLE
Add circuit symmetry score heuristic

### DIFF
--- a/docs/symmetry.md
+++ b/docs/symmetry.md
@@ -1,0 +1,10 @@
+# Symmetry heuristic
+
+QuASAr derives a simple **symmetry** score for each :class:`~quasar.circuit.Circuit`.
+The score looks for repeated gate types with identical parameters and
+normalises the count by the circuit depth, yielding a value in ``[0, 1]``.
+Higher values indicate more structural repetition while ``0`` signifies no
+repeated patterns.
+
+The symmetry value is accessible via :attr:`Circuit.symmetry` and can be
+used as a lightweight indicator of circuit regularity.

--- a/quasar/circuit.py
+++ b/quasar/circuit.py
@@ -36,6 +36,9 @@ class Circuit:
     sparsity:
         Estimated sparsity of the circuit's state vector.  This is a heuristic
         and should not be taken as an exact metric.
+    symmetry:
+        Heuristic symmetry score of the circuit's layers.  Higher values
+        indicate more repeated gate patterns.
     """
 
     def __init__(self, gates: Iterable[Dict[str, Any] | Gate]):
@@ -47,6 +50,8 @@ class Circuit:
         self.cost_estimates = self._estimate_costs()
         from .sparsity import sparsity_estimate
         self.sparsity = sparsity_estimate(self)
+        from .symmetry import symmetry_score
+        self.symmetry = symmetry_score(self)
 
     # ------------------------------------------------------------------
     # Construction helpers

--- a/quasar/symmetry.py
+++ b/quasar/symmetry.py
@@ -1,0 +1,39 @@
+"""Heuristic symmetry metric for circuits."""
+
+from __future__ import annotations
+
+from collections import Counter
+
+from .circuit import Circuit
+
+
+def symmetry_score(circuit: Circuit) -> float:
+    """Estimate the structural symmetry of ``circuit``.
+
+    The heuristic scans the circuit's gate sequence and counts how many
+    distinct gate types (including their parameters) are repeated.  The
+    number of repeated gate specifications is then normalised by the
+    total number of qubit layers (the circuit depth) to yield a score in
+    ``[0, 1]``.
+
+    Parameters
+    ----------
+    circuit:
+        Circuit to analyse.
+
+    Returns
+    -------
+    float
+        Symmetry score where ``0`` indicates no repeated gate patterns and
+        ``1`` represents high repetition relative to depth.
+    """
+
+    if circuit.depth == 0:
+        return 0.0
+
+    signatures = [
+        (gate.gate, tuple(sorted(gate.params.items()))) for gate in circuit.gates
+    ]
+    counts = Counter(signatures)
+    repeats = sum(1 for c in counts.values() if c > 1)
+    return min(repeats / circuit.depth, 1.0)

--- a/tests/test_symmetry.py
+++ b/tests/test_symmetry.py
@@ -1,0 +1,13 @@
+from benchmarks.circuits import qft_circuit, w_state_circuit, random_circuit
+
+
+def test_qft_symmetry_high():
+    assert qft_circuit(5).symmetry > 0.3
+
+
+def test_w_state_symmetry_high():
+    assert w_state_circuit(5).symmetry > 0.1
+
+
+def test_random_circuit_symmetry_low():
+    assert random_circuit(5, seed=123).symmetry < 0.05


### PR DESCRIPTION
## Summary
- implement symmetry_score for counting repeated gate patterns
- expose symmetry attribute on Circuit and document heuristic
- test symmetry metric on QFT, W-state, and random circuits

## Testing
- `pytest tests/test_symmetry.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68bab80169f48321bc6a9a8166958ede