### PR TITLE
Prefer decision diagram backend when sparsity metric triggers

### DIFF
--- a/tests/test_backend_symmetry_sparsity.py
+++ b/tests/test_backend_symmetry_sparsity.py
@@ -1,5 +1,7 @@
 from benchmarks.circuits import qft_circuit, random_circuit, w_state_circuit
 from quasar import Backend, Scheduler
+from quasar.planner import Planner
+from quasar.partitioner import Partitioner
 from quasar.config import DEFAULT
 
 
@@ -31,3 +33,16 @@ def test_random_circuit_stays_statevector_when_metrics_low():
     scheduler.prepare_run(circ)
     part = circ.ssd.partitions[0]
     assert part.backend == Backend.STATEVECTOR
+
+
+def test_w_state_planner_prefers_decision_diagram():
+    circ = w_state_circuit(5)
+    planner = Planner()
+    plan = planner.plan(circ)
+    assert plan.final_backend == Backend.DECISION_DIAGRAM
+
+
+def test_w_state_partitioner_prefers_decision_diagram():
+    circ = w_state_circuit(5)
+    part = Partitioner().partition(circ)
+    assert part.partitions[0].backend == Backend.DECISION_DIAGRAM

--- a/tests/test_conversion_layers.py
+++ b/tests/test_conversion_layers.py
@@ -26,7 +26,7 @@ def test_conversion_layer_inserted():
 
     conv = ssd.conversions[0]
     assert conv.source == Backend.TABLEAU
-    assert conv.target == Backend.STATEVECTOR
+    assert conv.target == Backend.DECISION_DIAGRAM
     assert set(conv.boundary) == {0, 1, 2, 3, 4}
     assert conv.cost.time > 0
 


### PR DESCRIPTION
## Summary
- Ensure planner ordering selects the decision diagram backend ahead of MPS when sparsity metrics trigger
- Partition locally connected circuits on the decision diagram backend when symmetry or sparsity thresholds are met
- Add regression tests for W-state planning on the decision diagram backend and adjust conversion layer expectations

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bafde1dd9c83218a202a6cc5444c01