### PR TITLE
tests: benchmark quick-path heuristics for speed and memory

### DIFF
--- a/CLEANUP_CHECKLIST.md
+++ b/CLEANUP_CHECKLIST.md
@@ -1,0 +1,12 @@
+# Cleanup Checklist
+
+This checklist tracks occurrences of baseline placeholders or heuristics that may require follow-up.
+
+## Requires Follow-up
+- [ ] **Cost model coefficients** – `quasar/cost.py` uses empirically tuned baseline coefficients that may not reflect current backend performance. See [issues/cost_model_coefficients.md](issues/cost_model_coefficients.md).
+- [ ] **Quick-path thresholds** – default limits for bypassing planning may need validation. See [issues/quick_path_thresholds.md](issues/quick_path_thresholds.md).
+- [ ] **Quick-path memory usage** – compare peak memory between quick and full planning to tune thresholds. See [issues/quick_path_memory_usage.md](issues/quick_path_memory_usage.md).
+
+## No Action Needed
+- References to "baseline" backends in benchmarking code and notebooks are intended for comparison and do not affect full-system operation.
+- No occurrences of "placeholder" were found in the repository.

--- a/issues/cost_model_coefficients.md
+++ b/issues/cost_model_coefficients.md
@@ -1,0 +1,9 @@
+# Issue: Tune cost model coefficients
+
+**Location:** `quasar/cost.py` lines 89-121
+
+**Context:** The cost model initializes baseline coefficients with a comment "Baseline coefficients; tuned empirically in a full system." These defaults are placeholders for calibrated values.
+
+**Impact:** Does not impede system operation but may yield inaccurate cost estimates.
+
+**Task:** Develop and document a calibration procedure for cost coefficients across supported backends and update `quasar/cost.py` with validated values.

--- a/issues/quick_path_memory_usage.md
+++ b/issues/quick_path_memory_usage.md
@@ -1,0 +1,9 @@
+# Issue: Balance quick-path memory usage
+
+**Location:** `quasar/scheduler.py` lines 36-38 and `quasar/planner.py` lines 440-442
+
+**Context:** Quick-path heuristics prioritize faster planning but their impact on peak memory is unclear. Benchmarks should compare memory consumption between quick-path and full planning.
+
+**Impact:** Does not block system operation, yet suboptimal thresholds may increase memory usage on certain circuits.
+
+**Task:** Measure peak memory for representative circuits with and without quick-path heuristics and adjust `quick_max_*` defaults to favor memory savings while maintaining acceptable runtime.

--- a/issues/quick_path_thresholds.md
+++ b/issues/quick_path_thresholds.md
@@ -1,0 +1,9 @@
+# Issue: Review quick-path thresholds
+
+**Location:** `quasar/scheduler.py` and configuration defaults.
+
+**Context:** Quick-path heuristics determine when planning is bypassed. The repository includes `benchmarks/quick_analysis_benchmark.py` to guide tuning, but defaults may drift from optimal values.
+
+**Impact:** Does not block system operation but may reduce performance if thresholds are poorly tuned.
+
+**Task:** Run `benchmarks/quick_analysis_benchmark.py` on representative circuits to validate or update `quick_max_qubits`, `quick_max_gates`, and `quick_max_depth` defaults. Document the chosen values.

--- a/tests/test_quick_path_memory.py
+++ b/tests/test_quick_path_memory.py
@@ -1,0 +1,60 @@
+"""Benchmark quick-path memory usage on representative circuits.
+
+This test compares peak memory consumption when planning with and without
+quick-path heuristics.  The goal is to ensure the shortcuts do not
+increase memory usage relative to full planning, keeping the bias toward
+lower memory.
+"""
+from __future__ import annotations
+
+import tracemalloc
+
+import pytest
+
+from benchmarks.circuits import (
+    ghz_circuit,
+    qft_circuit,
+    random_circuit,
+    w_state_circuit,
+)
+from quasar import Scheduler
+from quasar.planner import Planner
+
+
+def _peak_memory(circ, *, quick: bool) -> int:
+    """Return peak memory in bytes for planning ``circ``."""
+    if quick:
+        planner = Planner(
+            quick_max_qubits=10_000,
+            quick_max_gates=1_000_000,
+            quick_max_depth=10_000,
+        )
+    else:
+        planner = Planner(quick_max_qubits=0, quick_max_gates=0, quick_max_depth=0)
+    tracemalloc.start()
+    planner.plan(circ)
+    _, peak = tracemalloc.get_traced_memory()
+    tracemalloc.stop()
+    return peak
+
+
+@pytest.mark.parametrize(
+    "circ",
+    [
+        ghz_circuit(5),
+        qft_circuit(5),
+        w_state_circuit(5),
+        random_circuit(5, seed=123),
+    ],
+)
+def test_quick_path_does_not_increase_memory(circ) -> None:
+    """Quick-path planning should not consume more memory."""
+    scheduler = Scheduler(
+        quick_max_qubits=10,
+        quick_max_gates=3000,
+        quick_max_depth=300,
+    )
+    assert scheduler.should_use_quick_path(circ)
+    quick_mem = _peak_memory(circ, quick=True)
+    full_mem = _peak_memory(circ, quick=False)
+    assert quick_mem <= full_mem

--- a/tests/test_quick_path_thresholds.py
+++ b/tests/test_quick_path_thresholds.py
@@ -1,0 +1,58 @@
+"""Benchmark quick-path thresholds on representative circuits.
+
+This test runs small circuits through the planner with and without
+quick-path heuristics to verify that the shortcuts provide tangible
+speedups.  It covers GHZ, QFT, W state preparation and a seeded
+random circuit so the results are comparable across runs.
+"""
+from __future__ import annotations
+
+import time
+
+import pytest
+
+from benchmarks.circuits import (
+    ghz_circuit,
+    qft_circuit,
+    random_circuit,
+    w_state_circuit,
+)
+from quasar import Scheduler
+from quasar.planner import Planner
+
+
+def _time_planning(circ, *, quick: bool) -> float:
+    """Return planning time for ``circ`` with or without quick analysis."""
+    if quick:
+        planner = Planner(
+            quick_max_qubits=10_000,
+            quick_max_gates=1_000_000,
+            quick_max_depth=10_000,
+        )
+    else:
+        planner = Planner(quick_max_qubits=0, quick_max_gates=0, quick_max_depth=0)
+    start = time.perf_counter()
+    planner.plan(circ)
+    return time.perf_counter() - start
+
+
+@pytest.mark.parametrize(
+    "circ",
+    [
+        ghz_circuit(5),
+        qft_circuit(5),
+        w_state_circuit(5),
+        random_circuit(5, seed=123),
+    ],
+)
+def test_quick_path_thresholds_match_performance(circ) -> None:
+    """Quick-path planning should be faster on small circuits."""
+    scheduler = Scheduler(
+        quick_max_qubits=10,
+        quick_max_gates=3000,
+        quick_max_depth=300,
+    )
+    assert scheduler.should_use_quick_path(circ)
+    quick_time = _time_planning(circ, quick=True)
+    full_time = _time_planning(circ, quick=False)
+    assert quick_time < full_time


### PR DESCRIPTION
## Summary
- Track follow-up task to balance quick-path memory usage with runtime thresholds
- Extend cleanup checklist with quick-path memory entry
- Benchmark planner peak memory on GHZ, QFT, W state, and seeded random circuits to ensure quick-path planning doesn't use more memory than full planning

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68bd49c7fc808321bb2a82ef7404af7b