### PR TITLE
test: ensure scheduler selects dd backend

### DIFF
--- a/tests/test_backend_symmetry_sparsity.py
+++ b/tests/test_backend_symmetry_sparsity.py
@@ -1,5 +1,5 @@
 from benchmarks.circuits import qft_circuit, random_circuit, w_state_circuit
-from quasar import Backend, SimulationEngine
+from quasar import Backend, Scheduler
 from quasar.config import DEFAULT
 
 
@@ -7,24 +7,27 @@ def test_w_state_selects_decision_diagram_via_sparsity():
     circ = w_state_circuit(5)
     assert circ.sparsity >= DEFAULT.dd_sparsity_threshold
     assert circ.symmetry < DEFAULT.dd_symmetry_threshold
-    engine = SimulationEngine()
-    plan = engine.planner.plan(circ)
-    assert plan.final_backend == Backend.DECISION_DIAGRAM
+    scheduler = Scheduler()
+    scheduler.prepare_run(circ)
+    part = circ.ssd.partitions[0]
+    assert part.backend == Backend.DECISION_DIAGRAM
 
 
 def test_qft_selects_decision_diagram_via_symmetry():
     circ = qft_circuit(5)
     assert circ.symmetry >= DEFAULT.dd_symmetry_threshold
     assert circ.sparsity < DEFAULT.dd_sparsity_threshold
-    engine = SimulationEngine()
-    plan = engine.planner.plan(circ)
-    assert plan.final_backend == Backend.DECISION_DIAGRAM
+    scheduler = Scheduler()
+    scheduler.prepare_run(circ)
+    part = circ.ssd.partitions[0]
+    assert part.backend == Backend.DECISION_DIAGRAM
 
 
 def test_random_circuit_stays_statevector_when_metrics_low():
     circ = random_circuit(5, seed=123)
     assert circ.sparsity < DEFAULT.dd_sparsity_threshold
     assert circ.symmetry < DEFAULT.dd_symmetry_threshold
-    engine = SimulationEngine()
-    plan = engine.planner.plan(circ)
-    assert plan.final_backend == Backend.STATEVECTOR
+    scheduler = Scheduler()
+    scheduler.prepare_run(circ)
+    part = circ.ssd.partitions[0]
+    assert part.backend == Backend.STATEVECTOR


### PR DESCRIPTION
## Summary
- add scheduler-based symmetry and sparsity tests

## Testing
- `pytest tests/test_backend_symmetry_sparsity.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68baeb606b888321b685888c9d28db12