### PR TITLE
feat: track phase and amplitude rotation diversity

### DIFF
--- a/docs/backend_selection.md
+++ b/docs/backend_selection.md
@@ -7,21 +7,23 @@ examines basic structural metrics to guide this choice:
    the specialised TABLEAU backend is used exclusively, bypassing other
    candidates.
 2. **Heuristic metrics** – overall circuit [sparsity](sparsity.md), an
-   estimate of the number of non‑zero amplitudes (*nnz*), and *rotation
-   diversity* are consulted.  Each metric is normalised by its corresponding
-   threshold – ``adaptive_dd_sparsity_threshold(n_qubits)``,
-   ``dd_nnz_threshold`` and ``dd_rotation_diversity_threshold`` – and combined
-   using weights ``dd_sparsity_weight``, ``dd_nnz_weight`` and
-   ``dd_rotation_weight``.  The combined score is
+   estimate of the number of non‑zero amplitudes (*nnz*), and both *phase* and
+   *amplitude* rotation diversity are consulted. Each metric is normalised by
+   its corresponding threshold – ``adaptive_dd_sparsity_threshold(n_qubits)``,
+   ``dd_nnz_threshold``, ``dd_phase_rotation_diversity_threshold`` and
+   ``dd_amplitude_rotation_diversity_threshold`` – and combined using weights
+   ``dd_sparsity_weight``, ``dd_nnz_weight``, ``dd_phase_rotation_weight`` and
+   ``dd_amplitude_rotation_weight``.  The combined score is
 
-   ``(w_s*(s/s_thr) + w_n*(1 - nnz/nnz_thr) + w_r*(1 - rot/rot_thr)) / (w_s+w_n+w_r)``
+   ``(w_s*(s/s_thr) + w_n*(1 - nnz/nnz_thr) + w_p*(1 - p/p_thr) + w_a*(1 - a/a_thr)) / (w_s+w_n+w_p+w_a)``
 
-   where ``s`` is the sparsity, ``nnz`` the non‑zero estimate and ``rot`` the
-   rotation diversity.  Normalising each term by its threshold keeps the score
-   in the ``[0,1]`` range, maintaining comparability with dense backends.  The
-   score must exceed ``dd_metric_threshold`` for the decision‑diagram backend to
-   be considered.  Circuits with a high diversity of rotations are suppressed
-   regardless of score to avoid decision‑diagram blow‑ups.
+   where ``s`` is the sparsity, ``nnz`` the non‑zero estimate, ``p`` the phase
+   rotation diversity and ``a`` the amplitude rotation diversity. Normalising
+   each term by its threshold keeps the score in the ``[0,1]`` range,
+   maintaining comparability with dense backends.  The score must exceed
+   ``dd_metric_threshold`` for the decision‑diagram backend to be considered.
+   Circuits with a high diversity of rotations are suppressed regardless of
+   score to avoid decision‑diagram blow‑ups.
 3. **Entanglement heuristic** – an upper bound on the maximal Schmidt rank is
    derived from the gate sequence.  This estimate combines with the fidelity
    target ``mps_target_fidelity`` (default ``1.0`` and overrideable via
@@ -32,12 +34,13 @@ examines basic structural metrics to guide this choice:
 4. **Fallback** – remaining candidates such as the dense STATEVECTOR simulator
    are considered based on estimated runtime and memory cost.
 
-The default weights for sparsity, nnz and rotation are ``1.0`` each with a
-``dd_metric_threshold`` of ``0.8`` and a ``dd_rotation_diversity_threshold`` of
-``16`` distinct phase angles.  These values – along with
-``dd_sparsity_threshold`` and ``dd_nnz_threshold`` – may be tuned via the
-``QUASAR_DD_*`` environment variables or by overriding ``config.DEFAULT`` at
-runtime.  Lowering ``mps_target_fidelity`` reduces the required bond dimension
+The default weights for sparsity, nnz and the two rotation metrics are ``1.0``
+each with a ``dd_metric_threshold`` of ``0.8`` and rotation‑diversity thresholds
+of ``16`` distinct angles for both phase and amplitude rotations. These values
+– along with ``dd_sparsity_threshold`` and ``dd_nnz_threshold`` – may be tuned
+via the ``QUASAR_DD_*`` environment variables or by overriding
+``config.DEFAULT`` at runtime.  Lowering ``mps_target_fidelity`` reduces the
+required bond dimension
 and can therefore make the MPS backend applicable to more circuits.
 
 This lightweight heuristic steers the planner towards specialised backends for
@@ -63,7 +66,7 @@ Enable logging by setting the environment variable
 ``config.DEFAULT.backend_selection_log`` with a filesystem path.  Each quick
 selection appends a CSV row with
 
-``sparsity,nnz,rotation,backend,score``
+``sparsity,nnz,phase_rot,amplitude_rot,backend,score``
 
 Use the helper script to aggregate results across benchmark runs:
 

--- a/docs/sparsity.md
+++ b/docs/sparsity.md
@@ -31,7 +31,8 @@ controlled-phase rotations that drive `nnz` to `2**n`, producing a sparsity of
 The planner combines the sparsity score with an estimate of the number of
 non-zero amplitudes to form part of the decision-diagram metric.  Weights
 ``dd_sparsity_weight`` and ``dd_nnz_weight``—together with
-``dd_rotation_weight`` and ``dd_metric_threshold``—determine when the
-decision-diagram backend is considered.  These values may be overridden via
+``dd_phase_rotation_weight``, ``dd_amplitude_rotation_weight`` and
+``dd_metric_threshold``—determine when the decision-diagram backend is
+considered.  These values may be overridden via
 the ``QUASAR_DD_*`` environment variables.
 

--- a/quasar/circuit.py
+++ b/quasar/circuit.py
@@ -76,9 +76,16 @@ class Circuit:
             self.cost_estimates = self._estimate_costs()
             from .sparsity import sparsity_estimate
             self.sparsity = sparsity_estimate(self)
-            from .symmetry import symmetry_score, rotation_diversity
+            from .symmetry import (
+                symmetry_score,
+                phase_rotation_diversity,
+                amplitude_rotation_diversity,
+            )
             self.symmetry = symmetry_score(self)
-            self.rotation_diversity = rotation_diversity(self)
+            self.phase_rotation_diversity = phase_rotation_diversity(self)
+            self.amplitude_rotation_diversity = amplitude_rotation_diversity(self)
+            # Backward compatibility
+            self.rotation_diversity = self.phase_rotation_diversity
 
     # ------------------------------------------------------------------
     # Classical state tracking and simplification
@@ -222,10 +229,16 @@ class Circuit:
         self._depth = self._compute_depth()
         self.ssd = self._create_ssd()
         from .sparsity import sparsity_estimate
-        from .symmetry import symmetry_score, rotation_diversity
+        from .symmetry import (
+            symmetry_score,
+            phase_rotation_diversity,
+            amplitude_rotation_diversity,
+        )
         self.sparsity = sparsity_estimate(self)
         self.symmetry = symmetry_score(self)
-        self.rotation_diversity = rotation_diversity(self)
+        self.phase_rotation_diversity = phase_rotation_diversity(self)
+        self.amplitude_rotation_diversity = amplitude_rotation_diversity(self)
+        self.rotation_diversity = self.phase_rotation_diversity
         self.cost_estimates = self._estimate_costs()
         return new_gates
 

--- a/quasar/config.py
+++ b/quasar/config.py
@@ -102,14 +102,20 @@ class Config:
     dd_nnz_weight: float = _float_from_env(
         "QUASAR_DD_NNZ_WEIGHT", 1.0
     )
-    dd_rotation_weight: float = _float_from_env(
-        "QUASAR_DD_ROTATION_WEIGHT", 1.0
+    dd_phase_rotation_weight: float = _float_from_env(
+        "QUASAR_DD_PHASE_ROTATION_WEIGHT", 1.0
+    )
+    dd_amplitude_rotation_weight: float = _float_from_env(
+        "QUASAR_DD_AMPLITUDE_ROTATION_WEIGHT", 1.0
     )
     dd_metric_threshold: float = _float_from_env(
         "QUASAR_DD_METRIC_THRESHOLD", 0.8
     )
-    dd_rotation_diversity_threshold: int = _int_from_env(
-        "QUASAR_DD_ROTATION_DIVERSITY_THRESHOLD", 16
+    dd_phase_rotation_diversity_threshold: int = _int_from_env(
+        "QUASAR_DD_PHASE_ROTATION_DIVERSITY_THRESHOLD", 16
+    )
+    dd_amplitude_rotation_diversity_threshold: int = _int_from_env(
+        "QUASAR_DD_AMPLITUDE_ROTATION_DIVERSITY_THRESHOLD", 16
     )
     backend_selection_log: str | None = os.getenv("QUASAR_BACKEND_SELECTION_LOG")
 

--- a/quasar/planner.py
+++ b/quasar/planner.py
@@ -175,7 +175,8 @@ def _supported_backends(
     *,
     sparsity: float | None = None,
     circuit: "Circuit" | None = None,
-    rotation_diversity: int | None = None,
+    phase_rotation_diversity: int | None = None,
+    amplitude_rotation_diversity: int | None = None,
     allow_tableau: bool = True,
     estimator: CostEstimator | None = None,
     max_memory: float | None = None,
@@ -190,7 +191,7 @@ def _supported_backends(
         Optional sparsity metric for the overall circuit.
     circuit:
         Circuit providing heuristic metrics.  Explicit ``sparsity`` and
-        ``rotation_diversity`` arguments take precedence when supplied.
+        rotation-diversity arguments take precedence when supplied.
     allow_tableau:
         If ``True`` and the gate sequence is Clifford-only, include
         :class:`Backend.TABLEAU` as a candidate.  When ``False`` the tableau
@@ -208,8 +209,10 @@ def _supported_backends(
     if circuit is not None:
         if sparsity is None:
             sparsity = getattr(circuit, "sparsity", None)
-        if rotation_diversity is None:
-            rotation_diversity = getattr(circuit, "rotation_diversity", None)
+        if phase_rotation_diversity is None:
+            phase_rotation_diversity = getattr(circuit, "phase_rotation_diversity", None)
+        if amplitude_rotation_diversity is None:
+            amplitude_rotation_diversity = getattr(circuit, "amplitude_rotation_diversity", None)
 
     gates = list(gates)
     names = [g.gate.upper() for g in gates]
@@ -224,7 +227,8 @@ def _supported_backends(
     candidates: List[Backend] = []
 
     sparse = sparsity if sparsity is not None else 0.0
-    rot = rotation_diversity if rotation_diversity is not None else 0
+    phase_rot = phase_rotation_diversity if phase_rotation_diversity is not None else 0
+    amp_rot = amplitude_rotation_diversity if amplitude_rotation_diversity is not None else 0
     nnz = int((1 - sparse) * (2 ** num_qubits))
     from .sparsity import adaptive_dd_sparsity_threshold
 
@@ -232,22 +236,26 @@ def _supported_backends(
     passes = (
         sparse >= s_thresh
         and nnz <= config.DEFAULT.dd_nnz_threshold
-        and rot <= config.DEFAULT.dd_rotation_diversity_threshold
+        and phase_rot <= config.DEFAULT.dd_phase_rotation_diversity_threshold
+        and amp_rot <= config.DEFAULT.dd_amplitude_rotation_diversity_threshold
     )
     dd_metric = False
     if passes:
         s_score = sparse / s_thresh if s_thresh > 0 else 0.0
         nnz_score = 1 - nnz / config.DEFAULT.dd_nnz_threshold
-        rot_score = 1 - rot / config.DEFAULT.dd_rotation_diversity_threshold
+        phase_score = 1 - phase_rot / config.DEFAULT.dd_phase_rotation_diversity_threshold
+        amp_score = 1 - amp_rot / config.DEFAULT.dd_amplitude_rotation_diversity_threshold
         weight_sum = (
             config.DEFAULT.dd_sparsity_weight
             + config.DEFAULT.dd_nnz_weight
-            + config.DEFAULT.dd_rotation_weight
+            + config.DEFAULT.dd_phase_rotation_weight
+            + config.DEFAULT.dd_amplitude_rotation_weight
         )
         weighted = (
             config.DEFAULT.dd_sparsity_weight * s_score
             + config.DEFAULT.dd_nnz_weight * nnz_score
-            + config.DEFAULT.dd_rotation_weight * rot_score
+            + config.DEFAULT.dd_phase_rotation_weight * phase_score
+            + config.DEFAULT.dd_amplitude_rotation_weight * amp_score
         )
         metric = weighted / weight_sum if weight_sum else 0.0
         dd_metric = metric >= config.DEFAULT.dd_metric_threshold
@@ -427,14 +435,15 @@ class Planner:
         allow_tableau: bool = True,
         symmetry: float | None = None,
         sparsity: float | None = None,
-        rotation_diversity: int | None = None,
+        phase_rotation_diversity: int | None = None,
+        amplitude_rotation_diversity: int | None = None,
     ) -> PlanResult:
         """Internal DP routine supporting batching and pruning.
 
         When ``forced_backend`` is provided only that backend is considered
         during planning.  A ``ValueError`` is raised if the backend cannot
-        simulate a segment of the circuit.  ``sparsity`` and
-        ``rotation_diversity`` are forwarded to :func:`_supported_backends`.
+        simulate a segment of the circuit.  ``sparsity`` and rotation metrics
+        are forwarded to :func:`_supported_backends`.
         """
         from .sparsity import adaptive_dd_sparsity_threshold
         nnz_estimate = None
@@ -443,28 +452,42 @@ class Planner:
         s_thresh = adaptive_dd_sparsity_threshold(len({q for g in gates for q in g.qubits}))
         passes = (
             (sparsity is not None and sparsity >= s_thresh)
-            and (nnz_estimate is not None and nnz_estimate <= config.DEFAULT.dd_nnz_threshold)
             and (
-                rotation_diversity is None
-                or rotation_diversity <= config.DEFAULT.dd_rotation_diversity_threshold
+                nnz_estimate is not None and nnz_estimate <= config.DEFAULT.dd_nnz_threshold
+            )
+            and (
+                (phase_rotation_diversity is None
+                 or phase_rotation_diversity <= config.DEFAULT.dd_phase_rotation_diversity_threshold)
+                and (
+                    amplitude_rotation_diversity is None
+                    or amplitude_rotation_diversity
+                    <= config.DEFAULT.dd_amplitude_rotation_diversity_threshold
+                )
             )
         )
         dd_metric = False
         if passes:
             s_score = sparsity / s_thresh if s_thresh > 0 else 0.0
             nnz_score = 1 - nnz_estimate / config.DEFAULT.dd_nnz_threshold
-            rot_score = 1 - (
-                (rotation_diversity or 0) / config.DEFAULT.dd_rotation_diversity_threshold
+            phase_score = 1 - (
+                (phase_rotation_diversity or 0)
+                / config.DEFAULT.dd_phase_rotation_diversity_threshold
+            )
+            amp_score = 1 - (
+                (amplitude_rotation_diversity or 0)
+                / config.DEFAULT.dd_amplitude_rotation_diversity_threshold
             )
             weight_sum = (
                 config.DEFAULT.dd_sparsity_weight
                 + config.DEFAULT.dd_nnz_weight
-                + config.DEFAULT.dd_rotation_weight
+                + config.DEFAULT.dd_phase_rotation_weight
+                + config.DEFAULT.dd_amplitude_rotation_weight
             )
             weighted = (
                 config.DEFAULT.dd_sparsity_weight * s_score
                 + config.DEFAULT.dd_nnz_weight * nnz_score
-                + config.DEFAULT.dd_rotation_weight * rot_score
+                + config.DEFAULT.dd_phase_rotation_weight * phase_score
+                + config.DEFAULT.dd_amplitude_rotation_weight * amp_score
             )
             metric = weighted / weight_sum if weight_sum else 0.0
             dd_metric = metric >= config.DEFAULT.dd_metric_threshold
@@ -521,7 +544,8 @@ class Planner:
                     _supported_backends(
                         segment,
                         sparsity=sparsity,
-                        rotation_diversity=rotation_diversity,
+                        phase_rotation_diversity=phase_rotation_diversity,
+                        amplitude_rotation_diversity=amplitude_rotation_diversity,
                         allow_tableau=allow_tableau,
                         estimator=self.estimator,
                         max_memory=max_memory,
@@ -704,7 +728,8 @@ class Planner:
         max_memory: float | None,
         *,
         sparsity: float | None = None,
-        rotation_diversity: int | None = None,
+        phase_rotation_diversity: int | None = None,
+        amplitude_rotation_diversity: int | None = None,
         allow_tableau: bool = True,
     ) -> Tuple[Backend, Cost]:
         """Return best single-backend estimate for the full gate list.
@@ -717,8 +742,8 @@ class Planner:
             Optional memory threshold.
         symmetry, sparsity:
             Optional heuristic metrics for the overall circuit.
-        rotation_diversity:
-            Optional count of distinct rotation angles used by the circuit.
+        phase_rotation_diversity, amplitude_rotation_diversity:
+            Optional counts of distinct rotation angles used by the circuit.
         allow_tableau:
             Propagate the circuit-level Clifford check.  When ``False`` the
             tableau backend is never considered even if ``gates`` are
@@ -741,22 +766,34 @@ class Planner:
         passes = (
             (sparsity or 0.0) >= s_thresh
             and nnz_estimate <= config.DEFAULT.dd_nnz_threshold
-            and (rotation_diversity or 0) <= config.DEFAULT.dd_rotation_diversity_threshold
+            and (phase_rotation_diversity or 0)
+            <= config.DEFAULT.dd_phase_rotation_diversity_threshold
+            and (amplitude_rotation_diversity or 0)
+            <= config.DEFAULT.dd_amplitude_rotation_diversity_threshold
         )
         dd_metric = False
         if passes:
             s_score = (sparsity or 0.0) / s_thresh if s_thresh > 0 else 0.0
             nnz_score = 1 - nnz_estimate / config.DEFAULT.dd_nnz_threshold
-            rot_score = 1 - (rotation_diversity or 0) / config.DEFAULT.dd_rotation_diversity_threshold
+            phase_score = 1 - (
+                (phase_rotation_diversity or 0)
+                / config.DEFAULT.dd_phase_rotation_diversity_threshold
+            )
+            amp_score = 1 - (
+                (amplitude_rotation_diversity or 0)
+                / config.DEFAULT.dd_amplitude_rotation_diversity_threshold
+            )
             weight_sum = (
                 config.DEFAULT.dd_sparsity_weight
                 + config.DEFAULT.dd_nnz_weight
-                + config.DEFAULT.dd_rotation_weight
+                + config.DEFAULT.dd_phase_rotation_weight
+                + config.DEFAULT.dd_amplitude_rotation_weight
             )
             weighted = (
                 config.DEFAULT.dd_sparsity_weight * s_score
                 + config.DEFAULT.dd_nnz_weight * nnz_score
-                + config.DEFAULT.dd_rotation_weight * rot_score
+                + config.DEFAULT.dd_phase_rotation_weight * phase_score
+                + config.DEFAULT.dd_amplitude_rotation_weight * amp_score
             )
             metric = weighted / weight_sum if weight_sum else 0.0
             dd_metric = metric >= config.DEFAULT.dd_metric_threshold
@@ -764,7 +801,8 @@ class Planner:
             _supported_backends(
                 gates,
                 sparsity=sparsity,
-                rotation_diversity=rotation_diversity,
+                phase_rotation_diversity=phase_rotation_diversity,
+                amplitude_rotation_diversity=amplitude_rotation_diversity,
                 allow_tableau=allow_tableau,
                 estimator=self.estimator,
                 max_memory=max_memory,
@@ -874,7 +912,8 @@ class Planner:
             gates,
             threshold,
             sparsity=circuit.sparsity,
-            rotation_diversity=circuit.rotation_diversity,
+            phase_rotation_diversity=circuit.phase_rotation_diversity,
+            amplitude_rotation_diversity=circuit.amplitude_rotation_diversity,
             allow_tableau=allow_tableau,
         )
 
@@ -919,7 +958,8 @@ class Planner:
             max_memory=threshold,
             allow_tableau=allow_tableau,
             sparsity=circuit.sparsity,
-            rotation_diversity=circuit.rotation_diversity,
+            phase_rotation_diversity=circuit.phase_rotation_diversity,
+            amplitude_rotation_diversity=circuit.amplitude_rotation_diversity,
         )
         pre_cost = (
             pre.table[-1][pre.final_backend].cost if pre.table else Cost(0.0, 0.0)
@@ -956,7 +996,8 @@ class Planner:
             max_memory=threshold,
             allow_tableau=allow_tableau,
             sparsity=circuit.sparsity,
-            rotation_diversity=circuit.rotation_diversity,
+            phase_rotation_diversity=circuit.phase_rotation_diversity,
+            amplitude_rotation_diversity=circuit.amplitude_rotation_diversity,
         )
 
         dp_cost = (
@@ -1013,7 +1054,8 @@ class Planner:
                 max_memory=threshold,
                 allow_tableau=allow_tableau,
                 sparsity=circuit.sparsity,
-                rotation_diversity=circuit.rotation_diversity,
+                phase_rotation_diversity=circuit.phase_rotation_diversity,
+                amplitude_rotation_diversity=circuit.amplitude_rotation_diversity,
             )
             for sub_step in sub.steps:
                 refined_steps.append(

--- a/quasar/scheduler.py
+++ b/quasar/scheduler.py
@@ -134,34 +134,41 @@ class Scheduler:
         num_qubits = circuit.num_qubits
 
         sparsity = getattr(circuit, "sparsity", None)
-        rotation = getattr(circuit, "rotation_diversity", None)
+        phase_rot = getattr(circuit, "phase_rotation_diversity", None)
+        amp_rot = getattr(circuit, "amplitude_rotation_diversity", None)
         from .sparsity import sparsity_estimate, adaptive_dd_sparsity_threshold
-        from .symmetry import rotation_diversity
+        from .symmetry import phase_rotation_diversity, amplitude_rotation_diversity
         if sparsity is None:
             sparsity = sparsity_estimate(circuit)
-        if rotation is None:
-            rotation = rotation_diversity(circuit)
+        if phase_rot is None:
+            phase_rot = phase_rotation_diversity(circuit)
+        if amp_rot is None:
+            amp_rot = amplitude_rotation_diversity(circuit)
 
         nnz_estimate = int((1 - sparsity) * (2 ** num_qubits))
         s_thresh = adaptive_dd_sparsity_threshold(num_qubits)
         s_score = sparsity / s_thresh if s_thresh > 0 else 0.0
         nnz_score = 1 - nnz_estimate / config.DEFAULT.dd_nnz_threshold
-        rot_score = 1 - rotation / config.DEFAULT.dd_rotation_diversity_threshold
+        phase_score = 1 - phase_rot / config.DEFAULT.dd_phase_rotation_diversity_threshold
+        amp_score = 1 - amp_rot / config.DEFAULT.dd_amplitude_rotation_diversity_threshold
         weight_sum = (
             config.DEFAULT.dd_sparsity_weight
             + config.DEFAULT.dd_nnz_weight
-            + config.DEFAULT.dd_rotation_weight
+            + config.DEFAULT.dd_phase_rotation_weight
+            + config.DEFAULT.dd_amplitude_rotation_weight
         )
         weighted = (
             config.DEFAULT.dd_sparsity_weight * s_score
             + config.DEFAULT.dd_nnz_weight * nnz_score
-            + config.DEFAULT.dd_rotation_weight * rot_score
+            + config.DEFAULT.dd_phase_rotation_weight * phase_score
+            + config.DEFAULT.dd_amplitude_rotation_weight * amp_score
         )
         metric = weighted / weight_sum if weight_sum else 0.0
         passes = (
             sparsity >= s_thresh
             and nnz_estimate <= config.DEFAULT.dd_nnz_threshold
-            and rotation <= config.DEFAULT.dd_rotation_diversity_threshold
+            and phase_rot <= config.DEFAULT.dd_phase_rotation_diversity_threshold
+            and amp_rot <= config.DEFAULT.dd_amplitude_rotation_diversity_threshold
         )
         dd_metric = passes and metric >= config.DEFAULT.dd_metric_threshold
 
@@ -183,7 +190,7 @@ class Scheduler:
             try:
                 with open(self.backend_selection_log, "a", encoding="utf8") as f:
                     f.write(
-                        f"{sparsity:.6f},{nnz_estimate},{rotation:.6f},{backend_choice.name},{metric:.6f}\n"
+                        f"{sparsity:.6f},{nnz_estimate},{phase_rot:.6f},{amp_rot:.6f},{backend_choice.name},{metric:.6f}\n"
                     )
             except OSError:
                 pass

--- a/tests/test_backend_selection.py
+++ b/tests/test_backend_selection.py
@@ -67,7 +67,8 @@ def test_rotation_diversity_discourages_dd(monkeypatch):
     circuit = qft_circuit(5)
     monkeypatch.setattr(config.DEFAULT, "dd_sparsity_threshold", 0.0)
     monkeypatch.setattr(config.DEFAULT, "dd_nnz_threshold", 10_000_000)
-    monkeypatch.setattr(config.DEFAULT, "dd_rotation_diversity_threshold", 3)
+    monkeypatch.setattr(config.DEFAULT, "dd_phase_rotation_diversity_threshold", 3)
+    monkeypatch.setattr(config.DEFAULT, "dd_amplitude_rotation_diversity_threshold", 3)
     engine = SimulationEngine()
     plan = engine.planner.plan(circuit)
     assert plan.final_backend == Backend.STATEVECTOR

--- a/tests/test_backend_selection_logging.py
+++ b/tests/test_backend_selection_logging.py
@@ -15,4 +15,4 @@ def test_backend_selection_logging(tmp_path):
     backend = sched.select_backend(circuit)
     assert backend == Backend.TABLEAU
     content = log_file.read_text().strip().split(",")
-    assert content[3] == "TABLEAU"
+    assert content[4] == "TABLEAU"

--- a/tests/test_backend_symmetry_sparsity.py
+++ b/tests/test_backend_symmetry_sparsity.py
@@ -20,7 +20,8 @@ def test_high_rotation_diversity_stays_dense(monkeypatch):
     circ.classical_state = [None] * circ.num_qubits
     monkeypatch.setattr(config.DEFAULT, "dd_sparsity_threshold", 0.0)
     monkeypatch.setattr(config.DEFAULT, "dd_nnz_threshold", 10_000_000)
-    monkeypatch.setattr(config.DEFAULT, "dd_rotation_diversity_threshold", 3)
+    monkeypatch.setattr(config.DEFAULT, "dd_phase_rotation_diversity_threshold", 3)
+    monkeypatch.setattr(config.DEFAULT, "dd_amplitude_rotation_diversity_threshold", 3)
     scheduler = Scheduler()
     scheduler.prepare_run(circ)
     part = circ.ssd.partitions[0]
@@ -32,7 +33,8 @@ def test_high_nnz_stays_dense(monkeypatch):
     circ.classical_state = [None] * circ.num_qubits
     monkeypatch.setattr(config.DEFAULT, "dd_sparsity_threshold", 0.0)
     monkeypatch.setattr(config.DEFAULT, "dd_nnz_threshold", 1)
-    monkeypatch.setattr(config.DEFAULT, "dd_rotation_diversity_threshold", 1000)
+    monkeypatch.setattr(config.DEFAULT, "dd_phase_rotation_diversity_threshold", 1000)
+    monkeypatch.setattr(config.DEFAULT, "dd_amplitude_rotation_diversity_threshold", 1000)
     scheduler = Scheduler()
     scheduler.prepare_run(circ)
     part = circ.ssd.partitions[0]

--- a/tests/test_circuit.py
+++ b/tests/test_circuit.py
@@ -128,7 +128,8 @@ def test_metrics_recomputed_after_simplification():
     assert circ.gates == []
     assert circ.depth == 0
     assert circ.symmetry == 0
-    assert circ.rotation_diversity == 0
+    assert circ.phase_rotation_diversity == 0
+    assert circ.amplitude_rotation_diversity == 0
     assert circ.sparsity == 0.75
     assert circ.cost_estimates != initial_costs
     assert circ.cost_estimates == circ._estimate_costs()

--- a/tests/test_conversion_layers.py
+++ b/tests/test_conversion_layers.py
@@ -5,7 +5,8 @@ import quasar.config as config
 def test_conversion_layer_inserted(monkeypatch):
     monkeypatch.setattr(config.DEFAULT, "dd_sparsity_threshold", 0.0)
     monkeypatch.setattr(config.DEFAULT, "dd_nnz_threshold", 10_000_000)
-    monkeypatch.setattr(config.DEFAULT, "dd_rotation_diversity_threshold", 1000)
+    monkeypatch.setattr(config.DEFAULT, "dd_phase_rotation_diversity_threshold", 1000)
+    monkeypatch.setattr(config.DEFAULT, "dd_amplitude_rotation_diversity_threshold", 1000)
     monkeypatch.setattr(config.DEFAULT, "dd_metric_threshold", 0.0)
     # Construct a circuit that starts Clifford-only and then introduces
     # non-Clifford gates on the same qubits, forcing a backend switch and

--- a/tests/test_supported_backends_dd.py
+++ b/tests/test_supported_backends_dd.py
@@ -20,6 +20,7 @@ def test_supported_backends_qft_rotation_diversity():
     backends = _supported_backends(
         circ.gates,
         sparsity=circ.sparsity,
-        rotation_diversity=circ.rotation_diversity,
+        phase_rotation_diversity=circ.phase_rotation_diversity,
+        amplitude_rotation_diversity=circ.amplitude_rotation_diversity,
     )
     assert Backend.DECISION_DIAGRAM not in backends

--- a/tests/test_symmetry.py
+++ b/tests/test_symmetry.py
@@ -13,5 +13,9 @@ def test_random_circuit_symmetry_low():
     assert random_circuit(5, seed=123).symmetry < 0.05
 
 
-def test_qft_rotation_diversity_count():
-    assert qft_circuit(5).rotation_diversity == 4
+def test_qft_phase_rotation_diversity_count():
+    assert qft_circuit(5).phase_rotation_diversity == 4
+
+
+def test_w_state_amplitude_rotation_diversity_count():
+    assert w_state_circuit(5).amplitude_rotation_diversity == 4


### PR DESCRIPTION
## Summary
- count distinct phase and amplitude rotations separately
- weight phase and amplitude rotation diversity in backend scoring
- expose thresholds and weights for rotation heuristics

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68bc52c20a688321bb0a96368ef6890d