### PR TITLE
Handle non-serializable parameters in environment notebook

### DIFF
--- a/benchmarks/circuits.py
+++ b/benchmarks/circuits.py
@@ -447,7 +447,8 @@ def vqe_chain_circuit(num_qubits: int = 6, depth: int = 2) -> Circuit:
     """Parameterized VQE ansatz with linear entanglement chain."""
     qc = EfficientSU2(num_qubits, reps=depth, entanglement="linear")
     qc = transpile(qc, basis_gates=["u", "p", "cx", "h", "x", "ry", "rz"])
-    return Circuit.from_qiskit(qc)
+    # Disable classical simplification to avoid issues with unbound parameters
+    return Circuit.from_qiskit(qc, use_classical_simplification=False)
 
 
 def random_hybrid_circuit(num_qubits: int = 6, depth: int = 10, seed: int | None = None) -> Circuit:

--- a/benchmarks/notebooks/00_environment_setup.ipynb
+++ b/benchmarks/notebooks/00_environment_setup.ipynb
@@ -16,10 +16,10 @@
    "id": "b27a5f69",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2025-09-06T09:00:06.353964Z",
-     "iopub.status.busy": "2025-09-06T09:00:06.353631Z",
-     "iopub.status.idle": "2025-09-06T09:00:06.862293Z",
-     "shell.execute_reply": "2025-09-06T09:00:06.861468Z"
+     "iopub.execute_input": "2025-09-08T06:23:27.624491Z",
+     "iopub.status.busy": "2025-09-08T06:23:27.624252Z",
+     "iopub.status.idle": "2025-09-08T06:23:28.090050Z",
+     "shell.execute_reply": "2025-09-08T06:23:28.089367Z"
     }
    },
    "outputs": [
@@ -37,7 +37,7 @@
        " 'mqt_dd_version': '2.0.0',\n",
        " 'mqt_core_version': '3.2.1',\n",
        " 'pybind11_version': None,\n",
-       " 'quasar_commit': '3dfe9c4e4934095b6c80ea6d77d2f422211de9ac',\n",
+       " 'quasar_commit': '97ae58e04fc7c17d96371c0f300c8231aafc38b6',\n",
        " 'compiler': 'cc (Ubuntu 13.3.0-6ubuntu2~24.04) 13.3.0',\n",
        " 'cmake_version': 'cmake version 3.28.3',\n",
        " 'QUASAR_QUICK_MAX_QUBITS': None,\n",
@@ -112,20 +112,31 @@
    "id": "1866aa7a",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2025-09-06T09:00:06.864701Z",
-     "iopub.status.busy": "2025-09-06T09:00:06.864428Z",
-     "iopub.status.idle": "2025-09-06T09:00:06.870122Z",
-     "shell.execute_reply": "2025-09-06T09:00:06.869575Z"
+     "iopub.execute_input": "2025-09-08T06:23:28.092086Z",
+     "iopub.status.busy": "2025-09-08T06:23:28.091792Z",
+     "iopub.status.idle": "2025-09-08T06:23:28.313072Z",
+     "shell.execute_reply": "2025-09-08T06:23:28.312448Z"
     }
    },
    "outputs": [
     {
-     "ename": "SyntaxError",
-     "evalue": "unterminated string literal (detected at line 30) (744733715.py, line 30)",
-     "output_type": "error",
-     "traceback": [
-      "  \u001b[36mCell\u001b[39m\u001b[36m \u001b[39m\u001b[32mIn[2]\u001b[39m\u001b[32m, line 30\u001b[39m\n\u001b[31m    \u001b[39m\u001b[31mMarkdown(\"\u001b[39m\n             ^\n\u001b[31mSyntaxError\u001b[39m\u001b[31m:\u001b[39m unterminated string literal (detected at line 30)\n"
-     ]
+     "data": {
+      "text/markdown": [
+       "| Circuit | Qubits | Gates | Description | Source |\n",
+       "|---|---|---|---|---|\n",
+       "| Clifford-EC | 5 | 9 | 3-qubit bit-flip error correction | [generator](benchmarks/circuits.py#L419) |\n",
+       "| Ripple-Add | 13 | 203 | Ripple-carry adder for two 4-bit registers | [generator](benchmarks/circuits.py#L437) |\n",
+       "| VQE-Chain | 6 | 46 | VQE ansatz with linear entanglement chain | [generator](benchmarks/circuits.py#L446) |\n",
+       "| Random-Hybrid | 6 | 33 | Random mix of Clifford and T gates | [generator](benchmarks/circuits.py#L454) |\n",
+       "| Recur-Subroutine | 4 | 18 | Circuit with repeated subroutine layers | [generator](benchmarks/circuits.py#L472) |"
+      ],
+      "text/plain": [
+       "<IPython.core.display.Markdown object>"
+      ]
+     },
+     "execution_count": 2,
+     "metadata": {},
+     "output_type": "execute_result"
     }
    ],
    "source": [
@@ -158,8 +169,7 @@
     "for name, fn, desc in circuits:\n",
     "    circ = fn()\n",
     "    rows.append(f\"| {name} | {circ.num_qubits} | {circ.num_gates} | {desc} | {src_link(fn)} |\")\n",
-    "Markdown(\"\n",
-    "\".join(rows))\n"
+    "Markdown(\"\\n\".join(rows))\n"
    ]
   },
   {
@@ -168,10 +178,10 @@
    "id": "a2bc0180",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2025-09-06T09:00:06.872058Z",
-     "iopub.status.busy": "2025-09-06T09:00:06.871876Z",
-     "iopub.status.idle": "2025-09-06T09:00:06.878053Z",
-     "shell.execute_reply": "2025-09-06T09:00:06.877487Z"
+     "iopub.execute_input": "2025-09-08T06:23:28.314947Z",
+     "iopub.status.busy": "2025-09-08T06:23:28.314714Z",
+     "iopub.status.idle": "2025-09-08T06:23:28.321287Z",
+     "shell.execute_reply": "2025-09-08T06:23:28.320658Z"
     }
    },
    "outputs": [
@@ -183,8 +193,8 @@
       "  \"In\": [\n",
       "    \"\",\n",
       "    \"import json, platform, subprocess, psutil, numpy as np, os\\nfrom pathlib import Path\\n\\ninfo = {}\\ninfo['cpu_model'] = next((l.split(':',1)[1].strip() for l in open('/proc/cpuinfo') if 'model name' in l), platform.processor())\\ninfo['cpu_count'] = psutil.cpu_count()\\ninfo['ram_gb'] = round(psutil.virtual_memory().total / 1024**3, 2)\\ninfo['os'] = platform.platform()\\ninfo['python_version'] = platform.python_version()\\ninfo['blas_libraries'] = getattr(np.__config__, 'blas_opt_info', {}).get('libraries', [])\\ninfo['lapack_libraries'] = getattr(np.__config__, 'lapack_opt_info', {}).get('libraries', [])\\nimport stim, mqt.ddsim, mqt.core\\ninfo['stim_version'] = getattr(stim, '__version__', None)\\ninfo['mqt_dd_version'] = getattr(mqt.ddsim, '__version__', None)\\ninfo['mqt_core_version'] = getattr(mqt.core, '__version__', None)\\ntry:\\n    import pybind11\\n    info['pybind11_version'] = pybind11.__version__\\nexcept Exception:\\n    info['pybind11_version'] = None\\ninfo['quasar_commit'] = subprocess.check_output(['git','rev-parse','HEAD']).decode().strip()\\ndef run_cmd(cmd):\\n    try:\\n        return subprocess.check_output(cmd, text=True).splitlines()[0]\\n    except Exception:\\n        return None\\ninfo['compiler'] = run_cmd(['cc','--version']) or run_cmd(['gcc','--version'])\\ninfo['cmake_version'] = run_cmd(['cmake','--version'])\\ninfo['QUASAR_QUICK_MAX_QUBITS'] = os.getenv('QUASAR_QUICK_MAX_QUBITS')\\ninfo['QUASAR_QUICK_MAX_GATES'] = os.getenv('QUASAR_QUICK_MAX_GATES')\\ninfo['QUASAR_QUICK_MAX_DEPTH'] = os.getenv('QUASAR_QUICK_MAX_DEPTH')\\ninfo['QUASAR_MPS_TARGET_FIDELITY'] = os.getenv('QUASAR_MPS_TARGET_FIDELITY')\\nPath('environment.json').write_text(json.dumps(info, indent=2))\\ninfo\",\n",
-      "    \"from benchmarks.circuits import (\\n    clifford_ec_circuit,\\n    ripple_add_circuit,\\n    vqe_chain_circuit,\\n    random_hybrid_circuit,\\n    recur_subroutine_circuit,\\n)\\nimport inspect\\nfrom pathlib import Path\\nfrom IPython.display import Markdown\\n\\n\\ndef src_link(func):\\n    file = Path(inspect.getsourcefile(func)).relative_to(Path.cwd())\\n    line = inspect.getsourcelines(func)[1]\\n    return f\\\"[generator]({file}#L{line})\\\"\\n\\ncircuits = [\\n    (\\\"Clifford-EC\\\", clifford_ec_circuit, \\\"3-qubit bit-flip error correction\\\"),\\n    (\\\"Ripple-Add\\\", ripple_add_circuit, \\\"Ripple-carry adder for two 4-bit registers\\\"),\\n    (\\\"VQE-Chain\\\", vqe_chain_circuit, \\\"VQE ansatz with linear entanglement chain\\\"),\\n    (\\\"Random-Hybrid\\\", random_hybrid_circuit, \\\"Random mix of Clifford and T gates\\\"),\\n    (\\\"Recur-Subroutine\\\", recur_subroutine_circuit, \\\"Circuit with repeated subroutine layers\\\"),\\n]\\n\\nrows = [\\\"| Circuit | Qubits | Gates | Description | Source |\\\", \\\"|---|---|---|---|---|\\\"]\\nfor name, fn, desc in circuits:\\n    circ = fn()\\n    rows.append(f\\\"| {name} | {circ.num_qubits} | {circ.num_gates} | {desc} | {src_link(fn)} |\\\")\\nMarkdown(\\\"\\n\\\".join(rows))\",\n",
-      "    \"# Record parameters and results\\nimport json, pathlib\\ntry:\\n    import ipynbname\\n    nb_name = ipynbname.path().stem\\nexcept Exception:  # pragma: no cover\\n    nb_name = 'notebook'\\n\\n# Collect simple parameters from globals\\n_params = {\\n    k: v for k, v in globals().items()\\n    if not k.startswith('_') and isinstance(v, (int, float, str, bool, list, dict, tuple))\\n}\\npathlib.Path('../results').mkdir(exist_ok=True)\\nwith open(f\\\"../results/{nb_name}_params.json\\\", 'w') as f:\\n    json.dump(_params, f, indent=2)\\nif 'results' in globals():\\n    try:\\n        with open(f\\\"../results/{nb_name}_results.json\\\", 'w') as f:\\n            json.dump(results, f, indent=2)\\n    except TypeError:\\n        pass\\nprint(json.dumps(_params, indent=2))\"\n",
+      "    \"from benchmarks.circuits import (\\n    clifford_ec_circuit,\\n    ripple_add_circuit,\\n    vqe_chain_circuit,\\n    random_hybrid_circuit,\\n    recur_subroutine_circuit,\\n)\\nimport inspect\\nfrom pathlib import Path\\nfrom IPython.display import Markdown\\n\\n\\ndef src_link(func):\\n    file = Path(inspect.getsourcefile(func)).relative_to(Path.cwd())\\n    line = inspect.getsourcelines(func)[1]\\n    return f\\\"[generator]({file}#L{line})\\\"\\n\\ncircuits = [\\n    (\\\"Clifford-EC\\\", clifford_ec_circuit, \\\"3-qubit bit-flip error correction\\\"),\\n    (\\\"Ripple-Add\\\", ripple_add_circuit, \\\"Ripple-carry adder for two 4-bit registers\\\"),\\n    (\\\"VQE-Chain\\\", vqe_chain_circuit, \\\"VQE ansatz with linear entanglement chain\\\"),\\n    (\\\"Random-Hybrid\\\", random_hybrid_circuit, \\\"Random mix of Clifford and T gates\\\"),\\n    (\\\"Recur-Subroutine\\\", recur_subroutine_circuit, \\\"Circuit with repeated subroutine layers\\\"),\\n]\\n\\nrows = [\\\"| Circuit | Qubits | Gates | Description | Source |\\\", \\\"|---|---|---|---|---|\\\"]\\nfor name, fn, desc in circuits:\\n    circ = fn()\\n    rows.append(f\\\"| {name} | {circ.num_qubits} | {circ.num_gates} | {desc} | {src_link(fn)} |\\\")\\nMarkdown(\\\"\\\\n\\\".join(rows))\",\n",
+      "    \"# Record parameters and results\\nimport json, pathlib\\ntry:\\n    import ipynbname\\n    nb_name = ipynbname.path().stem\\nexcept Exception:  # pragma: no cover\\n    nb_name = 'notebook'\\n\\n# Collect simple parameters from globals\\n_params = {\\n    k: v for k, v in globals().items()\\n    if not k.startswith('_') and isinstance(v, (int, float, str, bool, list, dict, tuple))\\n}\\npathlib.Path('../results').mkdir(exist_ok=True)\\nwith open(f\\\"../results/{nb_name}_params.json\\\", 'w') as f:\\n    json.dump(_params, f, indent=2, default=str)\\nif 'results' in globals():\\n    try:\\n        with open(f\\\"../results/{nb_name}_results.json\\\", 'w') as f:\\n            json.dump(results, f, indent=2, default=str)\\n    except TypeError:\\n        pass\\nprint(json.dumps(_params, indent=2, default=str))\"\n",
       "  ],\n",
       "  \"Out\": {\n",
       "    \"1\": {\n",
@@ -199,14 +209,15 @@
       "      \"mqt_dd_version\": \"2.0.0\",\n",
       "      \"mqt_core_version\": \"3.2.1\",\n",
       "      \"pybind11_version\": null,\n",
-      "      \"quasar_commit\": \"3dfe9c4e4934095b6c80ea6d77d2f422211de9ac\",\n",
+      "      \"quasar_commit\": \"97ae58e04fc7c17d96371c0f300c8231aafc38b6\",\n",
       "      \"compiler\": \"cc (Ubuntu 13.3.0-6ubuntu2~24.04) 13.3.0\",\n",
       "      \"cmake_version\": \"cmake version 3.28.3\",\n",
       "      \"QUASAR_QUICK_MAX_QUBITS\": null,\n",
       "      \"QUASAR_QUICK_MAX_GATES\": null,\n",
       "      \"QUASAR_QUICK_MAX_DEPTH\": null,\n",
       "      \"QUASAR_MPS_TARGET_FIDELITY\": null\n",
-      "    }\n",
+      "    },\n",
+      "    \"2\": \"<IPython.core.display.Markdown object>\"\n",
       "  },\n",
       "  \"info\": {\n",
       "    \"cpu_model\": \"Intel(R) Xeon(R) Platinum 8370C CPU @ 2.80GHz\",\n",
@@ -220,7 +231,7 @@
       "    \"mqt_dd_version\": \"2.0.0\",\n",
       "    \"mqt_core_version\": \"3.2.1\",\n",
       "    \"pybind11_version\": null,\n",
-      "    \"quasar_commit\": \"3dfe9c4e4934095b6c80ea6d77d2f422211de9ac\",\n",
+      "    \"quasar_commit\": \"97ae58e04fc7c17d96371c0f300c8231aafc38b6\",\n",
       "    \"compiler\": \"cc (Ubuntu 13.3.0-6ubuntu2~24.04) 13.3.0\",\n",
       "    \"cmake_version\": \"cmake version 3.28.3\",\n",
       "    \"QUASAR_QUICK_MAX_QUBITS\": null,\n",
@@ -228,6 +239,44 @@
       "    \"QUASAR_QUICK_MAX_DEPTH\": null,\n",
       "    \"QUASAR_MPS_TARGET_FIDELITY\": null\n",
       "  },\n",
+      "  \"circuits\": [\n",
+      "    [\n",
+      "      \"Clifford-EC\",\n",
+      "      \"<function clifford_ec_circuit at 0x7f3e78d04680>\",\n",
+      "      \"3-qubit bit-flip error correction\"\n",
+      "    ],\n",
+      "    [\n",
+      "      \"Ripple-Add\",\n",
+      "      \"<function ripple_add_circuit at 0x7f3e78d04720>\",\n",
+      "      \"Ripple-carry adder for two 4-bit registers\"\n",
+      "    ],\n",
+      "    [\n",
+      "      \"VQE-Chain\",\n",
+      "      \"<function vqe_chain_circuit at 0x7f3e78d047c0>\",\n",
+      "      \"VQE ansatz with linear entanglement chain\"\n",
+      "    ],\n",
+      "    [\n",
+      "      \"Random-Hybrid\",\n",
+      "      \"<function random_hybrid_circuit at 0x7f3e78d04860>\",\n",
+      "      \"Random mix of Clifford and T gates\"\n",
+      "    ],\n",
+      "    [\n",
+      "      \"Recur-Subroutine\",\n",
+      "      \"<function recur_subroutine_circuit at 0x7f3e78d04900>\",\n",
+      "      \"Circuit with repeated subroutine layers\"\n",
+      "    ]\n",
+      "  ],\n",
+      "  \"rows\": [\n",
+      "    \"| Circuit | Qubits | Gates | Description | Source |\",\n",
+      "    \"|---|---|---|---|---|\",\n",
+      "    \"| Clifford-EC | 5 | 9 | 3-qubit bit-flip error correction | [generator](benchmarks/circuits.py#L419) |\",\n",
+      "    \"| Ripple-Add | 13 | 203 | Ripple-carry adder for two 4-bit registers | [generator](benchmarks/circuits.py#L437) |\",\n",
+      "    \"| VQE-Chain | 6 | 46 | VQE ansatz with linear entanglement chain | [generator](benchmarks/circuits.py#L446) |\",\n",
+      "    \"| Random-Hybrid | 6 | 33 | Random mix of Clifford and T gates | [generator](benchmarks/circuits.py#L454) |\",\n",
+      "    \"| Recur-Subroutine | 4 | 18 | Circuit with repeated subroutine layers | [generator](benchmarks/circuits.py#L472) |\"\n",
+      "  ],\n",
+      "  \"name\": \"Recur-Subroutine\",\n",
+      "  \"desc\": \"Circuit with repeated subroutine layers\",\n",
       "  \"nb_name\": \"notebook\"\n",
       "}\n"
      ]
@@ -250,14 +299,14 @@
     "}\n",
     "pathlib.Path('../results').mkdir(exist_ok=True)\n",
     "with open(f\"../results/{nb_name}_params.json\", 'w') as f:\n",
-    "    json.dump(_params, f, indent=2)\n",
+    "    json.dump(_params, f, indent=2, default=str)\n",
     "if 'results' in globals():\n",
     "    try:\n",
     "        with open(f\"../results/{nb_name}_results.json\", 'w') as f:\n",
-    "            json.dump(results, f, indent=2)\n",
+    "            json.dump(results, f, indent=2, default=str)\n",
     "    except TypeError:\n",
     "        pass\n",
-    "print(json.dumps(_params, indent=2))\n"
+    "print(json.dumps(_params, indent=2, default=str))"
    ]
   }
  ],

--- a/benchmarks/notebooks/environment.json
+++ b/benchmarks/notebooks/environment.json
@@ -10,7 +10,7 @@
   "mqt_dd_version": "2.0.0",
   "mqt_core_version": "3.2.1",
   "pybind11_version": null,
-  "quasar_commit": "3dfe9c4e4934095b6c80ea6d77d2f422211de9ac",
+  "quasar_commit": "97ae58e04fc7c17d96371c0f300c8231aafc38b6",
   "compiler": "cc (Ubuntu 13.3.0-6ubuntu2~24.04) 13.3.0",
   "cmake_version": "cmake version 3.28.3",
   "QUASAR_QUICK_MAX_QUBITS": null,


### PR DESCRIPTION
## Summary
- Ensure environment setup notebook writes JSON with `default=str` so non-serializable values don't crash
- Disable classical simplification in `vqe_chain_circuit` to handle unbound parameters
- Re-execute environment setup notebook and refresh `environment.json`

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68be75636b8c8321876f0c1211db74c2