### PR TITLE
Add peak memory tracking in comparison notebook

### DIFF
--- a/benchmarks/notebooks/comparison.ipynb
+++ b/benchmarks/notebooks/comparison.ipynb
@@ -96,6 +96,45 @@
   },
   {
    "cell_type": "code",
+   "execution_count": null,
+   "id": "1f44b4bf",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Compute peak memory per backend\n",
+    "peak_memory = cli_df.groupby('framework')['avg_run_peak_memory'].max()\n",
+    "peak_memory.to_frame(name='peak_run_memory_bytes')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "ab44ee97",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Plot execution time and peak memory\n",
+    "fig, ax1 = plt.subplots()\n",
+    "sns.lineplot(data=cli_df, x='qubits', y='avg_time', hue='framework', marker='o', ax=ax1)\n",
+    "ax2 = ax1.twinx()\n",
+    "sns.lineplot(data=cli_df, x='qubits', y='avg_run_peak_memory', hue='framework', marker='s', linestyle='--', ax=ax2)\n",
+    "ax1.set_xlabel('Qubits')\n",
+    "ax1.set_ylabel('Execution time (s)')\n",
+    "ax2.set_ylabel('Peak memory (bytes)')\n",
+    "ax1.set_title('Runtime and peak memory by backend')\n",
+    "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "3a776a36",
+   "metadata": {},
+   "source": [
+    "The dashed lines above show the peak memory consumed by each backend during the benchmark run.\\nComparing memory usage with execution time highlights trade-offs: a backend may execute faster but consume more memory.\\nUse these metrics to choose a backend that fits both runtime and memory constraints."
+   ]
+  },
+  {
+   "cell_type": "code",
    "execution_count": 4,
    "id": "2f003844",
    "metadata": {


### PR DESCRIPTION
## Summary
- record peak memory per backend in comparison notebook
- plot runtime and memory usage together
- explain interpretation of memory metrics

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68bb000e136c8321b6317dae556b4bd2