### PR TITLE
Force Stim for Clifford circuits

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,9 +49,10 @@ argument to explicitly choose the simulation backend (e.g.,
 ``Backend.TABLEAU`` for Clifford circuits).  When ``backend`` is ``None`` (the
 default), the planner selects a backend automatically based on estimated cost.
 Supplying a :class:`~quasar.cost.Backend` instance fixes the simulator choice
-and disables this automatic selection.  Clifford circuits default to the
-specialised TABLEAU backend, though a general-purpose backend like
-``Backend.STATEVECTOR`` can be requested explicitly.
+and disables this automatic selection.  Clifford circuits bypass other
+simulators and default to the specialised TABLEAU backend, though a
+general-purpose backend like ``Backend.STATEVECTOR`` can be requested
+explicitly.
 
 ```python
 from quasar import Backend, Circuit, SimulationEngine

--- a/docs/backend_selection.md
+++ b/docs/backend_selection.md
@@ -4,7 +4,8 @@ QuASAr's planner compares simulation backends for each circuit fragment.  It
 examines basic structural metrics to guide this choice:
 
 1. **Clifford detection** – if all gates in a fragment are Clifford operations
-   the specialised TABLEAU backend is preferred.
+   the specialised TABLEAU backend is used exclusively, bypassing other
+   candidates.
 2. **Heuristic metrics** – overall circuit [symmetry](symmetry.md) and
    [sparsity](sparsity.md) scores are evaluated against configurable thresholds.
    When either score exceeds its threshold the planner includes the

--- a/quasar/planner.py
+++ b/quasar/planner.py
@@ -209,19 +209,17 @@ def _supported_backends(
     qubits = {q for g in gates for q in g.qubits}
     num_qubits = len(qubits)
 
-    candidates: List[Backend] = []
-
     clifford = names and all(name in CLIFFORD_GATES for name in names)
     if allow_tableau and clifford:
-        candidates.append(Backend.TABLEAU)
+        return [Backend.TABLEAU]
+
+    candidates: List[Backend] = []
 
     dd_metric = False
     if symmetry is not None and symmetry >= config.DEFAULT.dd_symmetry_threshold:
         dd_metric = True
     if sparsity is not None and sparsity >= config.DEFAULT.dd_sparsity_threshold:
         dd_metric = True
-    if allow_tableau and clifford:
-        dd_metric = False
 
     multi = [g for g in gates if len(g.qubits) > 1]
     local = multi and all(

--- a/tests/test_backend_selection.py
+++ b/tests/test_backend_selection.py
@@ -7,3 +7,4 @@ def test_planner_selects_tableau_for_ghz():
     engine = SimulationEngine()
     plan = engine.planner.plan(circuit)
     assert plan.final_backend == Backend.TABLEAU
+    assert {s.backend for s in plan.steps} == {Backend.TABLEAU}

--- a/tests/test_scheduler_no_partition.py
+++ b/tests/test_scheduler_no_partition.py
@@ -5,7 +5,7 @@ which use 2- and 3-qubit systems. They should fit into a single partition
 when processed by the scheduler or simulation engine.
 """
 
-from quasar import Circuit, SimulationEngine, Scheduler
+from quasar import Backend, Circuit, SimulationEngine, Scheduler
 from qiskit import QuantumCircuit
 import numpy as np
 
@@ -43,7 +43,8 @@ def test_bell_circuit_single_partition():
     circuit = build_bell_circuit()
     engine = SimulationEngine()
     result = engine.simulate(circuit)
-    assert len({p.backend for p in result.ssd.partitions}) == 1
+    backends = {p.backend for p in result.ssd.partitions}
+    assert backends == {Backend.TABLEAU}
     assert not result.ssd.conversions
 
 
@@ -51,7 +52,8 @@ def test_prepare_run_single_partition():
     circuit = build_bell_circuit()
     scheduler = Scheduler()
     scheduler.prepare_run(circuit)
-    assert len({p.backend for p in circuit.ssd.partitions}) == 1
+    backends = {p.backend for p in circuit.ssd.partitions}
+    assert backends == {Backend.TABLEAU}
 
 
 def test_three_qubit_ghz_single_partition():
@@ -59,7 +61,8 @@ def test_three_qubit_ghz_single_partition():
     scheduler = Scheduler()
     plan = scheduler.prepare_run(circuit)
     ssd = scheduler.run(circuit, plan)
-    assert len({p.backend for p in ssd.partitions}) == 1
+    backends = {p.backend for p in ssd.partitions}
+    assert backends == {Backend.TABLEAU}
     assert not ssd.conversions
 
 
@@ -79,7 +82,8 @@ def test_ten_qubit_circuit_single_partition():
     scheduler = Scheduler(quick_max_qubits=None, force_single_backend_below=12)
     plan = scheduler.prepare_run(circuit)
     ssd = scheduler.run(circuit, plan)
-    assert len(ssd.partitions) == 1
+    backends = {p.backend for p in ssd.partitions}
+    assert backends == {Backend.TABLEAU}
     assert not ssd.conversions
 
 
@@ -90,5 +94,6 @@ def test_fifteen_qubit_circuit_single_backend():
     circuit = Circuit.from_qiskit(qc)
     engine = SimulationEngine(scheduler=Scheduler(quick_max_qubits=15))
     result = engine.simulate(circuit)
-    assert len(result.ssd.partitions) == 1
+    backends = {p.backend for p in result.ssd.partitions}
+    assert backends == {Backend.TABLEAU}
     assert not result.ssd.conversions


### PR DESCRIPTION
## Summary
- short-circuit planner backend candidates so Clifford fragments only use Stim
- document that Clifford circuits bypass other backends
- assert Stim usage in planner/scheduler tests

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68baf48b8fbc8321943bafa8d3563e14