### PR TITLE
Add memory-aware planner priority option

### DIFF
--- a/docs/backend_selection.md
+++ b/docs/backend_selection.md
@@ -34,6 +34,12 @@ examines basic structural metrics to guide this choice:
 4. **Fallback** – remaining candidates such as the dense STATEVECTOR simulator
    are considered based on estimated runtime and memory cost.
 
+The planner compares candidate costs using a configurable priority between
+runtime and memory.  By default memory consumption takes precedence to avoid
+backends with excessive requirements when a slower but leaner alternative
+exists.  This behaviour can be overridden via the planner's ``perf_prio``
+option, setting it to ``"time"`` to prioritise runtime instead.
+
 The default weights for sparsity, nnz and the two rotation metrics are ``1.0``
 each with a ``dd_metric_threshold`` of ``0.8`` and rotation‑diversity thresholds
 of ``16`` distinct angles for both phase and amplitude rotations. These values

--- a/tests/test_backend_selection.py
+++ b/tests/test_backend_selection.py
@@ -1,5 +1,6 @@
 from benchmarks.circuits import ghz_circuit, qft_circuit, w_state_circuit
 from quasar import Backend, SimulationEngine
+from quasar.planner import Planner
 from quasar.cost import CostEstimator
 import quasar.config as config
 
@@ -69,7 +70,7 @@ def test_rotation_diversity_discourages_dd(monkeypatch):
     monkeypatch.setattr(config.DEFAULT, "dd_nnz_threshold", 10_000_000)
     monkeypatch.setattr(config.DEFAULT, "dd_phase_rotation_diversity_threshold", 3)
     monkeypatch.setattr(config.DEFAULT, "dd_amplitude_rotation_diversity_threshold", 3)
-    engine = SimulationEngine()
+    engine = SimulationEngine(planner=Planner(perf_prio="time"))
     plan = engine.planner.plan(circuit)
     assert plan.final_backend == Backend.STATEVECTOR
     assert Backend.DECISION_DIAGRAM not in {s.backend for s in plan.steps}

--- a/tests/test_backend_symmetry_sparsity.py
+++ b/tests/test_backend_symmetry_sparsity.py
@@ -9,7 +9,7 @@ from quasar.config import DEFAULT
 def test_w_state_selects_decision_diagram_via_sparsity():
     circ = w_state_circuit(5)
     assert circ.sparsity >= DEFAULT.dd_sparsity_threshold
-    scheduler = Scheduler()
+    scheduler = Scheduler(planner=Planner(perf_prio="time"))
     scheduler.prepare_run(circ)
     part = circ.ssd.partitions[0]
     assert part.backend == Backend.DECISION_DIAGRAM
@@ -22,7 +22,7 @@ def test_high_rotation_diversity_stays_dense(monkeypatch):
     monkeypatch.setattr(config.DEFAULT, "dd_nnz_threshold", 10_000_000)
     monkeypatch.setattr(config.DEFAULT, "dd_phase_rotation_diversity_threshold", 3)
     monkeypatch.setattr(config.DEFAULT, "dd_amplitude_rotation_diversity_threshold", 3)
-    scheduler = Scheduler()
+    scheduler = Scheduler(planner=Planner(perf_prio="time"))
     scheduler.prepare_run(circ)
     part = circ.ssd.partitions[0]
     assert part.backend == Backend.STATEVECTOR
@@ -35,7 +35,7 @@ def test_high_nnz_stays_dense(monkeypatch):
     monkeypatch.setattr(config.DEFAULT, "dd_nnz_threshold", 1)
     monkeypatch.setattr(config.DEFAULT, "dd_phase_rotation_diversity_threshold", 1000)
     monkeypatch.setattr(config.DEFAULT, "dd_amplitude_rotation_diversity_threshold", 1000)
-    scheduler = Scheduler()
+    scheduler = Scheduler(planner=Planner(perf_prio="time"))
     scheduler.prepare_run(circ)
     part = circ.ssd.partitions[0]
     assert part.backend == Backend.STATEVECTOR
@@ -44,7 +44,7 @@ def test_high_nnz_stays_dense(monkeypatch):
 def test_random_circuit_stays_statevector_when_metrics_low():
     circ = random_circuit(5, seed=123)
     assert circ.sparsity < DEFAULT.dd_sparsity_threshold
-    scheduler = Scheduler()
+    scheduler = Scheduler(planner=Planner(perf_prio="time"))
     scheduler.prepare_run(circ)
     part = circ.ssd.partitions[0]
     assert part.backend == Backend.STATEVECTOR

--- a/tests/test_method_selection.py
+++ b/tests/test_method_selection.py
@@ -1,9 +1,10 @@
 from benchmarks.circuits import random_circuit
 from quasar import Circuit, Backend, Scheduler
+from quasar.planner import Planner
 
 
 def _prepare(circ: Circuit):
-    scheduler = Scheduler()
+    scheduler = Scheduler(planner=Planner(perf_prio="time"))
     plan = scheduler.prepare_run(circ)
     return scheduler, plan
 

--- a/tests/test_planner.py
+++ b/tests/test_planner.py
@@ -90,12 +90,13 @@ def test_conversion_cost_multiplier_discourages_switch():
         "ingest_sv": 0.375,
     }
     est = CostEstimator(coeff)
-    base = Planner(est)
+    base = Planner(est, perf_prio="time")
     steps = base.plan(circ).steps
     assert all(s.backend == Backend.STATEVECTOR for s in steps)
     penalized = Planner(
         est,
         conversion_cost_multiplier=50.0,
+        perf_prio="time",
     )
     steps2 = penalized.plan(circ).steps
     assert all(s.backend == Backend.STATEVECTOR for s in steps2)

--- a/tests/test_planner_perf_priority.py
+++ b/tests/test_planner_perf_priority.py
@@ -1,0 +1,43 @@
+from quasar.circuit import Circuit
+from quasar.cost import Cost, CostEstimator, ConversionEstimate
+from quasar.planner import Backend, Planner
+
+
+class MemoryEstimator(CostEstimator):
+    """Estimator favouring low-memory backends."""
+
+    def __init__(self):
+        super().__init__(chi_max=4)
+
+    def statevector(self, num_qubits, num_1q_gates, num_2q_gates, num_meas):
+        return Cost(time=1.0, memory=100.0)
+
+    def mps(self, num_qubits, num_1q_gates, num_2q_gates, chi, *, svd=False):
+        return Cost(time=10.0, memory=10.0)
+
+    def conversion(self, *args, **kwargs):
+        return ConversionEstimate("b2b", Cost(time=0.0, memory=0.0))
+
+
+def _example_circuit() -> Circuit:
+    gates = [
+        {"gate": "H", "qubits": [0]},
+        {"gate": "CX", "qubits": [0, 1]},
+        {"gate": "T", "qubits": [0]},
+    ]
+    return Circuit.from_dict(gates)
+
+
+def test_memory_priority_avoids_high_mem_backend():
+    circ = _example_circuit()
+    planner = Planner(MemoryEstimator())
+    result = planner.plan(circ)
+    assert result.steps[0].backend == Backend.MPS
+
+
+def test_time_priority_chooses_fast_backend():
+    circ = _example_circuit()
+    planner = Planner(MemoryEstimator(), perf_prio="time")
+    result = planner.plan(circ)
+    assert result.steps[0].backend == Backend.STATEVECTOR
+


### PR DESCRIPTION
## Summary
- allow choosing memory- or time-priority when comparing planner costs via new `perf_prio` option
- default to memory-first planning and document the behaviour
- test that planner avoids high-memory backends by default and can still favour speed when requested

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68bd1bf1fe7c8321b11ba8693a4ebe12