### PR TITLE
Refactor scheduling to precompute cross-backend states

### DIFF
--- a/quasar/cost.py
+++ b/quasar/cost.py
@@ -12,11 +12,13 @@ from typing import Dict, Optional
 
 @dataclass
 class Cost:
-    """Simple container for time, memory and complexity estimates."""
+    """Simple container for runtime and memory measurements."""
 
     time: float
     memory: float
     log_depth: float = 0.0
+    conversion: float = 0.0
+    replay: float = 0.0
 
 
 class Backend(Enum):

--- a/quasar/planner.py
+++ b/quasar/planner.py
@@ -10,12 +10,12 @@ cumulative cost up to a given gate index and acts as a backpointer to recover
 an optimal execution plan.
 """
 
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import Dict, List, Optional, Iterable, Set, Tuple, Hashable
 
 from .cost import Backend, Cost, CostEstimator
 from .partitioner import CLIFFORD_GATES, Partitioner
-from .ssd import ConversionLayer
+from .ssd import ConversionLayer, SSD
 from . import config
 
 if True:  # pragma: no cover - used for type checking when available
@@ -71,6 +71,7 @@ class PlanResult:
     explicit_steps: Optional[List[PlanStep]] = None
     explicit_conversions: Optional[List["ConversionLayer"]] = None
     step_costs: Optional[List[Cost]] = None
+    replay_ssd: Dict[int, "SSD"] = field(default_factory=dict)
 
     # The ``steps`` property recovers the final plan lazily using the
     # backpointers contained in ``table``.  If ``explicit_steps`` is provided
@@ -158,6 +159,8 @@ def _add_cost(a: Cost, b: Cost) -> Cost:
         time=a.time + b.time,
         memory=max(a.memory, b.memory),
         log_depth=max(a.log_depth, b.log_depth),
+        conversion=a.conversion + b.conversion,
+        replay=a.replay + b.replay,
     )
 
 

--- a/tests/test_benchmark_run_multiple.py
+++ b/tests/test_benchmark_run_multiple.py
@@ -181,7 +181,7 @@ def test_run_quasar_multiple_aggregates_statistics():
     assert record["repetitions"] == 3
     assert record["run_time_mean"] == 2.0
     assert math.isclose(record["run_time_std"], math.sqrt(2 / 3))
-    assert scheduler.plan_calls == [Backend.TABLEAU] * 3
+    assert scheduler.plan_calls == [Backend.TABLEAU]
     assert scheduler.run_calls == [(Backend.TABLEAU, True)] * 3
     assert record["backend"] == Backend.TABLEAU.name
 


### PR DESCRIPTION
## Summary
- extend runtime Cost metrics to capture conversion and replay overhead
- precompute bridge tensors and intermediate states in `prepare_run` to avoid gate replay
- track conversion time in `Scheduler.run`
- reuse prebuilt plans in benchmark runner

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68bae0d2fa14832199d87190765d75a3