### PR TITLE
Handle non-primitive values in evaluation notebook

### DIFF
--- a/benchmarks/notebooks/experimental_evaluation.ipynb
+++ b/benchmarks/notebooks/experimental_evaluation.ipynb
@@ -101,7 +101,7 @@
     "info['QUASAR_QUICK_MAX_GATES'] = os.getenv('QUASAR_QUICK_MAX_GATES')\n",
     "info['QUASAR_QUICK_MAX_DEPTH'] = os.getenv('QUASAR_QUICK_MAX_DEPTH')\n",
     "info['QUASAR_MPS_TARGET_FIDELITY'] = os.getenv('QUASAR_MPS_TARGET_FIDELITY')\n",
-    "Path('environment.json').write_text(json.dumps(info, indent=2))\n",
+    "Path('environment.json').write_text(json.dumps(info, indent=2, default=str))\n",
     "info\n"
    ]
   },
@@ -159,7 +159,11 @@
     "\n",
     "\n",
     "def src_link(func):\n",
-    "    file = Path(inspect.getsourcefile(func)).relative_to(Path.cwd())\n",
+    "    file = Path(inspect.getsourcefile(func)).resolve()\n",
+    "    try:\n",
+    "        file = file.relative_to(Path.cwd())\n",
+    "    except ValueError:\n",
+    "        file = file.relative_to(Path.cwd().parent)\n",
     "    line = inspect.getsourcelines(func)[1]\n",
     "    return f\"[generator]({file}#L{line})\"\n",
     "\n",
@@ -175,8 +179,7 @@
     "for name, fn, desc in circuits:\n",
     "    circ = fn()\n",
     "    rows.append(f\"| {name} | {circ.num_qubits} | {circ.num_gates} | {desc} | {src_link(fn)} |\")\n",
-    "Markdown(\"\n",
-    "\".join(rows))\n"
+    "Markdown(\"\\n\".join(rows))\n"
    ]
   },
   {
@@ -267,14 +270,14 @@
     "}\n",
     "pathlib.Path('../results').mkdir(exist_ok=True)\n",
     "with open(f\"../results/{nb_name}_params.json\", 'w') as f:\n",
-    "    json.dump(_params, f, indent=2)\n",
+    "    json.dump(_params, f, indent=2, default=str)\n",
     "if 'results' in globals():\n",
     "    try:\n",
     "        with open(f\"../results/{nb_name}_results.json\", 'w') as f:\n",
-    "            json.dump(results, f, indent=2)\n",
+    "            json.dump(results, f, indent=2, default=str)\n",
     "    except TypeError:\n",
     "        pass\n",
-    "print(json.dumps(_params, indent=2))\n"
+    "print(json.dumps(_params, indent=2, default=str))\n"
    ]
   },
   {
@@ -1568,17 +1571,17 @@
     "pathlib.Path('../results').mkdir(exist_ok=True)\n",
     "with open(f\"../results/{nb_name}_params.json\", 'w') as f:\n",
     "    try:\n",
-    "        json.dump(_params, f, indent=2)\n",
+    "        json.dump(_params, f, indent=2, default=str)\n",
     "    except TypeError:\n",
     "        pass\n",
     "if 'results' in globals():\n",
     "    try:\n",
     "        with open(f\"../results/{nb_name}_results.json\", 'w') as f:\n",
-    "            json.dump(results, f, indent=2)\n",
+    "            json.dump(results, f, indent=2, default=str)\n",
     "    except TypeError:\n",
     "        pass\n",
     "try:\n",
-    "    print(json.dumps(_params, indent=2))\n",
+    "    print(json.dumps(_params, indent=2, default=str))\n",
     "except TypeError:\n",
     "    print(_params)\n"
    ]
@@ -2562,14 +2565,14 @@
     "}\n",
     "pathlib.Path('../results').mkdir(exist_ok=True)\n",
     "with open(f\"../results/{nb_name}_params.json\", 'w') as f:\n",
-    "    json.dump(_params, f, indent=2)\n",
+    "    json.dump(_params, f, indent=2, default=str)\n",
     "if 'results' in globals():\n",
     "    try:\n",
     "        with open(f\"../results/{nb_name}_results.json\", 'w') as f:\n",
-    "            json.dump(results, f, indent=2)\n",
+    "            json.dump(results, f, indent=2, default=str)\n",
     "    except TypeError:\n",
     "        pass\n",
-    "print(json.dumps(_params, indent=2))\n"
+    "print(json.dumps(_params, indent=2, default=str))\n"
    ]
   },
   {
@@ -3957,7 +3960,7 @@
     "if 'results' in globals():\n",
     "    try:\n",
     "        with open(f\"../results/{nb_name}_results.json\", 'w') as f:\n",
-    "            json.dump(results, f, indent=2)\n",
+    "            json.dump(results, f, indent=2, default=str)\n",
     "    except TypeError:\n",
     "        pass\n",
     "print(json.dumps(_params, indent=2, default=str))\n"
@@ -4143,14 +4146,14 @@
     "}\n",
     "pathlib.Path('../results').mkdir(exist_ok=True)\n",
     "with open(f\"../results/{nb_name}_params.json\", 'w') as f:\n",
-    "    json.dump(_params, f, indent=2)\n",
+    "    json.dump(_params, f, indent=2, default=str)\n",
     "if 'results' in globals():\n",
     "    try:\n",
     "        with open(f\"../results/{nb_name}_results.json\", 'w') as f:\n",
-    "            json.dump(results, f, indent=2)\n",
+    "            json.dump(results, f, indent=2, default=str)\n",
     "    except TypeError:\n",
     "        pass\n",
-    "print(json.dumps(_params, indent=2))\n"
+    "print(json.dumps(_params, indent=2, default=str))\n"
    ]
   }
  ],


### PR DESCRIPTION
## Summary
- ensure experimental evaluation notebook dumps JSON with `default=str` to support non-primitive values
- make benchmark source linking robust to different working directories

## Testing
- `pytest`
- `PYTHONPATH=$PWD jupyter nbconvert --to notebook --execute --inplace benchmarks/notebooks/experimental_evaluation.ipynb` *(fails: AttributeError: 'Config' object has no attribute 'dd_symmetry_weight')*


------
https://chatgpt.com/codex/tasks/task_e_68be8ccac0c08321af235f18edbd8a0c