### PR TITLE
Fix JSON serialization and update Statevector backend notebook

### DIFF
--- a/benchmarks/notebooks/statevector_backend.ipynb
+++ b/benchmarks/notebooks/statevector_backend.ipynb
@@ -16,10 +16,10 @@
    "id": "ce56975c",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2025-09-01T10:40:48.639978Z",
-     "iopub.status.busy": "2025-09-01T10:40:48.639557Z",
-     "iopub.status.idle": "2025-09-01T10:40:49.889655Z",
-     "shell.execute_reply": "2025-09-01T10:40:49.888642Z"
+     "iopub.execute_input": "2025-09-08T06:24:53.410032Z",
+     "iopub.status.busy": "2025-09-08T06:24:53.409769Z",
+     "iopub.status.idle": "2025-09-08T06:24:54.310155Z",
+     "shell.execute_reply": "2025-09-08T06:24:54.309347Z"
     }
    },
    "outputs": [],
@@ -27,7 +27,11 @@
     "from benchmarks.backends import StatevectorAdapter\n",
     "from benchmarks.runner import BenchmarkRunner\n",
     "from benchmarks import circuits\n",
-    "import pandas as pd"
+    "import pandas as pd\n",
+    "from quasar.circuit import Circuit\n",
+    "import copy as _copy\n",
+    "if not hasattr(Circuit, 'copy'):\n",
+    "    Circuit.copy = lambda self: _copy.deepcopy(self)"
    ]
   },
   {
@@ -36,10 +40,10 @@
    "id": "3538a1de",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2025-09-01T10:40:49.893336Z",
-     "iopub.status.busy": "2025-09-01T10:40:49.892885Z",
-     "iopub.status.idle": "2025-09-01T10:40:50.103546Z",
-     "shell.execute_reply": "2025-09-01T10:40:50.102356Z"
+     "iopub.execute_input": "2025-09-08T06:24:54.313396Z",
+     "iopub.status.busy": "2025-09-08T06:24:54.313069Z",
+     "iopub.status.idle": "2025-09-08T06:24:54.513234Z",
+     "shell.execute_reply": "2025-09-08T06:24:54.512646Z"
     }
    },
    "outputs": [
@@ -76,29 +80,29 @@
        "    <tr>\n",
        "      <th>0</th>\n",
        "      <td>GHZ</td>\n",
-       "      <td>0.000731</td>\n",
-       "      <td>0.004107</td>\n",
-       "      <td>0.004838</td>\n",
-       "      <td>6078.666667</td>\n",
-       "      <td>31388.666667</td>\n",
+       "      <td>0.001789</td>\n",
+       "      <td>0.003217</td>\n",
+       "      <td>0.005006</td>\n",
+       "      <td>11190.333333</td>\n",
+       "      <td>33903.333333</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>1</th>\n",
        "      <td>QFT</td>\n",
-       "      <td>0.002631</td>\n",
-       "      <td>0.005390</td>\n",
-       "      <td>0.008021</td>\n",
-       "      <td>6572.333333</td>\n",
-       "      <td>28025.000000</td>\n",
+       "      <td>0.000629</td>\n",
+       "      <td>0.004439</td>\n",
+       "      <td>0.005068</td>\n",
+       "      <td>2982.000000</td>\n",
+       "      <td>20831.000000</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>2</th>\n",
        "      <td>Grover</td>\n",
-       "      <td>0.008965</td>\n",
-       "      <td>0.018399</td>\n",
-       "      <td>0.027364</td>\n",
-       "      <td>17789.666667</td>\n",
-       "      <td>35542.000000</td>\n",
+       "      <td>0.025493</td>\n",
+       "      <td>0.013116</td>\n",
+       "      <td>0.038609</td>\n",
+       "      <td>41014.000000</td>\n",
+       "      <td>66235.666667</td>\n",
        "    </tr>\n",
        "  </tbody>\n",
        "</table>\n",
@@ -106,14 +110,14 @@
       ],
       "text/plain": [
        "  circuit  prepare_time_mean  run_time_mean  total_time_mean  \\\n",
-       "0     GHZ           0.000731       0.004107         0.004838   \n",
-       "1     QFT           0.002631       0.005390         0.008021   \n",
-       "2  Grover           0.008965       0.018399         0.027364   \n",
+       "0     GHZ           0.001789       0.003217         0.005006   \n",
+       "1     QFT           0.000629       0.004439         0.005068   \n",
+       "2  Grover           0.025493       0.013116         0.038609   \n",
        "\n",
        "   prepare_peak_memory_mean  run_peak_memory_mean  \n",
-       "0               6078.666667          31388.666667  \n",
-       "1               6572.333333          28025.000000  \n",
-       "2              17789.666667          35542.000000  "
+       "0              11190.333333          33903.333333  \n",
+       "1               2982.000000          20831.000000  \n",
+       "2              41014.000000          66235.666667  "
       ]
      },
      "execution_count": 2,
@@ -131,6 +135,7 @@
     "\n",
     "runner = BenchmarkRunner()\n",
     "backend = StatevectorAdapter()\n",
+    "backend.prepare_benchmark = lambda circuit=None: backend.backend.prepare_benchmark()\n",
     "for name, circ in circuits_to_run:\n",
     "    res = runner.run_multiple(circ, backend, return_state=False, repetitions=3)\n",
     "    res[\"circuit\"] = name\n",
@@ -145,10 +150,10 @@
    "id": "3c5852f6",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2025-09-01T10:40:50.106695Z",
-     "iopub.status.busy": "2025-09-01T10:40:50.106367Z",
-     "iopub.status.idle": "2025-09-01T10:40:51.048954Z",
-     "shell.execute_reply": "2025-09-01T10:40:51.047588Z"
+     "iopub.execute_input": "2025-09-08T06:24:54.515671Z",
+     "iopub.status.busy": "2025-09-08T06:24:54.515462Z",
+     "iopub.status.idle": "2025-09-08T06:24:55.149727Z",
+     "shell.execute_reply": "2025-09-08T06:24:55.148795Z"
     }
    },
    "outputs": [],
@@ -194,10 +199,10 @@
    "id": "b06bde6c",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2025-09-01T10:40:51.053556Z",
-     "iopub.status.busy": "2025-09-01T10:40:51.053011Z",
-     "iopub.status.idle": "2025-09-01T10:40:51.073174Z",
-     "shell.execute_reply": "2025-09-01T10:40:51.071526Z"
+     "iopub.execute_input": "2025-09-08T06:24:55.152265Z",
+     "iopub.status.busy": "2025-09-08T06:24:55.151940Z",
+     "iopub.status.idle": "2025-09-08T06:24:55.163665Z",
+     "shell.execute_reply": "2025-09-08T06:24:55.162971Z"
     }
    },
    "outputs": [
@@ -205,15 +210,51 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "{'In': ['', 'from benchmarks.backends import StatevectorAdapter\\nfrom benchmarks.runner import BenchmarkRunner\\nfrom benchmarks import circuits\\nimport pandas as pd', '# Select representative circuits\\ncircuits_to_run = [\\n    (\"GHZ\", circuits.ghz_circuit(5)),\\n    (\"QFT\", circuits.qft_circuit(5)),\\n    (\"Grover\", circuits.grover_circuit(5, 1)),\\n]\\n\\nrunner = BenchmarkRunner()\\nbackend = StatevectorAdapter()\\nfor name, circ in circuits_to_run:\\n    res = runner.run_multiple(circ, backend, return_state=False, repetitions=3)\\n    res[\"circuit\"] = name\\n\\ndf = runner.dataframe()\\ndf[[\"circuit\", \"prepare_time_mean\", \"run_time_mean\", \"total_time_mean\", \"prepare_peak_memory_mean\", \"run_peak_memory_mean\"]]', 'import pandas as pd\\nfrom benchmarks.stats_utils import stats_table\\n\\ndef add_stats(df, quasar_col=\\'QuASAr\\', baseline_cols=None, test=\\'ttest\\', correction=\\'bonferroni\\'):\\n    \"\"\"Compute statistics comparing QuASAr with baselines.\\n\\n    Parameters\\n    ----------\\n    df : pandas.DataFrame\\n        DataFrame with per-circuit results. One column must correspond to QuASAr,\\n        others to baselines.\\n    quasar_col : str\\n        Name of the column containing QuASAr results.\\n    baseline_cols : list[str] | None\\n        Columns to treat as baselines. Defaults to all columns except quasar_col.\\n    test : str\\n        \\'ttest\\' or \\'wilcoxon\\'.\\n    correction : str\\n        \\'bonferroni\\' or \\'fdr_bh\\'.\\n\\n    Returns\\n    -------\\n    pd.DataFrame\\n        Table with baseline name, statistic, corrected p-value, and effect size.\\n    \"\"\"\\n    if baseline_cols is None:\\n        baseline_cols = [c for c in df.columns if c != quasar_col]\\n    baselines = {c: df[c] for c in baseline_cols}\\n    return stats_table(df[quasar_col], baselines, test=test, correction=correction)\\n\\n# Example usage after computing results DataFrame named `results_df`:\\n# stats_df = add_stats(results_df)\\n# stats_df', '# Record parameters and results\\nimport json, pathlib\\ntry:\\n    import ipynbname\\n    nb_name = ipynbname.path().stem\\nexcept Exception:  # pragma: no cover\\n    nb_name = \\'notebook\\'\\n\\n# Collect simple parameters from globals\\n_params = {\\n    k: v for k, v in globals().items()\\n    if not k.startswith(\\'_\\') and isinstance(v, (int, float, str, bool, list, dict, tuple))\\n}\\npathlib.Path(\\'../results\\').mkdir(exist_ok=True)\\ntry:\\n    with open(f\"../results/{nb_name}_params.json\", \\'w\\') as f:\\n        json.dump(_params, f, indent=2)\\nexcept TypeError:\\n    pass\\nif \\'results\\' in globals():\\n    try:\\n        with open(f\"../results/{nb_name}_results.json\", \\'w\\') as f:\\n            json.dump(results, f, indent=2)\\n    except TypeError:\\n        pass\\ntry:\\n    print(json.dumps(_params, indent=2))\\nexcept TypeError:\\n    print(_params)'], 'Out': {2:   circuit  prepare_time_mean  run_time_mean  total_time_mean  \\\n",
-      "0     GHZ           0.000731       0.004107         0.004838   \n",
-      "1     QFT           0.002631       0.005390         0.008021   \n",
-      "2  Grover           0.008965       0.018399         0.027364   \n",
-      "\n",
-      "   prepare_peak_memory_mean  run_peak_memory_mean  \n",
-      "0               6078.666667          31388.666667  \n",
-      "1               6572.333333          28025.000000  \n",
-      "2              17789.666667          35542.000000  }, 'circuits_to_run': [('GHZ', <quasar.circuit.Circuit object at 0x7fa6787acfe0>), ('QFT', <quasar.circuit.Circuit object at 0x7fa646838e30>), ('Grover', <quasar.circuit.Circuit object at 0x7fa6815d1880>)], 'name': 'Grover', 'res': {'framework': 'statevector', 'repetitions': 3, 'prepare_time_mean': 0.008965243666655928, 'prepare_time_std': 5.726562276467994e-05, 'run_time_mean': 0.01839871366701118, 'run_time_std': 0.007357944113781177, 'total_time_mean': 0.027363957333667106, 'total_time_std': 0.00738356499479113, 'prepare_peak_memory_mean': 17789.666666666668, 'prepare_peak_memory_std': 324.5821245163627, 'run_peak_memory_mean': 35542.0, 'run_peak_memory_std': 1184.21816683695, 'circuit': 'Grover'}, 'nb_name': 'notebook'}\n"
+      "{\n",
+      "  \"In\": [\n",
+      "    \"\",\n",
+      "    \"from benchmarks.backends import StatevectorAdapter\\nfrom benchmarks.runner import BenchmarkRunner\\nfrom benchmarks import circuits\\nimport pandas as pd\\nfrom quasar.circuit import Circuit\\nimport copy as _copy\\nif not hasattr(Circuit, 'copy'):\\n    Circuit.copy = lambda self: _copy.deepcopy(self)\",\n",
+      "    \"# Select representative circuits\\ncircuits_to_run = [\\n    (\\\"GHZ\\\", circuits.ghz_circuit(5)),\\n    (\\\"QFT\\\", circuits.qft_circuit(5)),\\n    (\\\"Grover\\\", circuits.grover_circuit(5, 1)),\\n]\\n\\nrunner = BenchmarkRunner()\\nbackend = StatevectorAdapter()\\nbackend.prepare_benchmark = lambda circuit=None: backend.backend.prepare_benchmark()\\nfor name, circ in circuits_to_run:\\n    res = runner.run_multiple(circ, backend, return_state=False, repetitions=3)\\n    res[\\\"circuit\\\"] = name\\n\\ndf = runner.dataframe()\\ndf[[\\\"circuit\\\", \\\"prepare_time_mean\\\", \\\"run_time_mean\\\", \\\"total_time_mean\\\", \\\"prepare_peak_memory_mean\\\", \\\"run_peak_memory_mean\\\"]]\",\n",
+      "    \"import pandas as pd\\nfrom benchmarks.stats_utils import stats_table\\n\\ndef add_stats(df, quasar_col='QuASAr', baseline_cols=None, test='ttest', correction='bonferroni'):\\n    \\\"\\\"\\\"Compute statistics comparing QuASAr with baselines.\\n\\n    Parameters\\n    ----------\\n    df : pandas.DataFrame\\n        DataFrame with per-circuit results. One column must correspond to QuASAr,\\n        others to baselines.\\n    quasar_col : str\\n        Name of the column containing QuASAr results.\\n    baseline_cols : list[str] | None\\n        Columns to treat as baselines. Defaults to all columns except quasar_col.\\n    test : str\\n        'ttest' or 'wilcoxon'.\\n    correction : str\\n        'bonferroni' or 'fdr_bh'.\\n\\n    Returns\\n    -------\\n    pd.DataFrame\\n        Table with baseline name, statistic, corrected p-value, and effect size.\\n    \\\"\\\"\\\"\\n    if baseline_cols is None:\\n        baseline_cols = [c for c in df.columns if c != quasar_col]\\n    baselines = {c: df[c] for c in baseline_cols}\\n    return stats_table(df[quasar_col], baselines, test=test, correction=correction)\\n\\n# Example usage after computing results DataFrame named `results_df`:\\n# stats_df = add_stats(results_df)\\n# stats_df\",\n",
+      "    \"# Record parameters and results\\nimport json, pathlib\\ntry:\\n    import ipynbname\\n    nb_name = ipynbname.path().stem\\nexcept Exception:  # pragma: no cover\\n    nb_name = 'notebook'\\n\\n# Collect simple parameters from globals\\n_params = {\\n    k: v for k, v in globals().items()\\n    if not k.startswith('_') and isinstance(v, (int, float, str, bool, list, dict, tuple))\\n}\\npathlib.Path('../results').mkdir(exist_ok=True)\\ntry:\\n    with open(f\\\"../results/{nb_name}_params.json\\\", 'w') as f:\\n        json.dump(_params, f, indent=2, default=str)\\nexcept TypeError:\\n    pass\\nif 'results' in globals():\\n    try:\\n        with open(f\\\"../results/{nb_name}_results.json\\\", 'w') as f:\\n            json.dump(results, f, indent=2, default=str)\\n    except TypeError:\\n        pass\\ntry:\\n    print(json.dumps(_params, indent=2, default=str))\\nexcept TypeError:\\n    print(_params)\"\n",
+      "  ],\n",
+      "  \"Out\": {\n",
+      "    \"2\": \"  circuit  prepare_time_mean  run_time_mean  total_time_mean  \\\\\\n0     GHZ           0.001789       0.003217         0.005006   \\n1     QFT           0.000629       0.004439         0.005068   \\n2  Grover           0.025493       0.013116         0.038609   \\n\\n   prepare_peak_memory_mean  run_peak_memory_mean  \\n0              11190.333333          33903.333333  \\n1               2982.000000          20831.000000  \\n2              41014.000000          66235.666667  \"\n",
+      "  },\n",
+      "  \"circuits_to_run\": [\n",
+      "    [\n",
+      "      \"GHZ\",\n",
+      "      \"<quasar.circuit.Circuit object at 0x7f05c70d8a10>\"\n",
+      "    ],\n",
+      "    [\n",
+      "      \"QFT\",\n",
+      "      \"<quasar.circuit.Circuit object at 0x7f05c5977fb0>\"\n",
+      "    ],\n",
+      "    [\n",
+      "      \"Grover\",\n",
+      "      \"<quasar.circuit.Circuit object at 0x7f05c4aa2a50>\"\n",
+      "    ]\n",
+      "  ],\n",
+      "  \"name\": \"Grover\",\n",
+      "  \"res\": {\n",
+      "    \"framework\": \"statevector\",\n",
+      "    \"backend\": \"statevector\",\n",
+      "    \"repetitions\": 3,\n",
+      "    \"prepare_time_mean\": 0.025493180000012217,\n",
+      "    \"prepare_time_std\": 0.0003722473771508929,\n",
+      "    \"run_time_mean\": 0.01311552033331509,\n",
+      "    \"run_time_std\": 0.001218467837348012,\n",
+      "    \"total_time_mean\": 0.038608700333327306,\n",
+      "    \"total_time_std\": 0.000909500686696515,\n",
+      "    \"prepare_peak_memory_mean\": 41014.0,\n",
+      "    \"prepare_peak_memory_std\": 2444.095470039308,\n",
+      "    \"run_peak_memory_mean\": 66235.66666666667,\n",
+      "    \"run_peak_memory_std\": 5933.152862423897,\n",
+      "    \"result\": null,\n",
+      "    \"circuit\": \"Grover\"\n",
+      "  },\n",
+      "  \"nb_name\": \"notebook\"\n",
+      "}\n"
      ]
     }
    ],
@@ -235,17 +276,17 @@
     "pathlib.Path('../results').mkdir(exist_ok=True)\n",
     "try:\n",
     "    with open(f\"../results/{nb_name}_params.json\", 'w') as f:\n",
-    "        json.dump(_params, f, indent=2)\n",
+    "        json.dump(_params, f, indent=2, default=str)\n",
     "except TypeError:\n",
     "    pass\n",
     "if 'results' in globals():\n",
     "    try:\n",
     "        with open(f\"../results/{nb_name}_results.json\", 'w') as f:\n",
-    "            json.dump(results, f, indent=2)\n",
+    "            json.dump(results, f, indent=2, default=str)\n",
     "    except TypeError:\n",
     "        pass\n",
     "try:\n",
-    "    print(json.dumps(_params, indent=2))\n",
+    "    print(json.dumps(_params, indent=2, default=str))\n",
     "except TypeError:\n",
     "    print(_params)\n"
    ]


### PR DESCRIPTION
## Summary
- Monkeypatch `Circuit.copy` and override `StatevectorAdapter.prepare_benchmark` in the statevector benchmark notebook
- Ensure results are JSON serializable by adding `default=str`
- Re-ran the statevector backend notebook

## Testing
- `pytest`
- `PYTHONPATH=/workspace/QuASAr jupyter nbconvert --to notebook --inplace --execute benchmarks/notebooks/statevector_backend.ipynb`

------
https://chatgpt.com/codex/tasks/task_e_68be759497348321ab54087f149d5e64