### PR TITLE
Simplify classical controls before planning

### DIFF
--- a/quasar/planner.py
+++ b/quasar/planner.py
@@ -967,9 +967,11 @@ class Planner:
         is restricted to Clifford circuits).
         """
 
-        gates = circuit.gates
+        gates = circuit.simplify_classical_controls()
         names = [g.gate.upper() for g in gates]
-        clifford_circuit = bool(names) and all(name in CLIFFORD_GATES for name in names)
+        clifford_circuit = bool(names) and all(
+            name in CLIFFORD_GATES for name in names
+        )
         allow_tableau = clifford_circuit
 
         threshold = max_memory if max_memory is not None else self.max_memory

--- a/tests/test_planner.py
+++ b/tests/test_planner.py
@@ -26,6 +26,19 @@ def test_explicit_statevector_for_clifford():
     assert steps[0].backend == Backend.STATEVECTOR
 
 
+def test_planner_simplifies_controls_for_clifford_detection():
+    gates = [
+        {"gate": "H", "qubits": [1]},
+        {"gate": "CT", "qubits": [0, 2]},
+    ]
+    circ = Circuit.from_dict(gates, use_classical_simplification=False)
+    circ.use_classical_simplification = True
+    circ.classical_state = [0] * circ.num_qubits
+    result = Planner().plan(circ, backend=Backend.TABLEAU)
+    assert result.final_backend == Backend.TABLEAU
+    assert [g.gate for g in circ.gates] == ["H"]
+
+
 def test_statevector_for_non_clifford():
     gates = [
         {"gate": "CX", "qubits": [0, 1]},


### PR DESCRIPTION
## Summary
- Simplify classical-control gates at the start of `Planner.plan` and base Clifford checks on the simplified list
- Add regression test ensuring planning detects Clifford circuits after control simplification

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68bd4ff9e2748321bce6aa150a26e75e