### PR TITLE
Refine MPS cost model with bond-aware estimates

### DIFF
--- a/quasar/planner.py
+++ b/quasar/planner.py
@@ -267,7 +267,7 @@ def _supported_backends(
     mps_metric = False
     if estimator is not None and all(len(g.qubits) <= 2 for g in gates):
         chi_cap = estimator.chi_max
-        if chi_cap is not None and chi_cap >= 1:
+        if chi_cap is not None and chi_cap > 1:
             num_meas = sum(
                 1 for g in gates if len(g.qubits) == 1 and g.gate.upper() in {"MEASURE", "RESET"}
             )


### PR DESCRIPTION
## Summary
- model MPS memory and runtime using per-bond dimensions and optional gate-derived χ
- account for SVD workspace via new `mps_temp_mem` coefficient
- guard planner from proposing MPS when χ≤1 and extend tests for MPS heuristics

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bd10b9c9988321969cd31d3293b58a