### PR TITLE
Track and simplify classical controls

### DIFF
--- a/tests/test_circuit.py
+++ b/tests/test_circuit.py
@@ -1,4 +1,5 @@
 import json
+import math
 
 from quasar import Circuit, SSD
 
@@ -41,3 +42,32 @@ def test_sparsity_attribute():
         {"gate": "X", "qubits": [1]},
     ])
     assert circ.sparsity == 0.5
+
+
+def test_classical_gate_simplification():
+    circ = Circuit.from_dict([
+        {"gate": "X", "qubits": [0]},
+        {"gate": "Z", "qubits": [0]},
+        {"gate": "H", "qubits": [0]},
+        {"gate": "X", "qubits": [0]},
+    ])
+    assert [g.gate for g in circ.gates] == ["H", "X"]
+    assert circ.classical_state == [None]
+
+
+def test_controlled_classical_simplification():
+    circ = Circuit.from_dict([
+        {"gate": "X", "qubits": [0]},
+        {"gate": "CX", "qubits": [0, 1]},
+    ])
+    assert circ.gates == []
+    assert circ.classical_state == [1, 1]
+
+
+def test_rx_branching():
+    circ = Circuit.from_dict([
+        {"gate": "RX", "qubits": [0], "params": {"param0": math.pi}},
+        {"gate": "RX", "qubits": [1], "params": {"param0": math.pi / 2}},
+    ])
+    assert [g.gate for g in circ.gates] == ["RX"]
+    assert circ.classical_state == [1, None]

--- a/tests/test_cost.py
+++ b/tests/test_cost.py
@@ -183,6 +183,8 @@ def test_st_chi_cap_override():
 
 def test_max_schmidt_rank_and_entropy():
     gates = [
+        Gate("H", [0]),
+        Gate("H", [1]),
         Gate("CX", [0, 2]),
         Gate("CX", [1, 3]),
     ]

--- a/tests/test_method_selection.py
+++ b/tests/test_method_selection.py
@@ -22,15 +22,17 @@ def test_clifford_tableau_selection():
 
 def test_small_statevector_selection():
     gates = [
+        {"gate": "H", "qubits": [0]},
         {"gate": "T", "qubits": [0]},
         {"gate": "CX", "qubits": [0, 1]},
+        {"gate": "H", "qubits": [1]},
         {"gate": "T", "qubits": [1]},
         {"gate": "CX", "qubits": [1, 2]},
     ]
     circ = Circuit.from_dict(gates)
     _prepare(circ)
     part = circ.ssd.partitions[0]
-    assert part.backend == Backend.DECISION_DIAGRAM
+    assert part.backend == Backend.STATEVECTOR
 
 
 def test_sparse_dd_selection():

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -267,10 +267,10 @@ def test_parallel_execution_on_independent_subcircuits(monkeypatch):
     monkeypatch.setattr(config.DEFAULT, "dd_metric_threshold", 2.0)
 
     circuit = Circuit([
-        {"gate": "T", "qubits": [0]},
-        {"gate": "T", "qubits": [1]},
         {"gate": "H", "qubits": [0]},
+        {"gate": "T", "qubits": [0]},
         {"gate": "H", "qubits": [1]},
+        {"gate": "T", "qubits": [1]},
     ])
     scheduler_p = Scheduler(
         backends={Backend.STATEVECTOR: SleepBackend()},

--- a/tests/test_scheduler_no_partition.py
+++ b/tests/test_scheduler_no_partition.py
@@ -75,6 +75,7 @@ def test_random_two_qubit_circuit_single_partition():
 
 def test_fifteen_qubit_circuit_single_backend():
     qc = QuantumCircuit(15)
+    qc.h(0)
     for i in range(14):
         qc.cx(i, i + 1)
     circuit = Circuit.from_qiskit(qc)


### PR DESCRIPTION
## Summary
- maintain `classical_state` of qubits and simplify gates based on known classical bits
- add pass to trim classically-controlled gates in Circuit construction
- adjust tests for updated simplification logic and scheduler behaviour

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68bc23fccf4083219cdf4f618767c42e