### PR TITLE
Call classical control simplification during circuit init

### DIFF
--- a/benchmarks/circuits.py
+++ b/benchmarks/circuits.py
@@ -25,11 +25,11 @@ def ghz_circuit(n_qubits: int) -> Circuit:
     """Create an ``n_qubits`` GHZ state preparation circuit."""
     gates: List[Gate] = []
     if n_qubits <= 0:
-        return Circuit(gates)
+        return Circuit(gates, use_classical_simplification=False)
     gates.append(Gate("H", [0]))
     for i in range(1, n_qubits):
         gates.append(Gate("CX", [i - 1, i]))
-    return Circuit(gates)
+    return Circuit(gates, use_classical_simplification=False)
 
 
 def _qft_spec(n: int) -> dict:
@@ -45,14 +45,14 @@ def _qft_spec(n: int) -> dict:
 def qft_circuit(n_qubits: int) -> Circuit:
     """Create an ``n_qubits`` quantum Fourier transform circuit."""
     spec = _qft_spec(n_qubits)
-    return Circuit(spec["gates"])
+    return Circuit(spec["gates"], use_classical_simplification=False)
 
 
 def qft_on_ghz_circuit(n_qubits: int) -> Circuit:
     """Apply the QFT to a GHZ state."""
     ghz = ghz_circuit(n_qubits)
     qft = qft_circuit(n_qubits)
-    return Circuit(list(ghz.gates) + list(qft.gates))
+    return Circuit(list(ghz.gates) + list(qft.gates), use_classical_simplification=False)
 
 
 def _w_state_spec(n: int) -> dict:
@@ -70,7 +70,7 @@ def _w_state_spec(n: int) -> dict:
 def w_state_circuit(n_qubits: int) -> Circuit:
     """Create an ``n_qubits`` W state preparation circuit."""
     spec = _w_state_spec(n_qubits)
-    return Circuit(spec["gates"])
+    return Circuit(spec["gates"], use_classical_simplification=False)
 
 
 def grover_circuit(n_qubits: int, n_iterations: int = 1) -> Circuit:
@@ -341,7 +341,7 @@ def random_circuit(num_qubits: int, seed: int | None = None) -> Circuit:
 
     qc = qiskit_random_circuit(num_qubits, 2 * num_qubits, seed=seed)
     qc = transpile(qc, basis_gates=["u", "p", "cx", "h", "x"])
-    return Circuit.from_qiskit(qc)
+    return Circuit.from_qiskit(qc, use_classical_simplification=False)
 
 
 def shor_circuit(circuit_size: int) -> Circuit:

--- a/quasar/circuit.py
+++ b/quasar/circuit.py
@@ -67,15 +67,18 @@ class Circuit:
             self.classical_state: List[int | None] = [0] * (max_index + 1)
         else:
             self.classical_state = [None] * (max_index + 1)
-        self._num_gates = len(self.gates)
-        self._depth = self._compute_depth()
-        self.ssd = self._create_ssd()
-        self.cost_estimates = self._estimate_costs()
-        from .sparsity import sparsity_estimate
-        self.sparsity = sparsity_estimate(self)
-        from .symmetry import symmetry_score, rotation_diversity
-        self.symmetry = symmetry_score(self)
-        self.rotation_diversity = rotation_diversity(self)
+        if self.use_classical_simplification:
+            self.simplify_classical_controls()
+        else:
+            self._num_gates = len(self.gates)
+            self._depth = self._compute_depth()
+            self.ssd = self._create_ssd()
+            self.cost_estimates = self._estimate_costs()
+            from .sparsity import sparsity_estimate
+            self.sparsity = sparsity_estimate(self)
+            from .symmetry import symmetry_score, rotation_diversity
+            self.symmetry = symmetry_score(self)
+            self.rotation_diversity = rotation_diversity(self)
 
     # ------------------------------------------------------------------
     # Classical state tracking and simplification
@@ -217,6 +220,7 @@ class Circuit:
         self.gates = new_gates
         self._num_gates = len(new_gates)
         self._depth = self._compute_depth()
+        self.ssd = self._create_ssd()
         from .sparsity import sparsity_estimate
         from .symmetry import symmetry_score, rotation_diversity
         self.sparsity = sparsity_estimate(self)

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -316,11 +316,14 @@ class BridgePlanner(Planner):
 
 
 def test_cross_backend_gate_uses_bridge_tensor():
-    circuit = Circuit([
-        {"gate": "H", "qubits": [0]},
-        {"gate": "H", "qubits": [1]},
-        {"gate": "CX", "qubits": [0, 1]},
-    ])
+    circuit = Circuit(
+        [
+            {"gate": "H", "qubits": [0]},
+            {"gate": "H", "qubits": [1]},
+            {"gate": "CX", "qubits": [0, 1]},
+        ],
+        use_classical_simplification=False,
+    )
     engine = BridgeTrackingEngine()
     scheduler = Scheduler(
         conversion_engine=engine,


### PR DESCRIPTION
## Summary
- Call `simplify_classical_controls` during `Circuit` initialization when enabled
- Update metric computation to run only when classical simplification is disabled
- Refresh tests and benchmark circuit builders to account for automatic simplification

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68bc616c65508321858a9c80e9bcb098