### PR TITLE
Fix imports in large-scale benchmark notebook

### DIFF
--- a/benchmarks/notebooks/large_scale_circuits.ipynb
+++ b/benchmarks/notebooks/large_scale_circuits.ipynb
@@ -38,7 +38,7 @@
     "import sys, platform, quasar\n",
     "print('Python', sys.version)\n",
     "print('Platform', platform.platform())\n",
-    "print('QuASAr', quasar.__version__)\n"
+    "print('QuASAr', getattr(quasar, '__version__', 'unknown'))\n"
    ]
   },
   {
@@ -49,7 +49,7 @@
     "\n",
     "## Benchmark setup\n",
     "\n",
-    "Each circuit generator from `large_scale_circuits.py` is instantiated at two scales. The circuits are executed on pure backends \u2013 dense statevector, Stim's tableau simulator, the tensor-network MPS backend and the decision-diagram backend \u2013 and via QuASAr's planner. Runtimes and memory consumption are recorded for comparison.\n"
+    "Each circuit generator from `large_scale_circuits.py` is instantiated at two scales. The circuits are executed on pure backends – dense statevector, Stim's tableau simulator, the tensor-network MPS backend and the decision-diagram backend – and via QuASAr's planner. Runtimes and memory consumption are recorded for comparison.\n"
    ]
   },
   {
@@ -67,10 +67,10 @@
     "import matplotlib.pyplot as plt\n",
     "import networkx as nx\n",
     "\n",
-    "from runner import BenchmarkRunner\n",
+    "from benchmarks.runner import BenchmarkRunner\n",
     "from quasar import SimulationEngine\n",
     "from quasar.cost import Backend\n",
-    "import large_scale_circuits as lsc\n"
+    "from benchmarks import large_scale_circuits as lsc\n"
    ]
   },
   {


### PR DESCRIPTION
## Summary
- fix BenchmarkRunner and large_scale_circuits imports in `large_scale_circuits.ipynb`
- guard notebook's version print when `quasar.__version__` is absent

## Testing
- `pytest`
- `jupyter nbconvert --to notebook --execute benchmarks/notebooks/large_scale_circuits.ipynb --output /tmp/large_scale_circuits.out.ipynb` *(fails: QuantumCircuit.measure() missing 1 required positional argument: 'cbit')*

------
https://chatgpt.com/codex/tasks/task_e_68be8ce3a954832182aae73b92ec1e6c