### PR TITLE
Refine statevector memory cost model

### DIFF
--- a/quasar/calibration.py
+++ b/quasar/calibration.py
@@ -10,6 +10,7 @@ The benchmarks are intentionally lightweight and avoid external
 dependencies.  They serve only as a coarse guide for relative
 performance on the current machine.
 """
+
 from __future__ import annotations
 
 from time import perf_counter
@@ -42,7 +43,8 @@ def benchmark_statevector(num_qubits: int = 8, num_gates: int = 50) -> Dict[str,
         "sv_gate_1q": coeff,
         "sv_gate_2q": coeff,
         "sv_meas": coeff,
-        "sv_mem": 16.0,  # Rough bytes per amplitude for complex128
+        # Rough buffer factor for statevector simulation.
+        "sv_bytes_per_amp": 2.0,
     }
 
 
@@ -88,7 +90,7 @@ def benchmark_dd(num_gates: int = 50, frontier: int = 32) -> Dict[str, float]:
 
 
 def benchmark_b2b(q: int = 6, s: int = 4) -> Dict[str, float]:
-    ops = (s ** 3) + q * (s ** 2)
+    ops = (s**3) + q * (s**2)
     elapsed = _bench_loop(ops)
     coeff = elapsed / ops
     return {"b2b_svd": coeff, "b2b_copy": coeff}
@@ -103,7 +105,7 @@ def benchmark_lw(w: int = 4) -> Dict[str, float]:
 
 def benchmark_st(s: int = 8) -> Dict[str, float]:
     chi = min(s, 16)
-    ops = chi ** 3
+    ops = chi**3
     elapsed = _bench_loop(ops)
     coeff = elapsed / ops
     return {"st_stage": coeff}
@@ -137,7 +139,9 @@ def save_coefficients(path: str | Path, coeff: Dict[str, float]) -> None:
 
 def main(argv: list[str] | None = None) -> None:
     parser = argparse.ArgumentParser(description="Calibrate QuASAr cost coefficients")
-    parser.add_argument("--output", "-o", default="coeff.json", help="Destination JSON file")
+    parser.add_argument(
+        "--output", "-o", default="coeff.json", help="Destination JSON file"
+    )
     args = parser.parse_args(argv)
     coeff = run_calibration()
     save_coefficients(args.output, coeff)

--- a/tests/test_cost.py
+++ b/tests/test_cost.py
@@ -12,6 +12,25 @@ def test_statevector_scaling():
     assert large.log_depth == math.log2(4)
 
 
+def test_statevector_precision_memory():
+    est = CostEstimator()
+    single = est.statevector(
+        num_qubits=3,
+        num_1q_gates=0,
+        num_2q_gates=0,
+        num_meas=0,
+        precision="complex64",
+    )
+    double = est.statevector(
+        num_qubits=3,
+        num_1q_gates=0,
+        num_2q_gates=0,
+        num_meas=0,
+        precision="complex128",
+    )
+    assert double.memory == 2 * single.memory
+
+
 def test_tableau_quadratic():
     est = CostEstimator()
     cost = est.tableau(num_qubits=5, num_gates=2)
@@ -23,8 +42,8 @@ def test_mps_chi_dependence():
     est = CostEstimator()
     chi2 = est.mps(num_qubits=4, num_1q_gates=0, num_2q_gates=1, chi=2)
     chi4 = est.mps(num_qubits=4, num_1q_gates=0, num_2q_gates=1, chi=4)
-    assert chi4.time == chi2.time * (4 ** 3) / (2 ** 3)
-    assert chi4.memory == chi2.memory * (4 ** 2) / (2 ** 2)
+    assert chi4.time == chi2.time * (4**3) / (2**3)
+    assert chi4.memory == chi2.memory * (4**2) / (2**2)
 
 
 def test_mps_gate_scaling():
@@ -44,7 +63,7 @@ def test_mps_svd_cost():
         chi=4,
         svd=True,
     )
-    assert with_svd.time == base.time + 4 * (4 ** 3) * math.log2(4)
+    assert with_svd.time == base.time + 4 * (4**3) * math.log2(4)
 
 
 def test_decision_diagram_log_scaling():
@@ -67,7 +86,9 @@ def test_decision_diagram_small_frontier_linear():
 
 
 def test_conversion_primitive_selection():
-    est = CostEstimator(coeff={"lw_extract": 10.0, "full_extract": 10.0, "st_stage": 10.0})
+    est = CostEstimator(
+        coeff={"lw_extract": 10.0, "full_extract": 10.0, "st_stage": 10.0}
+    )
     small = est.conversion(
         Backend.TABLEAU,
         Backend.MPS,


### PR DESCRIPTION
## Summary
- model statevector memory as bytes per amplitude with configurable precision
- expose `sv_bytes_per_amp` coefficient for buffer calibration
- test memory scaling for precision and qubit counts

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68bd0948e800832198c585beed2c7f82