### PR TITLE
Recompute circuit metrics after classical simplification

### DIFF
--- a/quasar/circuit.py
+++ b/quasar/circuit.py
@@ -217,6 +217,12 @@ class Circuit:
         self.gates = new_gates
         self._num_gates = len(new_gates)
         self._depth = self._compute_depth()
+        from .sparsity import sparsity_estimate
+        from .symmetry import symmetry_score, rotation_diversity
+        self.sparsity = sparsity_estimate(self)
+        self.symmetry = symmetry_score(self)
+        self.rotation_diversity = rotation_diversity(self)
+        self.cost_estimates = self._estimate_costs()
         return new_gates
 
     # ------------------------------------------------------------------

--- a/tests/test_circuit.py
+++ b/tests/test_circuit.py
@@ -117,3 +117,25 @@ def test_classical_simplification_can_be_disabled():
     circ.simplify_classical_controls()
     assert [g.gate for g in circ.gates] == ["X", "CX"]
     assert circ.classical_state == [None, None]
+
+
+def test_metrics_recomputed_after_simplification():
+    circ = Circuit.from_dict([
+        {"gate": "X", "qubits": [0]},
+        {"gate": "CX", "qubits": [0, 1]},
+    ])
+    # Capture initial metrics
+    initial_costs = circ.cost_estimates.copy()
+    assert circ.depth > 0
+
+    circ.simplify_classical_controls()
+
+    # After simplification, multi-qubit gate is removed and metrics refresh
+    assert circ.gates == []
+    assert circ.depth == 0
+    assert circ.symmetry == 0
+    assert circ.rotation_diversity == 0
+    assert circ.sparsity == 0.75
+    # Cost estimates must be recomputed
+    assert circ.cost_estimates != initial_costs
+    assert circ.cost_estimates == circ._estimate_costs()


### PR DESCRIPTION
## Summary
- refresh sparsity, symmetry, rotation diversity and cost estimates after simplifying classical controls
- add regression test ensuring metrics update when multi-qubit gates are removed

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68bc57365734832198e46f537c2aac47