### PR TITLE
Ensure JSON serialization in MQT DD backend benchmark

### DIFF
--- a/benchmarks/notebooks/mqt_dd_backend.ipynb
+++ b/benchmarks/notebooks/mqt_dd_backend.ipynb
@@ -12,9 +12,16 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 1,
    "id": "214ffc01",
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2025-09-08T06:23:06.391861Z",
+     "iopub.status.busy": "2025-09-08T06:23:06.391644Z",
+     "iopub.status.idle": "2025-09-08T06:23:07.277311Z",
+     "shell.execute_reply": "2025-09-08T06:23:07.276563Z"
+    }
+   },
    "outputs": [],
    "source": [
     "from benchmarks.backends import DecisionDiagramAdapter\n",
@@ -25,10 +32,95 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 2,
    "id": "d021b28d",
-   "metadata": {},
-   "outputs": [],
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2025-09-08T06:23:07.280186Z",
+     "iopub.status.busy": "2025-09-08T06:23:07.279863Z",
+     "iopub.status.idle": "2025-09-08T06:23:07.481215Z",
+     "shell.execute_reply": "2025-09-08T06:23:07.480645Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>circuit</th>\n",
+       "      <th>prepare_time_mean</th>\n",
+       "      <th>run_time_mean</th>\n",
+       "      <th>total_time_mean</th>\n",
+       "      <th>prepare_peak_memory_mean</th>\n",
+       "      <th>run_peak_memory_mean</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>GHZ</td>\n",
+       "      <td>0.026385</td>\n",
+       "      <td>0.000368</td>\n",
+       "      <td>0.026753</td>\n",
+       "      <td>240.000000</td>\n",
+       "      <td>2777.000000</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>QFT</td>\n",
+       "      <td>0.006584</td>\n",
+       "      <td>0.000616</td>\n",
+       "      <td>0.007200</td>\n",
+       "      <td>288.000000</td>\n",
+       "      <td>4475.000000</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2</th>\n",
+       "      <td>Grover</td>\n",
+       "      <td>0.001611</td>\n",
+       "      <td>0.005815</td>\n",
+       "      <td>0.007425</td>\n",
+       "      <td>4893.333333</td>\n",
+       "      <td>26395.666667</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "  circuit  prepare_time_mean  run_time_mean  total_time_mean  \\\n",
+       "0     GHZ           0.026385       0.000368         0.026753   \n",
+       "1     QFT           0.006584       0.000616         0.007200   \n",
+       "2  Grover           0.001611       0.005815         0.007425   \n",
+       "\n",
+       "   prepare_peak_memory_mean  run_peak_memory_mean  \n",
+       "0                240.000000           2777.000000  \n",
+       "1                288.000000           4475.000000  \n",
+       "2               4893.333333          26395.666667  "
+      ]
+     },
+     "execution_count": 2,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "# Select representative circuits\n",
     "circuits_to_run = [\n",
@@ -49,9 +141,16 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 3,
    "id": "a70ab596",
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2025-09-08T06:23:07.483475Z",
+     "iopub.status.busy": "2025-09-08T06:23:07.483274Z",
+     "iopub.status.idle": "2025-09-08T06:23:08.104212Z",
+     "shell.execute_reply": "2025-09-08T06:23:08.103502Z"
+    }
+   },
    "outputs": [],
    "source": [
     "import pandas as pd\n",
@@ -91,10 +190,69 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 4,
    "id": "f263254b",
-   "metadata": {},
-   "outputs": [],
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2025-09-08T06:23:08.107102Z",
+     "iopub.status.busy": "2025-09-08T06:23:08.106806Z",
+     "iopub.status.idle": "2025-09-08T06:23:08.118281Z",
+     "shell.execute_reply": "2025-09-08T06:23:08.117725Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "{\n",
+      "  \"In\": [\n",
+      "    \"\",\n",
+      "    \"from benchmarks.backends import DecisionDiagramAdapter\\nfrom benchmarks.runner import BenchmarkRunner\\nfrom benchmarks import circuits\\nimport pandas as pd\",\n",
+      "    \"# Select representative circuits\\ncircuits_to_run = [\\n    (\\\"GHZ\\\", circuits.ghz_circuit(5)),\\n    (\\\"QFT\\\", circuits.qft_circuit(5)),\\n    (\\\"Grover\\\", circuits.grover_circuit(5, 1)),\\n]\\n\\nrunner = BenchmarkRunner()\\nbackend = DecisionDiagramAdapter()\\nfor name, circ in circuits_to_run:\\n    res = runner.run_multiple(circ, backend, return_state=False, repetitions=3)\\n    res[\\\"circuit\\\"] = name\\n\\ndf = runner.dataframe()\\ndf[[\\\"circuit\\\", \\\"prepare_time_mean\\\", \\\"run_time_mean\\\", \\\"total_time_mean\\\", \\\"prepare_peak_memory_mean\\\", \\\"run_peak_memory_mean\\\"]]\",\n",
+      "    \"import pandas as pd\\nfrom benchmarks.stats_utils import stats_table\\n\\ndef add_stats(df, quasar_col='QuASAr', baseline_cols=None, test='ttest', correction='bonferroni'):\\n    \\\"\\\"\\\"Compute statistics comparing QuASAr with baselines.\\n\\n    Parameters\\n    ----------\\n    df : pandas.DataFrame\\n        DataFrame with per-circuit results. One column must correspond to QuASAr,\\n        others to baselines.\\n    quasar_col : str\\n        Name of the column containing QuASAr results.\\n    baseline_cols : list[str] | None\\n        Columns to treat as baselines. Defaults to all columns except quasar_col.\\n    test : str\\n        'ttest' or 'wilcoxon'.\\n    correction : str\\n        'bonferroni' or 'fdr_bh'.\\n\\n    Returns\\n    -------\\n    pd.DataFrame\\n        Table with baseline name, statistic, corrected p-value, and effect size.\\n    \\\"\\\"\\\"\\n    if baseline_cols is None:\\n        baseline_cols = [c for c in df.columns if c != quasar_col]\\n    baselines = {c: df[c] for c in baseline_cols}\\n    return stats_table(df[quasar_col], baselines, test=test, correction=correction)\\n\\n# Example usage after computing results DataFrame named `results_df`:\\n# stats_df = add_stats(results_df)\\n# stats_df\",\n",
+      "    \"# Record parameters and results\\nimport json, pathlib\\ntry:\\n    import ipynbname\\n    nb_name = ipynbname.path().stem\\nexcept Exception:  # pragma: no cover\\n    nb_name = 'notebook'\\n\\n# Collect simple parameters from globals\\n_params = {\\n    k: v for k, v in globals().items()\\n    if not k.startswith('_') and isinstance(v, (int, float, str, bool, list, dict, tuple))\\n}\\npathlib.Path('../results').mkdir(exist_ok=True)\\nwith open(f\\\"../results/{nb_name}_params.json\\\", 'w') as f:\\n    json.dump(_params, f, indent=2, default=str)\\nif 'results' in globals():\\n    try:\\n        with open(f\\\"../results/{nb_name}_results.json\\\", 'w') as f:\\n            json.dump(results, f, indent=2, default=str)\\n    except TypeError:\\n        pass\\nprint(json.dumps(_params, indent=2, default=str))\"\n",
+      "  ],\n",
+      "  \"Out\": {\n",
+      "    \"2\": \"  circuit  prepare_time_mean  run_time_mean  total_time_mean  \\\\\\n0     GHZ           0.026385       0.000368         0.026753   \\n1     QFT           0.006584       0.000616         0.007200   \\n2  Grover           0.001611       0.005815         0.007425   \\n\\n   prepare_peak_memory_mean  run_peak_memory_mean  \\n0                240.000000           2777.000000  \\n1                288.000000           4475.000000  \\n2               4893.333333          26395.666667  \"\n",
+      "  },\n",
+      "  \"circuits_to_run\": [\n",
+      "    [\n",
+      "      \"GHZ\",\n",
+      "      \"<quasar.circuit.Circuit object at 0x7fb2a4150380>\"\n",
+      "    ],\n",
+      "    [\n",
+      "      \"QFT\",\n",
+      "      \"<quasar.circuit.Circuit object at 0x7fb26c701640>\"\n",
+      "    ],\n",
+      "    [\n",
+      "      \"Grover\",\n",
+      "      \"<quasar.circuit.Circuit object at 0x7fb26b128830>\"\n",
+      "    ]\n",
+      "  ],\n",
+      "  \"name\": \"Grover\",\n",
+      "  \"res\": {\n",
+      "    \"framework\": \"mqt_dd\",\n",
+      "    \"backend\": \"mqt_dd\",\n",
+      "    \"repetitions\": 3,\n",
+      "    \"prepare_time_mean\": 0.0016109573333267235,\n",
+      "    \"prepare_time_std\": 0.0004347398838193415,\n",
+      "    \"run_time_mean\": 0.005814512333330413,\n",
+      "    \"run_time_std\": 0.0002520773362514418,\n",
+      "    \"total_time_mean\": 0.007425469666657136,\n",
+      "    \"total_time_std\": 0.0006772928738316745,\n",
+      "    \"prepare_peak_memory_mean\": 4893.333333333333,\n",
+      "    \"prepare_peak_memory_std\": 4747.986333407272,\n",
+      "    \"run_peak_memory_mean\": 26395.666666666668,\n",
+      "    \"run_peak_memory_std\": 5017.102904620909,\n",
+      "    \"result\": null,\n",
+      "    \"circuit\": \"Grover\"\n",
+      "  },\n",
+      "  \"nb_name\": \"notebook\"\n",
+      "}\n"
+     ]
+    }
+   ],
    "source": [
     "\n",
     "# Record parameters and results\n",
@@ -112,18 +270,31 @@
     "}\n",
     "pathlib.Path('../results').mkdir(exist_ok=True)\n",
     "with open(f\"../results/{nb_name}_params.json\", 'w') as f:\n",
-    "    json.dump(_params, f, indent=2)\n",
+    "    json.dump(_params, f, indent=2, default=str)\n",
     "if 'results' in globals():\n",
     "    try:\n",
     "        with open(f\"../results/{nb_name}_results.json\", 'w') as f:\n",
-    "            json.dump(results, f, indent=2)\n",
+    "            json.dump(results, f, indent=2, default=str)\n",
     "    except TypeError:\n",
     "        pass\n",
-    "print(json.dumps(_params, indent=2))\n"
+    "print(json.dumps(_params, indent=2, default=str))\n"
    ]
   }
  ],
- "metadata": {},
+ "metadata": {
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.12.10"
+  }
+ },
  "nbformat": 4,
  "nbformat_minor": 5
 }

--- a/benchmarks/results/mqt_dd_backend_params.json
+++ b/benchmarks/results/mqt_dd_backend_params.json
@@ -1,0 +1,45 @@
+{
+  "In": [
+    "",
+    "from benchmarks.backends import DecisionDiagramAdapter\nfrom benchmarks.runner import BenchmarkRunner\nfrom benchmarks import circuits\nimport pandas as pd",
+    "# Select representative circuits\ncircuits_to_run = [\n    (\"GHZ\", circuits.ghz_circuit(5)),\n    (\"QFT\", circuits.qft_circuit(5)),\n    (\"Grover\", circuits.grover_circuit(5, 1)),\n]\n\nrunner = BenchmarkRunner()\nbackend = DecisionDiagramAdapter()\nfor name, circ in circuits_to_run:\n    res = runner.run_multiple(circ, backend, return_state=False, repetitions=3)\n    res[\"circuit\"] = name\n\ndf = runner.dataframe()\ndf[[\"circuit\", \"prepare_time_mean\", \"run_time_mean\", \"total_time_mean\", \"prepare_peak_memory_mean\", \"run_peak_memory_mean\"]]",
+    "import pandas as pd\nfrom benchmarks.stats_utils import stats_table\n\ndef add_stats(df, quasar_col='QuASAr', baseline_cols=None, test='ttest', correction='bonferroni'):\n    \"\"\"Compute statistics comparing QuASAr with baselines.\n\n    Parameters\n    ----------\n    df : pandas.DataFrame\n        DataFrame with per-circuit results. One column must correspond to QuASAr,\n        others to baselines.\n    quasar_col : str\n        Name of the column containing QuASAr results.\n    baseline_cols : list[str] | None\n        Columns to treat as baselines. Defaults to all columns except quasar_col.\n    test : str\n        'ttest' or 'wilcoxon'.\n    correction : str\n        'bonferroni' or 'fdr_bh'.\n\n    Returns\n    -------\n    pd.DataFrame\n        Table with baseline name, statistic, corrected p-value, and effect size.\n    \"\"\"\n    if baseline_cols is None:\n        baseline_cols = [c for c in df.columns if c != quasar_col]\n    baselines = {c: df[c] for c in baseline_cols}\n    return stats_table(df[quasar_col], baselines, test=test, correction=correction)\n\n# Example usage after computing results DataFrame named `results_df`:\n# stats_df = add_stats(results_df)\n# stats_df",
+    "# Record parameters and results\nimport json, pathlib\ntry:\n    import ipynbname\n    nb_name = ipynbname.path().stem\nexcept Exception:  # pragma: no cover\n    nb_name = 'notebook'\n\n# Collect simple parameters from globals\n_params = {\n    k: v for k, v in globals().items()\n    if not k.startswith('_') and isinstance(v, (int, float, str, bool, list, dict, tuple))\n}\npathlib.Path('../results').mkdir(exist_ok=True)\nwith open(f\"../results/{nb_name}_params.json\", 'w') as f:\n    json.dump(_params, f, indent=2, default=str)\nif 'results' in globals():\n    try:\n        with open(f\"../results/{nb_name}_results.json\", 'w') as f:\n            json.dump(results, f, indent=2, default=str)\n    except TypeError:\n        pass\nprint(json.dumps(_params, indent=2, default=str))"
+  ],
+  "Out": {
+    "2": "  circuit  prepare_time_mean  run_time_mean  total_time_mean  \\\n0     GHZ           0.026385       0.000368         0.026753   \n1     QFT           0.006584       0.000616         0.007200   \n2  Grover           0.001611       0.005815         0.007425   \n\n   prepare_peak_memory_mean  run_peak_memory_mean  \n0                240.000000           2777.000000  \n1                288.000000           4475.000000  \n2               4893.333333          26395.666667  "
+  },
+  "circuits_to_run": [
+    [
+      "GHZ",
+      "<quasar.circuit.Circuit object at 0x7fb2a4150380>"
+    ],
+    [
+      "QFT",
+      "<quasar.circuit.Circuit object at 0x7fb26c701640>"
+    ],
+    [
+      "Grover",
+      "<quasar.circuit.Circuit object at 0x7fb26b128830>"
+    ]
+  ],
+  "name": "Grover",
+  "res": {
+    "framework": "mqt_dd",
+    "backend": "mqt_dd",
+    "repetitions": 3,
+    "prepare_time_mean": 0.0016109573333267235,
+    "prepare_time_std": 0.0004347398838193415,
+    "run_time_mean": 0.005814512333330413,
+    "run_time_std": 0.0002520773362514418,
+    "total_time_mean": 0.007425469666657136,
+    "total_time_std": 0.0006772928738316745,
+    "prepare_peak_memory_mean": 4893.333333333333,
+    "prepare_peak_memory_std": 4747.986333407272,
+    "run_peak_memory_mean": 26395.666666666668,
+    "run_peak_memory_std": 5017.102904620909,
+    "result": null,
+    "circuit": "Grover"
+  },
+  "nb_name": "notebook"
+}


### PR DESCRIPTION
## Summary
- serialize notebook parameters and results using `default=str`
- re-execute MQT DD backend benchmark notebook producing updated params file

## Testing
- `pytest` *(fails: tests/test_backend_selection_timing.py::test_auto_and_forced_single_backend_have_equal_runtime)*

------
https://chatgpt.com/codex/tasks/task_e_68be759321008321b267bde1b0b171fc