### PR TITLE
Refine decision diagram backend selection scoring

### DIFF
--- a/docs/sparsity.md
+++ b/docs/sparsity.md
@@ -28,11 +28,10 @@ grows.
 controlled-phase rotations that drive `nnz` to `2**n`, producing a sparsity of
 `0`—a maximally dense state.
 
-The planner combines the sparsity score with overall circuit symmetry to
-derive a weighted decision-diagram metric.  The weights
-``dd_sparsity_weight`` and ``dd_symmetry_weight`` along with the
-``dd_metric_threshold`` determine when the decision-diagram backend is
-considered.  These values may be overridden via the environment variables
-``QUASAR_DD_SPARSITY_WEIGHT``, ``QUASAR_DD_SYMMETRY_WEIGHT`` and
-``QUASAR_DD_METRIC_THRESHOLD``.
+The planner combines the sparsity score with an estimate of the number of
+non-zero amplitudes to form part of the decision-diagram metric.  Weights
+``dd_sparsity_weight`` and ``dd_nnz_weight``—together with
+``dd_rotation_weight`` and ``dd_metric_threshold``—determine when the
+decision-diagram backend is considered.  These values may be overridden via
+the ``QUASAR_DD_*`` environment variables.
 

--- a/quasar/config.py
+++ b/quasar/config.py
@@ -76,17 +76,20 @@ class Config:
     mps_target_fidelity: float = _float_from_env(
         "QUASAR_MPS_TARGET_FIDELITY", 1.0
     )
-    dd_symmetry_threshold: float = _float_from_env(
-        "QUASAR_DD_SYMMETRY_THRESHOLD", 0.3
-    )
     dd_sparsity_threshold: float = _float_from_env(
         "QUASAR_DD_SPARSITY_THRESHOLD", 0.8
     )
-    dd_symmetry_weight: float = _float_from_env(
-        "QUASAR_DD_SYMMETRY_WEIGHT", 1.0
+    dd_nnz_threshold: int = _int_from_env(
+        "QUASAR_DD_NNZ_THRESHOLD", 1_000_000
     )
     dd_sparsity_weight: float = _float_from_env(
         "QUASAR_DD_SPARSITY_WEIGHT", 1.0
+    )
+    dd_nnz_weight: float = _float_from_env(
+        "QUASAR_DD_NNZ_WEIGHT", 1.0
+    )
+    dd_rotation_weight: float = _float_from_env(
+        "QUASAR_DD_ROTATION_WEIGHT", 1.0
     )
     dd_metric_threshold: float = _float_from_env(
         "QUASAR_DD_METRIC_THRESHOLD", 0.8

--- a/quasar/sparsity.py
+++ b/quasar/sparsity.py
@@ -1,10 +1,26 @@
 """Heuristics for estimating circuit sparsity."""
-
 from __future__ import annotations
 
 from .circuit import Circuit, Gate
+from . import config
 
 BRANCHING_GATES = {"H", "RY", "RX", "U", "U2", "U3"}
+
+
+def adaptive_dd_sparsity_threshold(n_qubits: int) -> float:
+    """Return the sparsity threshold required for DD simulation.
+
+    The base threshold ``config.DEFAULT.dd_sparsity_threshold`` is gradually
+    relaxed for larger circuits to maintain comparability with dense
+    backends.  This simple heuristic avoids demanding unrealistically high
+    sparsity on wide circuits where dense simulation is already expensive.
+    """
+
+    base = config.DEFAULT.dd_sparsity_threshold
+    if n_qubits <= 10:
+        return base
+    # Linear relaxation beyond 10 qubits, clamped at zero.
+    return max(0.0, base - 0.01 * (n_qubits - 10))
 
 
 def is_controlled(gate: Gate) -> bool:

--- a/tests/test_backend_selection.py
+++ b/tests/test_backend_selection.py
@@ -1,5 +1,6 @@
 from benchmarks.circuits import ghz_circuit, qft_circuit, w_state_circuit
-from quasar import Backend, CostEstimator, SimulationEngine
+from quasar import Backend, SimulationEngine
+from quasar.cost import CostEstimator
 import quasar.config as config
 
 
@@ -24,7 +25,6 @@ def test_planner_selects_mps_for_qft():
 
 def test_planner_selects_dd_when_sparsity_weighted(monkeypatch):
     circuit = w_state_circuit(5)
-    monkeypatch.setattr(config.DEFAULT, "dd_symmetry_weight", 0.0)
     monkeypatch.setattr(config.DEFAULT, "dd_sparsity_weight", 1.2)
     monkeypatch.setattr(config.DEFAULT, "dd_metric_threshold", 0.9)
     engine = SimulationEngine()
@@ -65,11 +65,11 @@ def test_memory_threshold_limits_mps(monkeypatch):
 
 def test_rotation_diversity_discourages_dd(monkeypatch):
     circuit = qft_circuit(5)
-    monkeypatch.setattr(config.DEFAULT, "dd_symmetry_weight", 2.0)
-    monkeypatch.setattr(config.DEFAULT, "dd_sparsity_weight", 0.0)
-    monkeypatch.setattr(config.DEFAULT, "dd_metric_threshold", 0.5)
+    monkeypatch.setattr(config.DEFAULT, "dd_sparsity_threshold", 0.0)
+    monkeypatch.setattr(config.DEFAULT, "dd_nnz_threshold", 10_000_000)
     monkeypatch.setattr(config.DEFAULT, "dd_rotation_diversity_threshold", 3)
     engine = SimulationEngine()
     plan = engine.planner.plan(circuit)
     assert plan.final_backend == Backend.STATEVECTOR
     assert Backend.DECISION_DIAGRAM not in {s.backend for s in plan.steps}
+

--- a/tests/test_backend_symmetry_sparsity.py
+++ b/tests/test_backend_symmetry_sparsity.py
@@ -9,33 +9,28 @@ from quasar.config import DEFAULT
 def test_w_state_selects_decision_diagram_via_sparsity():
     circ = w_state_circuit(5)
     assert circ.sparsity >= DEFAULT.dd_sparsity_threshold
-    assert circ.symmetry < DEFAULT.dd_symmetry_threshold
     scheduler = Scheduler()
     scheduler.prepare_run(circ)
     part = circ.ssd.partitions[0]
     assert part.backend == Backend.DECISION_DIAGRAM
 
 
-def test_qft_selects_decision_diagram_via_symmetry(monkeypatch):
+def test_high_rotation_diversity_stays_dense(monkeypatch):
     circ = qft_circuit(5)
-    assert circ.symmetry >= DEFAULT.dd_symmetry_threshold
-    assert circ.sparsity < DEFAULT.dd_sparsity_threshold
-    monkeypatch.setattr(config.DEFAULT, "dd_symmetry_weight", 2.0)
-    monkeypatch.setattr(config.DEFAULT, "dd_sparsity_weight", 0.0)
-    monkeypatch.setattr(config.DEFAULT, "dd_metric_threshold", 0.5)
-    scheduler = Scheduler()
-    scheduler.prepare_run(circ)
-    part = circ.ssd.partitions[0]
-    assert part.backend == Backend.DECISION_DIAGRAM
-
-
-def test_qft_rotation_diversity_suppresses_dd(monkeypatch):
-    circ = qft_circuit(5)
-    assert circ.rotation_diversity > 3
-    monkeypatch.setattr(config.DEFAULT, "dd_symmetry_weight", 2.0)
-    monkeypatch.setattr(config.DEFAULT, "dd_sparsity_weight", 0.0)
-    monkeypatch.setattr(config.DEFAULT, "dd_metric_threshold", 0.5)
+    monkeypatch.setattr(config.DEFAULT, "dd_sparsity_threshold", 0.0)
+    monkeypatch.setattr(config.DEFAULT, "dd_nnz_threshold", 10_000_000)
     monkeypatch.setattr(config.DEFAULT, "dd_rotation_diversity_threshold", 3)
+    scheduler = Scheduler()
+    scheduler.prepare_run(circ)
+    part = circ.ssd.partitions[0]
+    assert part.backend == Backend.STATEVECTOR
+
+
+def test_high_nnz_stays_dense(monkeypatch):
+    circ = qft_circuit(5)
+    monkeypatch.setattr(config.DEFAULT, "dd_sparsity_threshold", 0.0)
+    monkeypatch.setattr(config.DEFAULT, "dd_nnz_threshold", 1)
+    monkeypatch.setattr(config.DEFAULT, "dd_rotation_diversity_threshold", 1000)
     scheduler = Scheduler()
     scheduler.prepare_run(circ)
     part = circ.ssd.partitions[0]
@@ -45,7 +40,6 @@ def test_qft_rotation_diversity_suppresses_dd(monkeypatch):
 def test_random_circuit_stays_statevector_when_metrics_low():
     circ = random_circuit(5, seed=123)
     assert circ.sparsity < DEFAULT.dd_sparsity_threshold
-    assert circ.symmetry < DEFAULT.dd_symmetry_threshold
     scheduler = Scheduler()
     scheduler.prepare_run(circ)
     part = circ.ssd.partitions[0]

--- a/tests/test_conversion_layers.py
+++ b/tests/test_conversion_layers.py
@@ -1,7 +1,12 @@
 from quasar import Circuit, Partitioner, Backend
+import quasar.config as config
 
 
-def test_conversion_layer_inserted():
+def test_conversion_layer_inserted(monkeypatch):
+    monkeypatch.setattr(config.DEFAULT, "dd_sparsity_threshold", 0.0)
+    monkeypatch.setattr(config.DEFAULT, "dd_nnz_threshold", 10_000_000)
+    monkeypatch.setattr(config.DEFAULT, "dd_rotation_diversity_threshold", 1000)
+    monkeypatch.setattr(config.DEFAULT, "dd_metric_threshold", 0.0)
     # Construct a circuit that starts Clifford-only and then introduces
     # non-Clifford gates on the same qubits, forcing a backend switch and
     # a conversion layer. The circuit size is deliberately large to ensure

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -263,7 +263,6 @@ class SleepBackend:
 def test_parallel_execution_on_independent_subcircuits(monkeypatch):
     import quasar.config as config
 
-    monkeypatch.setattr(config.DEFAULT, "dd_symmetry_threshold", 2.0)
     monkeypatch.setattr(config.DEFAULT, "dd_sparsity_threshold", 2.0)
     monkeypatch.setattr(config.DEFAULT, "dd_metric_threshold", 2.0)
 

--- a/tests/test_supported_backends_dd.py
+++ b/tests/test_supported_backends_dd.py
@@ -5,17 +5,13 @@ from quasar.planner import _supported_backends
 
 def test_supported_backends_sparse_adds_dd():
     circ = w_state_circuit(5)
-    backends = _supported_backends(
-        circ.gates, symmetry=circ.symmetry, sparsity=circ.sparsity
-    )
+    backends = _supported_backends(circ.gates, sparsity=circ.sparsity)
     assert Backend.DECISION_DIAGRAM in backends
 
 
 def test_supported_backends_random_excludes_dd():
     circ = random_circuit(5, seed=123)
-    backends = _supported_backends(
-        circ.gates, symmetry=circ.symmetry, sparsity=circ.sparsity
-    )
+    backends = _supported_backends(circ.gates, sparsity=circ.sparsity)
     assert Backend.DECISION_DIAGRAM not in backends
 
 
@@ -23,7 +19,6 @@ def test_supported_backends_qft_rotation_diversity():
     circ = qft_circuit(5)
     backends = _supported_backends(
         circ.gates,
-        symmetry=circ.symmetry,
         sparsity=circ.sparsity,
         rotation_diversity=circ.rotation_diversity,
     )


### PR DESCRIPTION
## Summary
- gate DD backend selection on sparsity, nonzero-estimate and rotation diversity
- weight metrics (sparsity, nnz, rotation) and require combined score over `dd_metric_threshold`
- document new scoring formula and expose configurable weights
- ensure circuits violating nnz or rotation limits stay on dense backends

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68bc1207418483218e846a58faedfdda