### PR TITLE
feat: penalise decision diagrams for diverse phase rotations

### DIFF
--- a/docs/backend_selection.md
+++ b/docs/backend_selection.md
@@ -6,12 +6,15 @@ examines basic structural metrics to guide this choice:
 1. **Clifford detection** – if all gates in a fragment are Clifford operations
    the specialised TABLEAU backend is used exclusively, bypassing other
    candidates.
-2. **Heuristic metrics** – overall circuit [symmetry](symmetry.md) and
-   [sparsity](sparsity.md) scores are combined into a weighted sum.  When this
-   weighted score exceeds the ``dd_metric_threshold`` the planner includes the
-   decision‑diagram backend as a candidate.  The weights
-   ``dd_symmetry_weight`` and ``dd_sparsity_weight`` control each metric's
-   contribution.
+2. **Heuristic metrics** – overall circuit [symmetry](symmetry.md),
+   [sparsity](sparsity.md) and *rotation diversity* are consulted.  Symmetry and
+   sparsity form a weighted sum; when this exceeds ``dd_metric_threshold`` and
+   the number of distinct phase rotations stays below
+   ``dd_rotation_diversity_threshold`` the planner includes the decision‑diagram
+   backend as a candidate.  The weights ``dd_symmetry_weight`` and
+   ``dd_sparsity_weight`` control each metric's contribution.  Decision diagrams
+   benefit from repeated phase angles; circuits with highly diverse rotations
+   tend to blow up the decision structure, hence the diversity guard.
 3. **Entanglement heuristic** – an upper bound on the maximal Schmidt rank is
    derived from the gate sequence.  This estimate combines with the fidelity
    target ``mps_target_fidelity`` (default ``1.0`` and overrideable via
@@ -22,13 +25,15 @@ examines basic structural metrics to guide this choice:
 4. **Fallback** – remaining candidates such as the dense STATEVECTOR simulator
    are considered based on estimated runtime and memory cost.
 
-The weights and threshold of step 2 default to ``1.0`` for both symmetry and
-sparsity with a ``dd_metric_threshold`` of ``0.8``.  They may be tuned via the
-``QUASAR_DD_SYMMETRY_WEIGHT``, ``QUASAR_DD_SPARSITY_WEIGHT`` and
-``QUASAR_DD_METRIC_THRESHOLD`` environment variables or by overriding
-``config.DEFAULT`` at runtime.  Lowering ``mps_target_fidelity`` reduces the
-required bond dimension and can therefore make the MPS backend applicable to
-more circuits.
+The weights and thresholds of step 2 default to ``1.0`` for both symmetry and
+sparsity with a ``dd_metric_threshold`` of ``0.8`` and a
+``dd_rotation_diversity_threshold`` of ``16`` distinct phase angles.  They may
+be tuned via the ``QUASAR_DD_SYMMETRY_WEIGHT``, ``QUASAR_DD_SPARSITY_WEIGHT``,
+``QUASAR_DD_METRIC_THRESHOLD`` and
+``QUASAR_DD_ROTATION_DIVERSITY_THRESHOLD`` environment variables or by
+overriding ``config.DEFAULT`` at runtime.  Lowering ``mps_target_fidelity``
+reduces the required bond dimension and can therefore make the MPS backend
+applicable to more circuits.
 
 This lightweight heuristic steers the planner towards specialised backends for
 circuits exhibiting repeated structure, large zero‑amplitude regions or limited

--- a/quasar/circuit.py
+++ b/quasar/circuit.py
@@ -50,8 +50,9 @@ class Circuit:
         self.cost_estimates = self._estimate_costs()
         from .sparsity import sparsity_estimate
         self.sparsity = sparsity_estimate(self)
-        from .symmetry import symmetry_score
+        from .symmetry import symmetry_score, rotation_diversity
         self.symmetry = symmetry_score(self)
+        self.rotation_diversity = rotation_diversity(self)
 
     # ------------------------------------------------------------------
     # Construction helpers

--- a/quasar/config.py
+++ b/quasar/config.py
@@ -91,6 +91,9 @@ class Config:
     dd_metric_threshold: float = _float_from_env(
         "QUASAR_DD_METRIC_THRESHOLD", 0.8
     )
+    dd_rotation_diversity_threshold: int = _int_from_env(
+        "QUASAR_DD_ROTATION_DIVERSITY_THRESHOLD", 16
+    )
 
 
 # Global configuration instance used when modules import ``quasar.config``.

--- a/quasar/partitioner.py
+++ b/quasar/partitioner.py
@@ -58,11 +58,14 @@ class Partitioner:
 
         symmetry = getattr(circuit, "symmetry", None)
         sparsity = getattr(circuit, "sparsity", None)
+        rotation = getattr(circuit, "rotation_diversity", None)
         dd_metric = False
         if symmetry is not None and symmetry >= config.DEFAULT.dd_symmetry_threshold:
             dd_metric = True
         if sparsity is not None and sparsity >= config.DEFAULT.dd_sparsity_threshold:
             dd_metric = True
+        if rotation is not None and rotation > config.DEFAULT.dd_rotation_diversity_threshold:
+            dd_metric = False
 
         for idx, gate in enumerate(gates):
             trial_gates = current_gates + [gate]

--- a/quasar/scheduler.py
+++ b/quasar/scheduler.py
@@ -138,19 +138,24 @@ class Scheduler:
 
         symmetry = getattr(circuit, "symmetry", None)
         sparsity = getattr(circuit, "sparsity", None)
-        if symmetry is None or sparsity is None:
-            from .symmetry import symmetry_score
+        rotation = getattr(circuit, "rotation_diversity", None)
+        if symmetry is None or sparsity is None or rotation is None:
+            from .symmetry import symmetry_score, rotation_diversity
             from .sparsity import sparsity_estimate
 
             if symmetry is None:
                 symmetry = symmetry_score(circuit)
             if sparsity is None:
                 sparsity = sparsity_estimate(circuit)
+            if rotation is None:
+                rotation = rotation_diversity(circuit)
 
         dd_metric = (
             symmetry >= config.DEFAULT.dd_symmetry_threshold
             or sparsity >= config.DEFAULT.dd_sparsity_threshold
         )
+        if rotation is not None and rotation > config.DEFAULT.dd_rotation_diversity_threshold:
+            dd_metric = False
 
         multi = [g for g in circuit.gates if len(g.qubits) > 1]
         local = multi and all(

--- a/tests/test_backend_selection.py
+++ b/tests/test_backend_selection.py
@@ -61,3 +61,15 @@ def test_memory_threshold_limits_mps(monkeypatch):
 
     plan = engine.planner.plan(circuit, max_memory=4, use_cache=False)
     assert Backend.MPS not in {s.backend for s in plan.steps}
+
+
+def test_rotation_diversity_discourages_dd(monkeypatch):
+    circuit = qft_circuit(5)
+    monkeypatch.setattr(config.DEFAULT, "dd_symmetry_weight", 2.0)
+    monkeypatch.setattr(config.DEFAULT, "dd_sparsity_weight", 0.0)
+    monkeypatch.setattr(config.DEFAULT, "dd_metric_threshold", 0.5)
+    monkeypatch.setattr(config.DEFAULT, "dd_rotation_diversity_threshold", 3)
+    engine = SimulationEngine()
+    plan = engine.planner.plan(circuit)
+    assert plan.final_backend == Backend.STATEVECTOR
+    assert Backend.DECISION_DIAGRAM not in {s.backend for s in plan.steps}

--- a/tests/test_backend_symmetry_sparsity.py
+++ b/tests/test_backend_symmetry_sparsity.py
@@ -29,6 +29,19 @@ def test_qft_selects_decision_diagram_via_symmetry(monkeypatch):
     assert part.backend == Backend.DECISION_DIAGRAM
 
 
+def test_qft_rotation_diversity_suppresses_dd(monkeypatch):
+    circ = qft_circuit(5)
+    assert circ.rotation_diversity > 3
+    monkeypatch.setattr(config.DEFAULT, "dd_symmetry_weight", 2.0)
+    monkeypatch.setattr(config.DEFAULT, "dd_sparsity_weight", 0.0)
+    monkeypatch.setattr(config.DEFAULT, "dd_metric_threshold", 0.5)
+    monkeypatch.setattr(config.DEFAULT, "dd_rotation_diversity_threshold", 3)
+    scheduler = Scheduler()
+    scheduler.prepare_run(circ)
+    part = circ.ssd.partitions[0]
+    assert part.backend == Backend.STATEVECTOR
+
+
 def test_random_circuit_stays_statevector_when_metrics_low():
     circ = random_circuit(5, seed=123)
     assert circ.sparsity < DEFAULT.dd_sparsity_threshold

--- a/tests/test_supported_backends_dd.py
+++ b/tests/test_supported_backends_dd.py
@@ -1,4 +1,4 @@
-from benchmarks.circuits import random_circuit, w_state_circuit
+from benchmarks.circuits import random_circuit, w_state_circuit, qft_circuit
 from quasar.cost import Backend
 from quasar.planner import _supported_backends
 
@@ -15,5 +15,16 @@ def test_supported_backends_random_excludes_dd():
     circ = random_circuit(5, seed=123)
     backends = _supported_backends(
         circ.gates, symmetry=circ.symmetry, sparsity=circ.sparsity
+    )
+    assert Backend.DECISION_DIAGRAM not in backends
+
+
+def test_supported_backends_qft_rotation_diversity():
+    circ = qft_circuit(5)
+    backends = _supported_backends(
+        circ.gates,
+        symmetry=circ.symmetry,
+        sparsity=circ.sparsity,
+        rotation_diversity=circ.rotation_diversity,
     )
     assert Backend.DECISION_DIAGRAM not in backends

--- a/tests/test_symmetry.py
+++ b/tests/test_symmetry.py
@@ -11,3 +11,7 @@ def test_w_state_symmetry_high():
 
 def test_random_circuit_symmetry_low():
     assert random_circuit(5, seed=123).symmetry < 0.05
+
+
+def test_qft_rotation_diversity_count():
+    assert qft_circuit(5).rotation_diversity == 4


### PR DESCRIPTION
## Summary
- add `rotation_diversity` metric counting distinct phase rotations
- avoid decision-diagram backends when rotation diversity is high
- document rotation-diversity heuristic and config knob

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68bc0e0d1ae48321811025f097cf0ec9