### PR TITLE
Return benchmark states

### DIFF
--- a/benchmarks/backends.py
+++ b/benchmarks/backends.py
@@ -29,7 +29,7 @@ class _Adapter:
         self.backend.apply_gate(gate, qubits, params)
 
     def run_benchmark(self, *, return_state: bool = False) -> Any | None:
-        result = self.backend.run_benchmark()
+        result = self.backend.run_benchmark(return_state=return_state)
         if return_state:
             if result is None and hasattr(self.backend, "statevector"):
                 try:

--- a/benchmarks/benchmark_cli.py
+++ b/benchmarks/benchmark_cli.py
@@ -79,6 +79,7 @@ def run_suite(
             backend=Backend.STATEVECTOR,
             repetitions=repetitions,
         )
+        _state = rec.get("result")  # retain state for potential downstream use
         record = {
             "circuit": circuit_fn.__name__,
             "qubits": n,

--- a/benchmarks/runner.py
+++ b/benchmarks/runner.py
@@ -87,6 +87,7 @@ class BenchmarkRunner:
                 _, prepare_peak_memory = tracemalloc.get_traced_memory()
                 tracemalloc.reset_peak()
 
+                kwargs.setdefault("return_state", True)
                 start_run = time.perf_counter()
                 result = backend.run_benchmark(**kwargs)
                 run_time = time.perf_counter() - start_run
@@ -278,6 +279,8 @@ class BenchmarkRunner:
             summary[f"{m}_std"] = (
                 statistics.pstdev(values) if len(values) > 1 else 0.0
             )
+
+        summary["result"] = records[-1].get("result") if records else None
 
         self.results.append(summary)
         return summary
@@ -544,6 +547,8 @@ class BenchmarkRunner:
             summary[f"{m}_std"] = (
                 statistics.pstdev(values) if len(values) > 1 else 0.0
             )
+
+        summary["result"] = records[-1].get("result") if records else None
 
         self.results.append(summary)
         return summary

--- a/quasar/backends/mps.py
+++ b/quasar/backends/mps.py
@@ -195,13 +195,13 @@ class MPSBackend(Backend):
         self._cached_state = None
         self._cached_statevector = None
 
-    def run_benchmark(self) -> object:
-        """Execute the prepared circuit once and cache the resulting state."""
+    def run_benchmark(self, *, return_state: bool = False) -> object | None:
+        """Execute the prepared circuit once and optionally return the state."""
         self._benchmark_mode = False
         state = self._run()
         self._cached_state = state
         self._cached_statevector = None
-        return state
+        return state if return_state else None
 
     # ------------------------------------------------------------------
     def _run(self) -> object:

--- a/quasar/backends/mqt_dd.py
+++ b/quasar/backends/mqt_dd.py
@@ -133,11 +133,13 @@ class DecisionDiagramBackend(Backend):
             self.apply_gate(name, qubits, params)
 
     # ------------------------------------------------------------------
-    def run_benchmark(self) -> None:
-        """Apply queued gates and cache the resulting state."""
+    def run_benchmark(self, *, return_state: bool = False) -> SSD | None:
+        """Apply queued gates and optionally return the final state."""
 
         self.run()
         self._benchmark_state = self.state if isinstance(self.state, dd.VectorDD) else None
+        if return_state:
+            return self.extract_ssd()
         return None
 
     # ------------------------------------------------------------------

--- a/quasar/backends/statevector.py
+++ b/quasar/backends/statevector.py
@@ -172,12 +172,12 @@ class StatevectorBackend(Backend):
         self._benchmark_ops = []
         self._cached_state = None
 
-    def run_benchmark(self) -> np.ndarray:
-        """Execute the prepared circuit once and cache the resulting state."""
+    def run_benchmark(self, *, return_state: bool = False) -> np.ndarray | None:
+        """Execute the prepared circuit once and optionally return the state."""
         self._benchmark_mode = False
         state = self._run()
         self._cached_state = state
-        return state
+        return state if return_state else None
 
     # ------------------------------------------------------------------
     def _run(self) -> np.ndarray:

--- a/quasar/backends/stim_backend.py
+++ b/quasar/backends/stim_backend.py
@@ -120,16 +120,8 @@ class StimBackend(Backend):
         for name, qubits, params in ops:
             self.apply_gate(name, qubits, params)
 
-    def run_benchmark(self) -> None:
-        """Execute queued operations and cache the resulting tableau.
-
-        Benchmarking should avoid generating a dense statevector as this would
-        defeat the purpose of timing a stabilizer simulation.  Instead we apply
-        the queued gates via :meth:`run` and store the resulting tableau in
-        ``_benchmark_tableau`` for later retrieval by :meth:`extract_ssd`.
-        ``None`` is returned so callers do not accidentally trigger a
-        statevector extraction.
-        """
+    def run_benchmark(self, *, return_state: bool = False) -> SSD | None:
+        """Execute queued operations and optionally return the final state."""
         self.run()
         self._benchmark_tableau = None
         if self.simulator is not None:
@@ -137,6 +129,8 @@ class StimBackend(Backend):
                 self._benchmark_tableau = self.simulator.current_inverse_tableau()
             except Exception:
                 self._benchmark_tableau = None
+        if return_state:
+            return self.extract_ssd()
         return None
 
     def extract_ssd(self) -> SSD:

--- a/tests/backends/test_mps.py
+++ b/tests/backends/test_mps.py
@@ -42,7 +42,7 @@ def test_mps_benchmark_uses_cached_state(monkeypatch):
         return original_run()
 
     monkeypatch.setattr(backend, "_run", run_spy)
-    state = backend.run_benchmark()
+    state = backend.run_benchmark(return_state=True)
     assert run_calls["n"] == 1
 
     def fail_run() -> object:  # pragma: no cover - should not run

--- a/tests/backends/test_mqt_dd.py
+++ b/tests/backends/test_mqt_dd.py
@@ -12,12 +12,6 @@ def test_mqt_dd_benchmark_uses_cached_state(monkeypatch):
         raise AssertionError("statevector called during run_benchmark")
 
     monkeypatch.setattr(backend, "statevector", fail_statevector)
-    original_extract = backend.extract_ssd
-
-    def fail_extract():  # pragma: no cover - should not be called
-        raise AssertionError("extract_ssd called during run_benchmark")
-
-    monkeypatch.setattr(backend, "extract_ssd", fail_extract)
 
     run_calls = {"n": 0}
     original_run = backend.run
@@ -28,17 +22,13 @@ def test_mqt_dd_benchmark_uses_cached_state(monkeypatch):
 
     monkeypatch.setattr(backend, "run", run_spy)
 
-    result = backend.run_benchmark()
-    assert result is None
+    result = backend.run_benchmark(return_state=True)
     assert run_calls["n"] == 1
     state = backend._benchmark_state
-    assert state is backend.state
-
-    monkeypatch.setattr(backend, "extract_ssd", original_extract)
+    assert result.partitions[0].state[1] is state
 
     def fail_run() -> None:  # pragma: no cover - should not be called
         raise AssertionError("run invoked despite cached state")
-
     monkeypatch.setattr(backend, "run", fail_run)
     ssd = backend.extract_ssd()
     assert ssd.partitions[0].state[1] is state

--- a/tests/backends/test_statevector.py
+++ b/tests/backends/test_statevector.py
@@ -8,7 +8,7 @@ def test_statevector_benchmark_uses_cached_state(monkeypatch):
     backend.load(1)
     backend.prepare_benchmark()
     backend.apply_gate("H", [0])
-    state = backend.run_benchmark()
+    state = backend.run_benchmark(return_state=True)
 
     def fail_run():  # pragma: no cover - should not be called
         raise AssertionError("_run invoked despite cached state")

--- a/tests/test_comparison_notebook.py
+++ b/tests/test_comparison_notebook.py
@@ -4,6 +4,7 @@ import pytest
 import benchmarks.circuits as circuit_lib
 from benchmarks.runner import BenchmarkRunner
 from quasar import Backend, SimulationEngine
+from quasar.ssd import SSD
 
 
 @pytest.mark.parametrize("num_qubits", [3, 5])
@@ -28,6 +29,8 @@ def test_notebook_comparison_behaviour(num_qubits: int) -> None:
                 rec = runner.run_quasar_multiple(base, engine, backend=b, repetitions=1)
                 rec.update({"circuit": name, "mode": "forced"})
                 records.append(rec)
+                state_rec = runner.run_quasar(base, engine, backend=b)
+                assert isinstance(state_rec["result"], SSD)
             except RuntimeError:
                 pass
         try:
@@ -35,6 +38,8 @@ def test_notebook_comparison_behaviour(num_qubits: int) -> None:
             rec = runner.run_quasar_multiple(auto, engine, repetitions=1)
             rec.update({"circuit": name, "mode": "auto"})
             records.append(rec)
+            state_rec = runner.run_quasar(auto, engine)
+            assert isinstance(state_rec["result"], SSD)
         except RuntimeError:
             pass
 


### PR DESCRIPTION
## Summary
- ensure benchmarks request backend state via `run_benchmark(return_state=True)`
- add optional state return to all backends and propagate through runner
- test that forced and auto-selected benchmark runs expose a resulting SSD

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68bda42f4cc48321a96d5fa651184863