### PR TITLE
Refine exception handling in comparison notebook test

### DIFF
--- a/tests/test_comparison_notebook.py
+++ b/tests/test_comparison_notebook.py
@@ -24,14 +24,20 @@ def test_notebook_comparison_behaviour():
                 rec = runner.run_quasar_multiple(base, engine, backend=b, repetitions=1)
                 rec.update({'circuit': name, 'mode': 'forced'})
                 records.append(rec)
-            except Exception:
+            except RuntimeError:
+                # some backend/circuit combinations are unsupported and
+                # ``run_quasar_multiple`` raises a RuntimeError in those cases
+                # when no runs can be executed.  Treat these as expected
+                # failures for the purposes of this comparison and skip them.
                 pass
         try:
             auto = build(5, use_classical_simplification=True)
             rec = runner.run_quasar_multiple(auto, engine, repetitions=1)
             rec.update({'circuit': name, 'mode': 'auto'})
             records.append(rec)
-        except Exception:
+        except RuntimeError:
+            # As above, only ignore known failures where the automatic
+            # selection could not execute any runs.
             pass
 
     df = pd.DataFrame(records)


### PR DESCRIPTION
## Summary
- Avoid catching all exceptions in `test_comparison_notebook.py`
- Only swallow known `RuntimeError` cases when benchmark runs cannot be executed

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68bd5ac13a78832189d6252741be7f65