### PR TITLE
Add helper for re-enabling classical simplification

### DIFF
--- a/benchmarks/benchmark_cli.py
+++ b/benchmarks/benchmark_cli.py
@@ -64,9 +64,14 @@ def run_suite(
             )
         except TypeError:
             circuit = circuit_fn(n)
-            reset = getattr(circuit, "reset_classical_simplification", None)
-            if callable(reset):
-                reset(use_classical_simplification)
+            if use_classical_simplification:
+                enable = getattr(circuit, "enable_classical_simplification", None)
+                if callable(enable):
+                    enable()
+                else:
+                    circuit.use_classical_simplification = True
+            else:
+                circuit.use_classical_simplification = False
         runner = BenchmarkRunner()
         rec = runner.run_quasar_multiple(
             circuit,

--- a/quasar/circuit.py
+++ b/quasar/circuit.py
@@ -242,6 +242,19 @@ class Circuit:
         self.cost_estimates = self._estimate_costs()
         return new_gates
 
+    def enable_classical_simplification(self) -> None:
+        """Enable classical control simplification on an existing circuit.
+
+        The classical state is reset to all zeros before re-running
+        :meth:`simplify_classical_controls` so that cached metrics such as
+        depth, sparsity and cost estimates reflect the simplified circuit.
+        """
+
+        self.use_classical_simplification = True
+        max_index = max((q for gate in self.gates for q in gate.qubits), default=-1)
+        self.classical_state = [0] * (max_index + 1)
+        self.simplify_classical_controls()
+
     # ------------------------------------------------------------------
     # Construction helpers
     # ------------------------------------------------------------------

--- a/tests/test_circuit.py
+++ b/tests/test_circuit.py
@@ -118,12 +118,10 @@ def test_metrics_recomputed_after_simplification():
         {"gate": "X", "qubits": [0]},
         {"gate": "CX", "qubits": [0, 1]},
     ], use_classical_simplification=False)
-    circ.classical_state = [0] * circ.num_qubits
     initial_costs = circ.cost_estimates.copy()
     assert circ.depth > 0
 
-    circ.use_classical_simplification = True
-    circ.simplify_classical_controls()
+    circ.enable_classical_simplification()
 
     assert circ.gates == []
     assert circ.depth == 0


### PR DESCRIPTION
## Summary
- add `enable_classical_simplification` to rebuild classical state and re-run gate simplification
- use the helper when toggling simplification in benchmark CLI
- update tests for new helper

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68bd4fadc7848321871eebdc2a40a21c