### PR TITLE
Allow benchmarks to configure classical simplification

### DIFF
--- a/benchmarks/benchmark_cli.py
+++ b/benchmarks/benchmark_cli.py
@@ -58,9 +58,15 @@ def run_suite(
     engine = SimulationEngine()
     results = []
     for n in qubits:
-        circuit = circuit_fn(n)
-        if hasattr(circuit, "use_classical_simplification"):
-            circuit.use_classical_simplification = use_classical_simplification
+        try:
+            circuit = circuit_fn(
+                n, use_classical_simplification=use_classical_simplification
+            )
+        except TypeError:
+            circuit = circuit_fn(n)
+            reset = getattr(circuit, "reset_classical_simplification", None)
+            if callable(reset):
+                reset(use_classical_simplification)
         runner = BenchmarkRunner()
         rec = runner.run_quasar_multiple(
             circuit,

--- a/benchmarks/circuits.py
+++ b/benchmarks/circuits.py
@@ -21,15 +21,17 @@ from qiskit.circuit.random import random_circuit as qiskit_random_circuit
 from quasar.circuit import Circuit, Gate
 
 
-def ghz_circuit(n_qubits: int) -> Circuit:
+def ghz_circuit(
+    n_qubits: int, *, use_classical_simplification: bool = False
+) -> Circuit:
     """Create an ``n_qubits`` GHZ state preparation circuit."""
     gates: List[Gate] = []
     if n_qubits <= 0:
-        return Circuit(gates, use_classical_simplification=False)
+        return Circuit(gates, use_classical_simplification=use_classical_simplification)
     gates.append(Gate("H", [0]))
     for i in range(1, n_qubits):
         gates.append(Gate("CX", [i - 1, i]))
-    return Circuit(gates, use_classical_simplification=False)
+    return Circuit(gates, use_classical_simplification=use_classical_simplification)
 
 
 def _qft_spec(n: int) -> dict:
@@ -42,17 +44,28 @@ def _qft_spec(n: int) -> dict:
     return {"n_qubits": n, "gates": gates}
 
 
-def qft_circuit(n_qubits: int) -> Circuit:
+def qft_circuit(
+    n_qubits: int, *, use_classical_simplification: bool = False
+) -> Circuit:
     """Create an ``n_qubits`` quantum Fourier transform circuit."""
     spec = _qft_spec(n_qubits)
-    return Circuit(spec["gates"], use_classical_simplification=False)
+    return Circuit(spec["gates"], use_classical_simplification=use_classical_simplification)
 
 
-def qft_on_ghz_circuit(n_qubits: int) -> Circuit:
+def qft_on_ghz_circuit(
+    n_qubits: int, *, use_classical_simplification: bool = False
+) -> Circuit:
     """Apply the QFT to a GHZ state."""
-    ghz = ghz_circuit(n_qubits)
-    qft = qft_circuit(n_qubits)
-    return Circuit(list(ghz.gates) + list(qft.gates), use_classical_simplification=False)
+    ghz = ghz_circuit(
+        n_qubits, use_classical_simplification=use_classical_simplification
+    )
+    qft = qft_circuit(
+        n_qubits, use_classical_simplification=use_classical_simplification
+    )
+    return Circuit(
+        list(ghz.gates) + list(qft.gates),
+        use_classical_simplification=use_classical_simplification,
+    )
 
 
 def _w_state_spec(n: int) -> dict:
@@ -67,10 +80,14 @@ def _w_state_spec(n: int) -> dict:
     return {"n_qubits": n, "gates": gates}
 
 
-def w_state_circuit(n_qubits: int) -> Circuit:
+def w_state_circuit(
+    n_qubits: int, *, use_classical_simplification: bool = False
+) -> Circuit:
     """Create an ``n_qubits`` W state preparation circuit."""
     spec = _w_state_spec(n_qubits)
-    return Circuit(spec["gates"], use_classical_simplification=False)
+    return Circuit(
+        spec["gates"], use_classical_simplification=use_classical_simplification
+    )
 
 
 def grover_circuit(n_qubits: int, n_iterations: int = 1) -> Circuit:
@@ -336,12 +353,19 @@ def quantum_walk_circuit(num_qubits: int, depth: int) -> Circuit:
     return Circuit.from_qiskit(qc)
 
 
-def random_circuit(num_qubits: int, seed: int | None = None) -> Circuit:
+def random_circuit(
+    num_qubits: int,
+    seed: int | None = None,
+    *,
+    use_classical_simplification: bool = False,
+) -> Circuit:
     """Generate a random circuit of depth ``2*num_qubits``."""
 
     qc = qiskit_random_circuit(num_qubits, 2 * num_qubits, seed=seed)
     qc = transpile(qc, basis_gates=["u", "p", "cx", "h", "x"])
-    return Circuit.from_qiskit(qc, use_classical_simplification=False)
+    return Circuit.from_qiskit(
+        qc, use_classical_simplification=use_classical_simplification
+    )
 
 
 def shor_circuit(circuit_size: int) -> Circuit:

--- a/tests/test_benchmark_circuits.py
+++ b/tests/test_benchmark_circuits.py
@@ -8,6 +8,7 @@ from benchmarks.circuits import (
     w_state_circuit,
     grover_circuit,
     bernstein_vazirani_circuit,
+    qft_circuit,
 )
 
 
@@ -33,6 +34,13 @@ def test_ghz_circuit_state():
     expected[0] = 1 / math.sqrt(2)
     expected[-1] = 1 / math.sqrt(2)
     _assert_equivalent(state, expected)
+
+
+def test_qft_circuit_respects_flag():
+    circ = qft_circuit(2, use_classical_simplification=True)
+    assert circ.use_classical_simplification is True
+    circ2 = qft_circuit(2)
+    assert circ2.use_classical_simplification is False
 
 
 def test_w_state_circuit_state():

--- a/tests/test_benchmark_run_suite.py
+++ b/tests/test_benchmark_run_suite.py
@@ -1,0 +1,38 @@
+import sys
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parents[1] / "benchmarks"))
+import benchmark_cli
+
+from quasar.circuit import Circuit
+
+
+def dummy_run_quasar_multiple(self, circuit, engine, backend, repetitions):
+    return {
+        "backend": backend.name if hasattr(backend, "name") else backend,
+        "repetitions": repetitions,
+        "run_time_mean": 0.0,
+        "run_time_std": 0.0,
+        "total_time_mean": 0.0,
+        "total_time_std": 0.0,
+        "prepare_peak_memory_mean": 0.0,
+        "prepare_peak_memory_std": 0.0,
+        "run_peak_memory_mean": 0.0,
+        "run_peak_memory_std": 0.0,
+    }
+
+
+def test_run_suite_passes_classical_flag(monkeypatch):
+    flags = []
+
+    def circuit_fn(n, *, use_classical_simplification):
+        flags.append(use_classical_simplification)
+        return Circuit([], use_classical_simplification=use_classical_simplification)
+
+    monkeypatch.setattr(benchmark_cli, "SimulationEngine", lambda: object())
+    monkeypatch.setattr(
+        benchmark_cli.BenchmarkRunner, "run_quasar_multiple", dummy_run_quasar_multiple
+    )
+    results = benchmark_cli.run_suite(circuit_fn, [1], 1, use_classical_simplification=False)
+    assert flags == [False]
+    assert results[0]["qubits"] == 1


### PR DESCRIPTION
## Summary
- Add `use_classical_simplification` flag to GHZ, QFT, W-state, random, and QFT-on-GHZ circuit generators
- Pass classical simplification setting directly when constructing circuits in `benchmark_cli.run_suite`
- Test QFT circuit flag and ensure `run_suite` forwards the option

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68bd4e036ce083219a3fd09e12885fcf