### PR TITLE
Add classical-control simplification pass and integrate with scheduler

### DIFF
--- a/tests/test_backend_symmetry_sparsity.py
+++ b/tests/test_backend_symmetry_sparsity.py
@@ -17,6 +17,7 @@ def test_w_state_selects_decision_diagram_via_sparsity():
 
 def test_high_rotation_diversity_stays_dense(monkeypatch):
     circ = qft_circuit(5)
+    circ.classical_state = [None] * circ.num_qubits
     monkeypatch.setattr(config.DEFAULT, "dd_sparsity_threshold", 0.0)
     monkeypatch.setattr(config.DEFAULT, "dd_nnz_threshold", 10_000_000)
     monkeypatch.setattr(config.DEFAULT, "dd_rotation_diversity_threshold", 3)
@@ -28,6 +29,7 @@ def test_high_rotation_diversity_stays_dense(monkeypatch):
 
 def test_high_nnz_stays_dense(monkeypatch):
     circ = qft_circuit(5)
+    circ.classical_state = [None] * circ.num_qubits
     monkeypatch.setattr(config.DEFAULT, "dd_sparsity_threshold", 0.0)
     monkeypatch.setattr(config.DEFAULT, "dd_nnz_threshold", 1)
     monkeypatch.setattr(config.DEFAULT, "dd_rotation_diversity_threshold", 1000)

--- a/tests/test_circuit.py
+++ b/tests/test_circuit.py
@@ -51,6 +51,7 @@ def test_classical_gate_simplification():
         {"gate": "H", "qubits": [0]},
         {"gate": "X", "qubits": [0]},
     ])
+    circ.simplify_classical_controls()
     assert [g.gate for g in circ.gates] == ["H", "X"]
     assert circ.classical_state == [None]
 
@@ -60,8 +61,39 @@ def test_controlled_classical_simplification():
         {"gate": "X", "qubits": [0]},
         {"gate": "CX", "qubits": [0, 1]},
     ])
+    circ.simplify_classical_controls()
     assert circ.gates == []
     assert circ.classical_state == [1, 1]
+
+
+def test_controlled_gate_dropped_when_control_zero():
+    circ = Circuit.from_dict([
+        {"gate": "CX", "qubits": [0, 1]},
+    ])
+    circ.simplify_classical_controls()
+    assert circ.gates == []
+    assert circ.classical_state == [0, 0]
+
+
+def test_controlled_gate_with_quantum_control_kept():
+    circ = Circuit.from_dict([
+        {"gate": "H", "qubits": [0]},
+        {"gate": "CX", "qubits": [0, 1]},
+    ])
+    circ.simplify_classical_controls()
+    assert [g.gate for g in circ.gates] == ["H", "CX"]
+    assert circ.classical_state == [None, None]
+
+
+def test_multi_controlled_classical_simplification():
+    circ = Circuit.from_dict([
+        {"gate": "X", "qubits": [0]},
+        {"gate": "X", "qubits": [1]},
+        {"gate": "CCX", "qubits": [0, 1, 2]},
+    ])
+    circ.simplify_classical_controls()
+    assert circ.gates == []
+    assert circ.classical_state == [1, 1, 1]
 
 
 def test_rx_branching():
@@ -69,5 +101,6 @@ def test_rx_branching():
         {"gate": "RX", "qubits": [0], "params": {"param0": math.pi}},
         {"gate": "RX", "qubits": [1], "params": {"param0": math.pi / 2}},
     ])
+    circ.simplify_classical_controls()
     assert [g.gate for g in circ.gates] == ["RX"]
     assert circ.classical_state == [1, None]


### PR DESCRIPTION
## Summary
- Simplify gates with classical controls, dropping gates on all-zero controls and reducing those with all-one controls to single-qubit operations
- Run classical-control simplification within Scheduler.prepare_run and Scheduler.run to operate on optimized gate lists
- Adjust tests for explicit simplification usage and preserve dense circuit heuristics

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68bc28686cc483218a85076b0b7c096a