### PR TITLE
Handle non-serializable params in parallelism notebook

### DIFF
--- a/benchmarks/notebooks/07_parallelism.ipynb
+++ b/benchmarks/notebooks/07_parallelism.ipynb
@@ -172,14 +172,14 @@
     "}\n",
     "pathlib.Path('../results').mkdir(exist_ok=True)\n",
     "with open(f\"../results/{nb_name}_params.json\", 'w') as f:\n",
-    "    json.dump(_params, f, indent=2)\n",
+    "    json.dump(_params, f, indent=2, default=str)\n",
     "if 'results' in globals():\n",
     "    try:\n",
     "        with open(f\"../results/{nb_name}_results.json\", 'w') as f:\n",
     "            json.dump(results, f, indent=2)\n",
     "    except TypeError:\n",
     "        pass\n",
-    "print(json.dumps(_params, indent=2))\n"
+    "print(json.dumps(_params, indent=2, default=str))\n"
    ]
   }
  ],


### PR DESCRIPTION
## Summary
- ensure parameters in 07_parallelism notebook serialize with `default=str`
- apply same fallback when printing params

## Testing
- `jupyter nbconvert --to notebook --execute benchmarks/notebooks/07_parallelism.ipynb --output /tmp/07_parallelism.ipynb`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68be756b9d3483218570a4af0185c571