### PR TITLE
Increase conversion overhead and add 10-qubit partition test

### DIFF
--- a/CALIBRATION.md
+++ b/CALIBRATION.md
@@ -11,6 +11,16 @@ singular-value-decomposition (SVD) truncation step.  Separate
 coefficients for these components are produced by the calibration
 script.
 
+## Conversion overhead
+
+Backend switches incur additional fixed and ingestion costs.  The default
+coefficients `ingest_sv`, `ingest_tab`, `ingest_mps`, and `ingest_dd` are
+set to `2.0` to model the effort required to load a full register into a
+new representation.  A separate `conversion_base` value of `5.0` adds a
+constant penalty to every backend transition.  These parameters can be
+measured and adjusted using the calibration utilities in this project to
+better match the characteristics of the target hardware.
+
 ## Running the benchmarks
 
 Run the calibration script to measure the cost of the supported

--- a/quasar/cost.py
+++ b/quasar/cost.py
@@ -82,12 +82,12 @@ class CostEstimator:
             "full_extract": 1.0,
             "st_chi_cap": 16.0,
             # Ingestion cost per target backend
-            "ingest_sv": 1.0,
-            "ingest_tab": 1.0,
-            "ingest_mps": 1.0,
-            "ingest_dd": 1.0,
+            "ingest_sv": 2.0,
+            "ingest_tab": 2.0,
+            "ingest_mps": 2.0,
+            "ingest_dd": 2.0,
             # Fixed overhead applied to every backend switch
-            "conversion_base": 0.0,
+            "conversion_base": 5.0,
         }
         if coeff:
             self.coeff.update(coeff)

--- a/tests/test_scheduler_no_partition.py
+++ b/tests/test_scheduler_no_partition.py
@@ -70,6 +70,19 @@ def test_random_two_qubit_circuit_single_partition():
     assert len({p.backend for p in result.ssd.partitions}) == 1
 
 
+def test_ten_qubit_circuit_single_partition():
+    """A 10-qubit chain should remain a single partition after planning."""
+    qc = QuantumCircuit(10)
+    for i in range(9):
+        qc.cx(i, i + 1)
+    circuit = Circuit.from_qiskit(qc)
+    scheduler = Scheduler(quick_max_qubits=None, force_single_backend_below=12)
+    plan = scheduler.prepare_run(circuit)
+    ssd = scheduler.run(circuit, plan)
+    assert len(ssd.partitions) == 1
+    assert not ssd.conversions
+
+
 def test_fifteen_qubit_circuit_single_backend():
     qc = QuantumCircuit(15)
     for i in range(14):


### PR DESCRIPTION
## Summary
- Increase default ingestion costs and add a base penalty for backend switches in the cost model
- Test that a 10‑qubit circuit is planned as a single partition with no conversions
- Document the new conversion-related coefficients in the calibration notes

## Testing
- `pytest tests/test_scheduler_no_partition.py::test_ten_qubit_circuit_single_partition -q`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68bae4b93d808321b35da17c9d67c160