### PR TITLE
Ensure Stim benchmark notebook handles non-JSON types

### DIFF
--- a/benchmarks/notebooks/stim_backend.ipynb
+++ b/benchmarks/notebooks/stim_backend.ipynb
@@ -112,14 +112,14 @@
     "}\n",
     "pathlib.Path('../results').mkdir(exist_ok=True)\n",
     "with open(f\"../results/{nb_name}_params.json\", 'w') as f:\n",
-    "    json.dump(_params, f, indent=2)\n",
+    "    json.dump(_params, f, indent=2, default=str)\n",
     "if 'results' in globals():\n",
     "    try:\n",
     "        with open(f\"../results/{nb_name}_results.json\", 'w') as f:\n",
-    "            json.dump(results, f, indent=2)\n",
+    "            json.dump(results, f, indent=2, default=str)\n",
     "    except TypeError:\n",
     "        pass\n",
-    "print(json.dumps(_params, indent=2))\n"
+    "print(json.dumps(_params, indent=2, default=str))\n"
    ]
   }
  ],


### PR DESCRIPTION
## Summary
- Allow stim_backend notebook to serialize non-standard parameter and result types by passing `default=str` to `json.dump` and `json.dumps`
- Executed the Stim backend notebook to generate results

## Testing
- `jupyter nbconvert --to notebook --execute benchmarks/notebooks/stim_backend.ipynb`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68be759512988321a761f00faf593c5c