### PR TITLE
Document backend selection heuristic

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,18 @@ versions add one.  Consequently, an ``n``‑qubit W‑state yields a high sparsi
 of ``1 - n / 2**n`` whereas the quantum Fourier transform drives the estimate
 to ``0``.  See [docs/sparsity.md](docs/sparsity.md) for details.
 
+## Backend selection
+
+The planner selects a simulation backend for each circuit fragment based on
+simple heuristics.  [Symmetry](docs/symmetry.md) and
+[sparsity](docs/sparsity.md) scores are compared against thresholds to decide
+when to include the decision-diagram backend alongside dense simulators.
+These thresholds default to ``0.3`` and ``0.8`` respectively and can be tuned
+via the ``QUASAR_DD_SYMMETRY_THRESHOLD`` and
+``QUASAR_DD_SPARSITY_THRESHOLD`` environment variables.  A detailed overview
+of the decision flow is provided in
+[docs/backend_selection.md](docs/backend_selection.md).
+
 ## Configuration
 
 QuASAr exposes a small set of tunables that influence planning heuristics.  The

--- a/docs/backend_selection.md
+++ b/docs/backend_selection.md
@@ -1,0 +1,22 @@
+# Backend selection
+
+QuASAr's planner compares simulation backends for each circuit fragment.  It
+examines basic structural metrics to guide this choice:
+
+1. **Clifford detection** – if all gates in a fragment are Clifford operations
+   the specialised TABLEAU backend is preferred.
+2. **Heuristic metrics** – overall circuit [symmetry](symmetry.md) and
+   [sparsity](sparsity.md) scores are evaluated against configurable thresholds.
+   When either score exceeds its threshold the planner includes the
+   decision‑diagram backend as a candidate.
+3. **Fallback** – remaining candidates such as the dense STATEVECTOR simulator
+   are considered based on estimated runtime and memory cost.
+
+The thresholds controlling step 2 default to ``0.3`` for symmetry and ``0.8``
+for sparsity.  They can be tuned via the
+``QUASAR_DD_SYMMETRY_THRESHOLD`` and ``QUASAR_DD_SPARSITY_THRESHOLD``
+environment variables or by overriding ``config.DEFAULT`` at runtime.
+
+This lightweight heuristic steers the planner towards the decision‑diagram
+backend for circuits exhibiting repeated structure or large zero‑amplitude
+regions, while favouring dense methods otherwise.


### PR DESCRIPTION
## Summary
- document planner backend decision flow and thresholds for symmetry and sparsity
- link backend selection doc from README and mention tuning via environment variables

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68bad7d3b7fc8321996dbe5a33a18623