### PR TITLE
Handle non-serializable params in MPS notebook

### DIFF
--- a/benchmarks/notebooks/mps_backend.ipynb
+++ b/benchmarks/notebooks/mps_backend.ipynb
@@ -112,11 +112,11 @@
     "}\n",
     "pathlib.Path('../results').mkdir(exist_ok=True)\n",
     "with open(f\"../results/{nb_name}_params.json\", 'w') as f:\n",
-    "    json.dump(_params, f, indent=2)\n",
+    "    json.dump(_params, f, indent=2, default=str)\n",
     "if 'results' in globals():\n",
     "    try:\n",
     "        with open(f\"../results/{nb_name}_results.json\", 'w') as f:\n",
-    "            json.dump(results, f, indent=2)\n",
+    "            json.dump(results, f, indent=2, default=str)\n",
     "    except TypeError:\n",
     "        pass\n",
     "print(json.dumps(_params, indent=2))\n"


### PR DESCRIPTION
## Summary
- ensure MPS notebook can record arbitrary parameters by using `json.dump(..., default=str)` for parameter and result dumps

## Testing
- `pytest`
- `jupyter nbconvert --to notebook --execute benchmarks/notebooks/mps_backend.ipynb --output mps_backend_out.ipynb` (fails: RuntimeError: no runs executed)


------
https://chatgpt.com/codex/tasks/task_e_68be75921bb88321bd3de2eb5595dddf