### PR TITLE
Cap MPS bond dimension using memory and fidelity

### DIFF
--- a/docs/backend_selection.md
+++ b/docs/backend_selection.md
@@ -15,9 +15,10 @@ examines basic structural metrics to guide this choice:
 3. **Entanglement heuristic** – an upper bound on the maximal Schmidt rank is
    derived from the gate sequence.  This estimate combines with the fidelity
    target ``mps_target_fidelity`` (default ``1.0`` and overrideable via
-   ``QUASAR_MPS_TARGET_FIDELITY``) to determine the bond dimension ``χ``
-   required for matrix‑product state simulation.  The MPS backend is only
-   considered when this derived ``χ`` fits within the available memory.
+   ``QUASAR_MPS_TARGET_FIDELITY``) to determine the bond dimension ``χ`` for
+   matrix‑product state simulation.  The resulting ``χ`` is further capped by
+   the memory threshold supplied to the planner; if even ``χ = 1`` exceeds the
+   available memory the MPS backend is skipped.
 4. **Fallback** – remaining candidates such as the dense STATEVECTOR simulator
    are considered based on estimated runtime and memory cost.
 

--- a/quasar/planner.py
+++ b/quasar/planner.py
@@ -765,14 +765,10 @@ class Planner:
 
         if self.estimator is not None:
             fidelity = config.DEFAULT.mps_target_fidelity
-            chi_cap = self.estimator.chi_for_fidelity(num_qubits, gates, fidelity)
-            if chi_cap > 0:
-                mps_cost = self.estimator.mps(
-                    num_qubits, num_1q + num_meas, num_2q, chi_cap
-                )
-                if threshold is not None and mps_cost.memory > threshold:
-                    chi_cap = None
-            self.estimator.chi_max = chi_cap
+            chi_cap = self.estimator.chi_for_constraints(
+                num_qubits, gates, fidelity, threshold
+            )
+            self.estimator.chi_max = chi_cap if chi_cap > 0 else None
 
         if backend is not None:
             # Allow explicitly requested backends as long as they can simulate the

--- a/tests/test_backend_selection.py
+++ b/tests/test_backend_selection.py
@@ -46,3 +46,18 @@ def test_mps_target_fidelity_controls_selection(monkeypatch):
     monkeypatch.setattr(config.DEFAULT, "mps_target_fidelity", 0.9)
     plan = engine.planner.plan(circuit, max_memory=26000, use_cache=False)
     assert plan.final_backend == Backend.MPS
+
+
+def test_memory_threshold_limits_mps(monkeypatch):
+    circuit = qft_circuit(5)
+    circuit.symmetry = 0.0
+    circuit.sparsity = 0.0
+    est = CostEstimator(coeff={"sv_gate_1q": 50.0, "sv_gate_2q": 50.0})
+    engine = SimulationEngine(estimator=est)
+
+    monkeypatch.setattr(config.DEFAULT, "mps_target_fidelity", 0.9)
+    plan = engine.planner.plan(circuit, max_memory=1000, use_cache=False)
+    assert plan.final_backend == Backend.MPS
+
+    plan = engine.planner.plan(circuit, max_memory=4, use_cache=False)
+    assert Backend.MPS not in {s.backend for s in plan.steps}


### PR DESCRIPTION
## Summary
- derive MPS bond dimension from fidelity and available memory
- update planner and docs to use memory-aware χ cap
- cover new behaviour with tests

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68bbdfe275c88321bef280747153da76