### PR TITLE
Add regression tests for verbose backend selection logs

### DIFF
--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -66,6 +66,25 @@ Benchmark results can be explored with the Jupyter notebooks in
 jupyter notebook benchmarks/notebooks/comparison.ipynb
 ```
 
+## Inspecting backend-selection logs
+
+The script `verbose_selection_demo.py` runs small sample circuits with
+the scheduler's verbose logging enabled and checks that the reported
+metrics match the chosen backend:
+
+```bash
+python benchmarks/verbose_selection_demo.py
+```
+
+Running it prints lines such as
+
+```
+[backend-selection] sparsity=... rotation_diversity=... nnz=... locality=... candidates=... selected=...
+```
+
+These metrics explain why a particular backend was selected for each
+sample circuit.
+
 ## Adding circuit families
 
 New circuit generators are added to

--- a/benchmarks/verbose_selection_demo.py
+++ b/benchmarks/verbose_selection_demo.py
@@ -1,0 +1,47 @@
+"""Run sample circuits to demonstrate verbose backend-selection logs."""
+
+from __future__ import annotations
+
+import contextlib
+import io
+
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from benchmarks.circuits import qft_circuit, w_state_circuit
+from quasar import Backend, Scheduler
+
+
+def _run_and_capture(circuit):
+    scheduler = Scheduler(
+        quick_max_qubits=10,
+        quick_max_gates=100,
+        quick_max_depth=100,
+        verbose_selection=True,
+    )
+    buf = io.StringIO()
+    with contextlib.redirect_stdout(buf):
+        backend = scheduler.select_backend(circuit)
+    log = buf.getvalue().strip()
+    return backend, log
+
+
+def main() -> None:
+    tests = [
+        ("QFT", qft_circuit(3), Backend.STATEVECTOR),
+        ("W-state", w_state_circuit(3), Backend.MPS),
+    ]
+    for name, circuit, expected in tests:
+        backend, log = _run_and_capture(circuit)
+        print(f"{name} circuit backend: {backend.name}")
+        print(log)
+        assert backend == expected
+        assert f"selected={expected.name}" in log
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_backend_selection_verbose.py
+++ b/tests/test_backend_selection_verbose.py
@@ -1,0 +1,48 @@
+from __future__ import annotations
+
+"""Regression tests for verbose backend selection output."""
+
+import io
+import contextlib
+
+from benchmarks.circuits import qft_circuit, w_state_circuit
+from quasar import Backend, Scheduler
+
+
+def _capture_backend_selection(circuit):
+    """Run backend selection with verbose logging and capture output."""
+    scheduler = Scheduler(
+        quick_max_qubits=10,
+        quick_max_gates=100,
+        quick_max_depth=100,
+        verbose_selection=True,
+    )
+    buf = io.StringIO()
+    with contextlib.redirect_stdout(buf):
+        backend = scheduler.select_backend(circuit)
+    return backend, buf.getvalue().strip()
+
+
+def test_verbose_selection_qft():
+    backend, log = _capture_backend_selection(qft_circuit(3))
+    assert backend == Backend.STATEVECTOR
+    assert "[backend-selection]" in log
+    assert "sparsity=0.000000" in log
+    assert "rotation_diversity=2.000000" in log
+    assert "nnz=8" in log
+    assert "locality=False" in log
+    assert "candidates=STATEVECTOR" in log
+    assert "selected=STATEVECTOR" in log
+
+
+def test_verbose_selection_w_state():
+    backend, log = _capture_backend_selection(w_state_circuit(3))
+    assert backend == Backend.MPS
+    assert "[backend-selection]" in log
+    assert "sparsity=0.625000" in log
+    assert "rotation_diversity=0.000000" in log
+    assert "nnz=3" in log
+    assert "locality=True" in log
+    assert "candidates=MPS>STATEVECTOR" in log
+    assert "selected=MPS" in log
+


### PR DESCRIPTION
## Summary
- add regression tests ensuring verbose backend-selection metrics and backend choices for QFT and W-state circuits
- add `verbose_selection_demo.py` script demonstrating verbose backend-selection logging
- document how to inspect backend-selection logs in benchmarks README

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bc661e6de8832180742e0d944cf7e2