### PR TITLE
feat: extend tableau cost estimation

### DIFF
--- a/tests/test_cost.py
+++ b/tests/test_cost.py
@@ -31,11 +31,19 @@ def test_statevector_precision_memory():
     assert double.memory == 2 * single.memory
 
 
-def test_tableau_quadratic():
+def test_tableau_qubit_scaling():
     est = CostEstimator()
-    cost = est.tableau(num_qubits=5, num_gates=2)
-    assert cost.time == 2 * 25
-    assert cost.memory == 25
+    small = est.tableau(num_qubits=2, num_gates=1)
+    large = est.tableau(num_qubits=4, num_gates=1)
+    assert large.time == 4 * small.time
+    assert large.memory == 4 * small.memory
+
+
+def test_tableau_measurement_memory():
+    est = CostEstimator()
+    base = est.tableau(num_qubits=3, num_gates=0)
+    meas = est.tableau(num_qubits=3, num_gates=0, num_meas=5)
+    assert meas.memory == base.memory + 5 * est.coeff["tab_meas_mem"]
 
 
 def test_mps_chi_dependence():

--- a/tests/test_planner_single_backend_choice.py
+++ b/tests/test_planner_single_backend_choice.py
@@ -11,7 +11,7 @@ class OverheadEstimator(CostEstimator):
     def statevector(self, num_qubits, num_1q_gates, num_2q_gates, num_meas):
         return Cost(time=num_1q_gates + num_2q_gates + num_meas + 1, memory=0)
 
-    def tableau(self, num_qubits, num_gates):
+    def tableau(self, num_qubits, num_gates, **kwargs):
         return Cost(time=num_gates + 1, memory=0)
 
     def mps(self, num_qubits, num_1q_gates, num_2q_gates, chi, *, svd=False):


### PR DESCRIPTION
## Summary
- refine tableau cost model with explicit stabilizer and destabilizer dimensions
- account for phase bits and measurement logs with new tuning coefficients
- test tableau scaling with qubit count and measurement operations

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68bd17cb221c83218a9a36a336f5a103