### PR TITLE
Optimize single backend run in scheduler

### DIFF
--- a/tests/test_scheduler_single_backend_parity.py
+++ b/tests/test_scheduler_single_backend_parity.py
@@ -1,0 +1,30 @@
+from quasar.circuit import Circuit
+from quasar.scheduler import Scheduler
+
+
+def test_single_backend_auto_and_fixed_runtime_parity(monkeypatch):
+    scheduler = Scheduler()
+    auto_circ = Circuit([
+        {"gate": "H", "qubits": [0]},
+        {"gate": "X", "qubits": [0]},
+    ])
+    fixed_circ = Circuit([
+        {"gate": "H", "qubits": [0]},
+        {"gate": "X", "qubits": [0]},
+    ])
+
+    backend = scheduler.select_backend(auto_circ)
+
+    times = iter(range(100))
+    monkeypatch.setattr("quasar.scheduler.time.perf_counter", lambda: next(times))
+    monkeypatch.setattr("quasar.scheduler.tracemalloc.start", lambda: None)
+    monkeypatch.setattr("quasar.scheduler.tracemalloc.stop", lambda: None)
+    monkeypatch.setattr("quasar.scheduler.tracemalloc.reset_peak", lambda: None)
+    monkeypatch.setattr(
+        "quasar.scheduler.tracemalloc.get_traced_memory", lambda: (0, 0)
+    )
+
+    _, auto_cost = scheduler.run(auto_circ, instrument=True)
+    _, fixed_cost = scheduler.run(fixed_circ, instrument=True, backend=backend)
+
+    assert auto_cost.time == fixed_cost.time


### PR DESCRIPTION
## Summary
- Detect single-step plans without conversions and execute directly on chosen backend
- Preserve instrumentation while replaying gates for single-backend plans
- Add regression test asserting runtime parity between auto and fixed single-backend runs

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68bdaa0842148321a7ca98ef12e83f4e