### PR TITLE
Decouple instrumentation from run_quasar_multiple

### DIFF
--- a/tests/test_backend_selection_timing.py
+++ b/tests/test_backend_selection_timing.py
@@ -5,29 +5,31 @@ from quasar.planner import Planner
 import pytest
 
 
-def test_backend_selection_timing():
+def test_auto_and_forced_single_backend_have_equal_runtime():
     circuit_auto = Circuit([
         {"gate": "H", "qubits": [0]},
         {"gate": "RZ", "qubits": [0], "params": {"param0": 0.3}},
     ])
     engine_auto = SimulationEngine(planner=Planner(perf_prio="time"))
 
-    runner = BenchmarkRunner()
-    auto = runner.run_quasar_multiple(circuit_auto, engine_auto, repetitions=3)
-
     circuit_forced = Circuit([
         {"gate": "H", "qubits": [0]},
         {"gate": "RZ", "qubits": [0], "params": {"param0": 0.3}},
     ])
     engine_forced = SimulationEngine(planner=Planner(perf_prio="time"))
+
+    runner = BenchmarkRunner()
+    runner.setup_quasar(circuit_auto, engine_auto)
+    runner.setup_quasar(circuit_forced, engine_forced, backend=Backend.STATEVECTOR)
     forced = runner.run_quasar_multiple(
-        circuit_forced, engine_forced, backend=Backend.STATEVECTOR, repetitions=3
+        circuit_forced, engine_forced, backend=Backend.STATEVECTOR, repetitions=10
     )
+    auto = runner.run_quasar_multiple(circuit_auto, engine_auto, repetitions=10)
 
     assert auto["backend"] == "STATEVECTOR"
     assert forced["backend"] == "STATEVECTOR"
-    assert auto["run_time_mean"] == pytest.approx(forced["run_time_mean"], rel=0.5)
+    assert auto["run_time_mean"] == pytest.approx(forced["run_time_mean"], rel=0.1)
     assert auto["run_peak_memory_mean"] == pytest.approx(
-        forced["run_peak_memory_mean"], rel=0.5
+        forced["run_peak_memory_mean"], rel=0.1
     )
 

--- a/tests/test_benchmark_run_multiple.py
+++ b/tests/test_benchmark_run_multiple.py
@@ -192,7 +192,7 @@ def test_run_quasar_multiple_aggregates_statistics():
     assert record["run_time_mean"] == 2.0
     assert math.isclose(record["run_time_std"], math.sqrt(2 / 3))
     assert scheduler.plan_calls == [Backend.TABLEAU]
-    assert scheduler.run_calls == [(Backend.TABLEAU, True)] + [(Backend.TABLEAU, False)] * 3
+    assert scheduler.run_calls == [(Backend.TABLEAU, False)] * 3
     assert record["backend"] == Backend.TABLEAU.name
 
 


### PR DESCRIPTION
## Summary
- Add `setup_quasar` helper to run an instrumented warm-up outside timed executions
- Remove pre-measurement `scheduler.run(..., instrument=True)` from `run_quasar_multiple` and restore any estimator or SSD state after planning
- Add regression test ensuring auto and forced single-backend runs have matching runtimes

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bdd953670083218836c561243972a1