### PR TITLE
test: cover classical simplification on benchmark circuits

### DIFF
--- a/tests/test_classical_simplification_equivalence.py
+++ b/tests/test_classical_simplification_equivalence.py
@@ -1,0 +1,23 @@
+from benchmarks.circuits import ghz_circuit, qft_circuit, w_state_circuit
+from quasar.circuit import Gate
+
+
+def test_classical_simplification_equivalence() -> None:
+    n = 4
+
+    ghz = ghz_circuit(n)
+    ghz_original = list(ghz.gates)
+    ghz.enable_classical_simplification()
+    assert ghz.gates == ghz_original
+
+    w_state = w_state_circuit(n)
+    w_original = list(w_state.gates)
+    w_state.enable_classical_simplification()
+    assert w_state.gates == w_original
+
+    qft = qft_circuit(n)
+    qft_original = list(qft.gates)
+    qft.enable_classical_simplification()
+    assert qft.gates != qft_original
+    expected = [Gate("H", [i]) for i in reversed(range(n))]
+    assert qft.gates == expected


### PR DESCRIPTION
## Summary
- add regression test to ensure classical simplification leaves GHZ and W-state circuits unchanged
- verify QFT circuit sheds controlled phases and reduces to Hadamards

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68bd6290ebac8321953b367df45cd459