### PR TITLE
Planner pre-pass cost comparison removes single-backend force heuristic

### DIFF
--- a/docs/small_circuit_heuristic.md
+++ b/docs/small_circuit_heuristic.md
@@ -1,11 +1,10 @@
 # Small circuit heuristic
 
-QuASAr's planner and scheduler expose a `force_single_backend_below` option
-that disables multi-backend partitioning for small circuits.  When set to an
-integer *N*, any circuit whose number of qubits **or** depth does not exceed *N*
-executes entirely on a single backend.  No conversion layers are inserted in
-this mode, even if the circuit is slightly larger than the quick-path limits.
+QuASAr performs a lightweight planning pre-pass that compares the
+estimated cost of executing a circuit on a single backend against a
+coarsely partitioned multi-backend plan.  If the single-backend
+estimate, including a small planning overhead, is cheaper the planner
+skips dynamic partitioning and executes the circuit as a single step.
 
-The setting is available through the `Planner` and `Scheduler` constructors and
-can also be configured via the `QUASAR_FORCE_SINGLE_BACKEND_BELOW` environment
-variable.
+This replaces the previous `force_single_backend_below` option and the
+`QUASAR_FORCE_SINGLE_BACKEND_BELOW` environment variable.

--- a/quasar/config.py
+++ b/quasar/config.py
@@ -61,7 +61,6 @@ class Config:
     quick_max_qubits: int | None = _int_from_env("QUASAR_QUICK_MAX_QUBITS", None)
     quick_max_gates: int | None = _int_from_env("QUASAR_QUICK_MAX_GATES", None)
     quick_max_depth: int | None = _int_from_env("QUASAR_QUICK_MAX_DEPTH", None)
-    force_single_backend_below: int | None = _int_from_env("QUASAR_FORCE_SINGLE_BACKEND_BELOW", None)
     preferred_backend_order: List[Backend] = field(
         default_factory=lambda: _order_from_env(
             "QUASAR_BACKEND_ORDER",

--- a/quasar/planner.py
+++ b/quasar/planner.py
@@ -320,9 +320,6 @@ class Planner:
         quick_max_qubits: int | None = config.DEFAULT.quick_max_qubits,
         quick_max_gates: int | None = config.DEFAULT.quick_max_gates,
         quick_max_depth: int | None = config.DEFAULT.quick_max_depth,
-        force_single_backend_below: (
-            int | None
-        ) = config.DEFAULT.force_single_backend_below,
         backend_order: Optional[List[Backend]] = None,
         conversion_cost_multiplier: float = 1.0,
     ):
@@ -357,11 +354,6 @@ class Planner:
             Factor applied to conversion time estimates.  Values greater than
             one discourage backend switches while values below one encourage
             them.  Defaults to ``1.0``.
-        force_single_backend_below:
-            If not ``None`` and either the circuit's qubit count or depth does
-            not exceed this value, planning returns a single step without
-            considering backend switches.  Defaults to
-            ``config.DEFAULT.force_single_backend_below``.
         """
 
         self.estimator = estimator or CostEstimator()
@@ -371,7 +363,6 @@ class Planner:
         self.quick_max_qubits = quick_max_qubits
         self.quick_max_gates = quick_max_gates
         self.quick_max_depth = quick_max_depth
-        self.force_single_backend_below = force_single_backend_below
         self.backend_order = (
             list(backend_order)
             if backend_order is not None
@@ -436,85 +427,6 @@ class Planner:
                 {init: DPEntry(cost=Cost(0.0, 0.0), prev_index=0, prev_backend=None)}
             ]
             return PlanResult(table=table, final_backend=init, gates=gates)
-
-        if self.force_single_backend_below is not None:
-            qubits = {q for g in gates for q in g.qubits}
-            num_qubits = len(qubits)
-            depth = _circuit_depth(gates)
-            if (
-                num_qubits <= self.force_single_backend_below
-                or depth <= self.force_single_backend_below
-            ):
-                num_meas = sum(
-                    1 for g in gates if g.gate.upper() in {"MEASURE", "RESET"}
-                )
-                num_1q = sum(
-                    1
-                    for g in gates
-                    if len(g.qubits) == 1 and g.gate.upper() not in {"MEASURE", "RESET"}
-                )
-                num_2q = len(gates) - num_1q - num_meas
-                if forced_backend is not None:
-                    backends = _supported_backends(
-                        gates,
-                        symmetry=symmetry,
-                        sparsity=sparsity,
-                        allow_tableau=allow_tableau,
-                        estimator=self.estimator,
-                        max_memory=max_memory,
-                    )
-                    if forced_backend not in backends:
-                        raise ValueError(
-                            f"Backend {forced_backend} unsupported for given circuit segment"
-                        )
-                    backend_choice = forced_backend
-                    cost = _simulation_cost(
-                        self.estimator,
-                        backend_choice,
-                        num_qubits,
-                        num_1q,
-                        num_2q,
-                        num_meas,
-                    )
-                    if max_memory is not None and cost.memory > max_memory:
-                        raise ValueError("Requested backend exceeds memory threshold")
-                    part = Partitioner()
-                    groups = part.parallel_groups(gates)
-                    parallel = tuple(g[0] for g in groups) if groups else ()
-                    step = PlanStep(
-                        start=0, end=n, backend=backend_choice, parallel=parallel
-                    )
-                    return PlanResult(
-                        table=[],
-                        final_backend=backend_choice,
-                        gates=gates,
-                        explicit_steps=[step],
-                        explicit_conversions=[],
-                    )
-                else:
-                    backend_choice, cost = self._single_backend(
-                        gates,
-                        max_memory,
-                        symmetry=symmetry,
-                        sparsity=sparsity,
-                        allow_tableau=allow_tableau,
-                    )
-                    if max_memory is not None and cost.memory > max_memory:
-                        pass  # fall through to full DP
-                    else:
-                        part = Partitioner()
-                        groups = part.parallel_groups(gates)
-                        parallel = tuple(g[0] for g in groups) if groups else ()
-                        step = PlanStep(
-                            start=0, end=n, backend=backend_choice, parallel=parallel
-                        )
-                        return PlanResult(
-                            table=[],
-                            final_backend=backend_choice,
-                            gates=gates,
-                            explicit_steps=[step],
-                            explicit_conversions=[],
-                        )
 
         # Pre-compute prefix and future qubit sets to derive boundary sizes.
         prefix_qubits: List[Set[int]] = [set() for _ in range(n + 1)]
@@ -932,33 +844,45 @@ class Planner:
                     self.cache_insert(gates, result, single_backend_choice)
                 return result
 
-        if self.force_single_backend_below is not None and (
-            num_qubits <= self.force_single_backend_below
-            or depth <= self.force_single_backend_below
+        # Lightweight pre-pass comparing single backend to coarse partitioning
+        pre_batch = max(1, len(gates) // 4)
+        pre = self._dp(
+            gates,
+            batch_size=pre_batch,
+            max_memory=threshold,
+            allow_tableau=allow_tableau,
+            symmetry=circuit.symmetry,
+            sparsity=circuit.sparsity,
+        )
+        pre_cost = (
+            pre.table[-1][pre.final_backend].cost if pre.table else Cost(0.0, 0.0)
+        )
+        overhead = Cost(time=len(gates) * 1e-6, memory=0.0)
+        if _better(single_cost, _add_cost(pre_cost, overhead)) and (
+            threshold is None or single_cost.memory <= threshold
         ):
-            if threshold is None or single_cost.memory <= threshold:
-                part = Partitioner()
-                groups = part.parallel_groups(gates)
-                parallel = tuple(g[0] for g in groups) if groups else ()
-                step = PlanStep(
-                    start=0,
-                    end=len(gates),
-                    backend=single_backend_choice,
-                    parallel=parallel,
-                )
-                result = PlanResult(
-                    table=[],
-                    final_backend=single_backend_choice,
-                    gates=gates,
-                    explicit_steps=[step],
-                    explicit_conversions=[],
-                )
-                circuit.ssd.conversions = []
-                if use_cache:
-                    self.cache_insert(gates, result, single_backend_choice)
-                return result
+            part = Partitioner()
+            groups = part.parallel_groups(gates)
+            parallel = tuple(g[0] for g in groups) if groups else ()
+            step = PlanStep(
+                start=0,
+                end=len(gates),
+                backend=single_backend_choice,
+                parallel=parallel,
+            )
+            result = PlanResult(
+                table=[],
+                final_backend=single_backend_choice,
+                gates=gates,
+                explicit_steps=[step],
+                explicit_conversions=[],
+            )
+            circuit.ssd.conversions = []
+            if use_cache:
+                self.cache_insert(gates, result, single_backend_choice)
+            return result
 
-        # First perform a coarse plan using the configured batch size.
+        # Perform a coarse plan using the configured batch size for refinement
         coarse = self._dp(
             gates,
             batch_size=self.batch_size,

--- a/quasar/scheduler.py
+++ b/quasar/scheduler.py
@@ -36,7 +36,6 @@ class Scheduler:
     quick_max_qubits: int | None = config.DEFAULT.quick_max_qubits
     quick_max_gates: int | None = config.DEFAULT.quick_max_gates
     quick_max_depth: int | None = config.DEFAULT.quick_max_depth
-    force_single_backend_below: int | None = config.DEFAULT.force_single_backend_below
     backend_order: List[Backend] = field(
         default_factory=lambda: list(config.DEFAULT.preferred_backend_order)
     )
@@ -214,7 +213,6 @@ class Scheduler:
                 quick_max_qubits=self.quick_max_qubits,
                 quick_max_gates=self.quick_max_gates,
                 quick_max_depth=self.quick_max_depth,
-                force_single_backend_below=self.force_single_backend_below,
                 backend_order=self.backend_order,
             )
         if self.conversion_engine is None:

--- a/tests/test_planner.py
+++ b/tests/test_planner.py
@@ -99,22 +99,3 @@ def test_conversion_cost_multiplier_discourages_switch():
     )
     steps2 = penalized.plan(circ).steps
     assert all(s.backend == Backend.STATEVECTOR for s in steps2)
-
-
-def test_force_single_backend_below():
-    gates = [
-        {"gate": "H", "qubits": [0]},
-        {"gate": "CX", "qubits": [0, 1]},
-        {"gate": "CX", "qubits": [1, 2]},
-        {"gate": "CX", "qubits": [2, 3]},
-    ]
-    circ = Circuit.from_dict(gates)
-    planner = Planner(
-        quick_max_qubits=3,
-        quick_max_gates=100,
-        quick_max_depth=3,
-        force_single_backend_below=5,
-    )
-    result = planner.plan(circ)
-    assert len(result.steps) == 1
-    assert circ.ssd.conversions == []

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -610,23 +610,3 @@ def test_runtime_excludes_planning_overhead():
 
     assert prepare_duration >= 0.1
     assert run_duration < 0.1
-
-
-def test_scheduler_force_single_backend_below():
-    circuit = Circuit([
-        {"gate": "H", "qubits": [0]},
-        {"gate": "CX", "qubits": [0, 1]},
-        {"gate": "CX", "qubits": [1, 2]},
-        {"gate": "CX", "qubits": [2, 3]},
-    ])
-    scheduler = Scheduler(
-        quick_max_qubits=3,
-        quick_max_gates=100,
-        quick_max_depth=3,
-        force_single_backend_below=5,
-    )
-    plan = scheduler.prepare_run(circuit)
-    assert len(plan.steps) == 1
-    assert plan.conversions == []
-    result = scheduler.run(circuit, plan)
-    assert result.conversions == []

--- a/tests/test_scheduler_no_partition.py
+++ b/tests/test_scheduler_no_partition.py
@@ -73,20 +73,6 @@ def test_random_two_qubit_circuit_single_partition():
     assert len({p.backend for p in result.ssd.partitions}) == 1
 
 
-def test_ten_qubit_circuit_single_partition():
-    """A 10-qubit chain should remain a single partition after planning."""
-    qc = QuantumCircuit(10)
-    for i in range(9):
-        qc.cx(i, i + 1)
-    circuit = Circuit.from_qiskit(qc)
-    scheduler = Scheduler(quick_max_qubits=None, force_single_backend_below=12)
-    plan = scheduler.prepare_run(circuit)
-    ssd = scheduler.run(circuit, plan)
-    backends = {p.backend for p in ssd.partitions}
-    assert backends == {Backend.TABLEAU}
-    assert not ssd.conversions
-
-
 def test_fifteen_qubit_circuit_single_backend():
     qc = QuantumCircuit(15)
     for i in range(14):


### PR DESCRIPTION
## Summary
- Drop `force_single_backend_below` configuration and related planner/scheduler arguments
- Use a lightweight planning pre-pass to compare single-backend and partitioned costs, falling back to a single backend only when cheaper
- Update small-circuit heuristic documentation

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68bbf02fef448321aed40a4695d2b578