### PR TITLE
Respect quick-path heuristics with forced backend

### DIFF
--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -78,7 +78,8 @@ CLI can discover it automatically.  The existing functions, such as
 
 Benchmarks can force a particular simulator without using adapter classes.
 Invoke :func:`benchmarks.runner.BenchmarkRunner.run_quasar_multiple` and pass
-the desired :class:`quasar.cost.Backend` value:
+the desired :class:`quasar.cost.Backend` value.  Set ``quick=True`` to bypass
+planning and execute directly on the chosen backend:
 
 ```python
 from benchmarks.runner import BenchmarkRunner
@@ -87,7 +88,13 @@ from quasar.cost import Backend
 
 runner = BenchmarkRunner()
 engine = SimulationEngine()
-rec = runner.run_quasar_multiple(circuit, engine, backend=Backend.STATEVECTOR, repetitions=3)
+rec = runner.run_quasar_multiple(
+    circuit,
+    engine,
+    backend=Backend.STATEVECTOR,
+    repetitions=3,
+    quick=True,
+)
 ```
 
 This leverages the scheduler while still collecting timings for a single

--- a/benchmarks/benchmark_cli.py
+++ b/benchmarks/benchmark_cli.py
@@ -82,6 +82,7 @@ def run_suite(
             engine,
             backend=Backend.STATEVECTOR,
             repetitions=repetitions,
+            quick=True,
         )
         state = rec.get("result")
         if state is None:

--- a/quasar/scheduler.py
+++ b/quasar/scheduler.py
@@ -62,14 +62,19 @@ class Scheduler:
             }
 
     def should_use_quick_path(
-        self, circuit: Circuit, *, backend: Backend | None = None
+        self,
+        circuit: Circuit,
+        *,
+        backend: Backend | None = None,
+        force: bool = False,
     ) -> bool:
         """Return ``True`` if ``circuit`` can bypass planning.
 
-        The decision is based on the quick‑path heuristics configured for the
-        scheduler.  When ``backend`` is explicitly specified the caller is
-        requesting direct execution on a backend and therefore planning is not
-        required.
+        The decision is based on the quick-path heuristics configured for the
+        scheduler.  Explicitly setting ``force`` to ``True`` bypasses these
+        heuristics and unconditionally enables quick-path execution.  When a
+        backend is specified the heuristics are still evaluated unless
+        ``force`` is also ``True``.
 
         Parameters
         ----------
@@ -77,15 +82,17 @@ class Scheduler:
             Circuit to simulate.
         backend:
             Optional override selecting a specific backend.
+        force:
+            When ``True`` skip heuristic checks and force quick-path execution.
 
         Returns
         -------
         bool
             ``True`` when the circuit is small enough to execute directly
-            without invoking the planner.
+            without invoking the planner or when ``force`` is ``True``.
         """
 
-        if backend is not None:
+        if force:
             return True
 
         quick = True

--- a/tests/test_benchmark_quick_path_prebuild.py
+++ b/tests/test_benchmark_quick_path_prebuild.py
@@ -49,7 +49,7 @@ class DummyScheduler:
         self.backends = {Backend.STATEVECTOR: DummyBackend()}
         self.ran = False
 
-    def should_use_quick_path(self, circuit, *, backend=None):  # pragma: no cover - trivial
+    def should_use_quick_path(self, circuit, *, backend=None, force: bool = False):  # pragma: no cover - trivial
         return True
 
     def select_backend(self, circuit, *, backend=None):  # pragma: no cover - trivial

--- a/tests/test_benchmark_run_suite.py
+++ b/tests/test_benchmark_run_suite.py
@@ -7,7 +7,7 @@ import benchmark_cli
 from quasar.circuit import Circuit
 
 
-def dummy_run_quasar_multiple(self, circuit, engine, backend, repetitions):
+def dummy_run_quasar_multiple(self, circuit, engine, backend, repetitions, quick=False):
     return {
         "backend": backend.name if hasattr(backend, "name") else backend,
         "repetitions": repetitions,

--- a/tests/test_benchmark_state_return.py
+++ b/tests/test_benchmark_state_return.py
@@ -22,7 +22,7 @@ class DummyScheduler:
 
         self.planner = Planner()
 
-    def should_use_quick_path(self, circuit, *, backend=None):
+    def should_use_quick_path(self, circuit, *, backend=None, force: bool = False):
         return False
 
     def prepare_run(self, circuit, plan=None, *, backend=None):

--- a/tests/test_comparison_notebook.py
+++ b/tests/test_comparison_notebook.py
@@ -26,10 +26,12 @@ def test_notebook_comparison_behaviour(num_qubits: int) -> None:
             if name == "wstate" and b == Backend.TABLEAU:
                 continue
             try:
-                rec = runner.run_quasar_multiple(base, engine, backend=b, repetitions=1)
+                rec = runner.run_quasar_multiple(
+                    base, engine, backend=b, repetitions=1, quick=True
+                )
                 rec.update({"circuit": name, "mode": "forced"})
                 records.append(rec)
-                state_rec = runner.run_quasar(base, engine, backend=b)
+                state_rec = runner.run_quasar(base, engine, backend=b, quick=True)
                 assert isinstance(state_rec["result"], SSD)
             except RuntimeError:
                 pass

--- a/tests/test_quick_path_thresholds.py
+++ b/tests/test_quick_path_thresholds.py
@@ -19,6 +19,7 @@ from benchmarks.circuits import (
 )
 from quasar import Scheduler
 from quasar.planner import Planner
+from quasar.cost import Backend
 
 
 def _time_planning(circ, *, quick: bool) -> float:
@@ -56,3 +57,12 @@ def test_quick_path_thresholds_match_performance(circ) -> None:
     quick_time = _time_planning(circ, quick=True)
     full_time = _time_planning(circ, quick=False)
     assert quick_time < full_time
+
+
+def test_backend_still_checks_quick_path() -> None:
+    scheduler = Scheduler(quick_max_qubits=1, quick_max_gates=1, quick_max_depth=1)
+    circ = ghz_circuit(2)
+    assert not scheduler.should_use_quick_path(circ, backend=Backend.STATEVECTOR)
+    assert scheduler.should_use_quick_path(
+        circ, backend=Backend.STATEVECTOR, force=True
+    )


### PR DESCRIPTION
## Summary
- allow `Scheduler.should_use_quick_path` to evaluate heuristics even when a backend is supplied
- add `quick`/`force` flags so benchmarks can explicitly request quick-path execution
- document and exercise the new explicit quick-path option

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68bdc18c22448321ac9a1b3f2f717b8f