### PR TITLE
Refactor benchmark runner to use single instrumented QuASAr run

### DIFF
--- a/tests/test_benchmark_run_multiple.py
+++ b/tests/test_benchmark_run_multiple.py
@@ -352,9 +352,24 @@ class RunErrorScheduler:
         ]), Cost(time=0.0, memory=0.0)
 
 
+class RunFailScheduler:
+    def __init__(self):
+        class Planner:
+            def plan(self, circuit, *, backend=None):
+                return PlanResult(table=[], final_backend=backend, gates=[], explicit_steps=[], explicit_conversions=[], step_costs=[])
+
+        self.planner = Planner()
+
+    def prepare_run(self, circuit, plan=None, *, backend=None):
+        return plan
+
+    def run(self, circuit, plan, *, monitor=None, instrument=False):
+        raise ValueError("run boom")
+
+
 def test_run_quasar_returns_failure_record_on_run_error():
     runner = BenchmarkRunner()
-    scheduler = RunErrorScheduler()
+    scheduler = RunFailScheduler()
     record = runner.run_quasar(None, scheduler)
     assert record["failed"] is True
     assert "run boom" in record["error"]

--- a/tests/test_benchmark_runner_memory.py
+++ b/tests/test_benchmark_runner_memory.py
@@ -46,7 +46,7 @@ class DummyScheduler:
         self.instrument_calls.append(instrument)
         self._data = [0] * 10000
         if instrument:
-            return "done", Cost(time=0.0, memory=0.0)
+            return "done", Cost(time=0.0, memory=123.0)
         return "done"
 
 
@@ -57,4 +57,4 @@ def test_run_quasar_records_memory():
     assert record["prepare_peak_memory"] > 0
     assert record["run_peak_memory"] > 0
     assert "backend" in record and record["backend"] is None
-    assert scheduler.instrument_calls == [True, False]
+    assert scheduler.instrument_calls == [True]


### PR DESCRIPTION
## Summary
- Simplify `run_quasar` to execute the scheduler only once with `instrument=True`
- Use returned `Cost` object for runtime and memory metrics and exclude simulation from `prepare_time`
- Adjust tests for new instrumentation behavior

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bdd5da15f8832198d8ad074f60ea0e