### PR TITLE
Handle non-serializable results in summary notebook

### DIFF
--- a/benchmarks/notebooks/summary.ipynb
+++ b/benchmarks/notebooks/summary.ipynb
@@ -163,7 +163,7 @@
     "if 'results' in globals():\n",
     "    try:\n",
     "        with open(f\"../results/{nb_name}_results.json\", 'w') as f:\n",
-    "            json.dump(results, f, indent=2)\n",
+    "            json.dump(results, f, indent=2, default=str)\n",
     "    except TypeError:\n",
     "        pass\n",
     "print(json.dumps(_params, indent=2))\n"


### PR DESCRIPTION
## Summary
- ensure summary notebook writes non-JSON-serializable result objects by stringifying them with `default=str`

## Testing
- `python -m nbconvert --to notebook --execute benchmarks/notebooks/summary_exec.ipynb --output /tmp/summary_exec_out.ipynb`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68be7587ad208321a47bc7a2f0792966