### PR TITLE
Scale DD rotation diversity threshold with circuit size

### DIFF
--- a/docs/backend_selection.md
+++ b/docs/backend_selection.md
@@ -11,9 +11,10 @@ examines basic structural metrics to guide this choice:
    *amplitude* rotation diversity are consulted. Each metric is normalised by
    its corresponding threshold – ``adaptive_dd_sparsity_threshold(n_qubits)``,
    ``dd_nnz_threshold``, ``dd_phase_rotation_diversity_threshold`` and
-   ``dd_amplitude_rotation_diversity_threshold`` – and combined using weights
-   ``dd_sparsity_weight``, ``dd_nnz_weight``, ``dd_phase_rotation_weight`` and
-   ``dd_amplitude_rotation_weight``.  The combined score is
+   ``adaptive_dd_amplitude_rotation_threshold(n_qubits, sparsity)`` – and
+   combined using weights ``dd_sparsity_weight``, ``dd_nnz_weight``,
+   ``dd_phase_rotation_weight`` and ``dd_amplitude_rotation_weight``.  The
+   combined score is
 
    ``(w_s*(s/s_thr) + w_n*(1 - nnz/nnz_thr) + w_p*(1 - p/p_thr) + w_a*(1 - a/a_thr)) / (w_s+w_n+w_p+w_a)``
 
@@ -41,12 +42,12 @@ exists.  This behaviour can be overridden via the planner's ``perf_prio``
 option, setting it to ``"time"`` to prioritise runtime instead.
 
 The default weights for sparsity, nnz and the two rotation metrics are ``1.0``
-each with a ``dd_metric_threshold`` of ``0.8`` and rotation‑diversity thresholds
-of ``16`` distinct angles for both phase and amplitude rotations. These values
-– along with ``dd_sparsity_threshold`` and ``dd_nnz_threshold`` – may be tuned
-via the ``QUASAR_DD_*`` environment variables or by overriding
-``config.DEFAULT`` at runtime.  Lowering ``mps_target_fidelity`` reduces the
-required bond dimension
+each with a ``dd_metric_threshold`` of ``0.8``.  Phase rotation diversity is
+limited to ``16`` distinct angles while the amplitude rotation threshold uses
+the same base value but scales with circuit width and sparsity. These values –
+along with ``dd_sparsity_threshold`` and ``dd_nnz_threshold`` – may be tuned via
+the ``QUASAR_DD_*`` environment variables or by overriding ``config.DEFAULT`` at
+runtime.  Lowering ``mps_target_fidelity`` reduces the required bond dimension
 and can therefore make the MPS backend applicable to more circuits.
 
 This lightweight heuristic steers the planner towards specialised backends for

--- a/quasar/config.py
+++ b/quasar/config.py
@@ -123,3 +123,29 @@ class Config:
 
 # Global configuration instance used when modules import ``quasar.config``.
 DEFAULT = Config()
+
+
+def adaptive_dd_amplitude_rotation_threshold(
+    n_qubits: int, sparsity: float | None = None
+) -> int:
+    """Return the amplitude rotation diversity limit for a circuit.
+
+    The base threshold ``DEFAULT.dd_amplitude_rotation_diversity_threshold``
+    is scaled with circuit width and sparsity.  Extremely sparse circuits such
+    as W states therefore retain the decision diagram backend even when they
+    contain many distinct rotation angles.
+
+    Args:
+        n_qubits: Number of qubits in the circuit segment.
+        sparsity: Estimated sparsity of the segment.  When provided the
+            threshold grows with the estimated number of non-zero amplitudes.
+
+    Returns:
+        An adjusted diversity threshold.
+    """
+
+    base = DEFAULT.dd_amplitude_rotation_diversity_threshold
+    if sparsity is None:
+        return max(base, n_qubits)
+    nnz = int((1 - sparsity) * (2**n_qubits))
+    return max(base, nnz)

--- a/quasar/partitioner.py
+++ b/quasar/partitioner.py
@@ -72,18 +72,21 @@ class Partitioner:
             amp_rot = rot_amp(circuit)
         nnz_estimate = int((1 - sparsity) * (2 ** circuit.num_qubits))
         s_thresh = adaptive_dd_sparsity_threshold(circuit.num_qubits)
+        amp_thresh = config.adaptive_dd_amplitude_rotation_threshold(
+            circuit.num_qubits, sparsity
+        )
         passes = (
             sparsity >= s_thresh
             and nnz_estimate <= config.DEFAULT.dd_nnz_threshold
             and phase_rot <= config.DEFAULT.dd_phase_rotation_diversity_threshold
-            and amp_rot <= config.DEFAULT.dd_amplitude_rotation_diversity_threshold
+            and amp_rot <= amp_thresh
         )
         dd_metric = False
         if passes:
             s_score = sparsity / s_thresh if s_thresh > 0 else 0.0
             nnz_score = 1 - nnz_estimate / config.DEFAULT.dd_nnz_threshold
             phase_score = 1 - phase_rot / config.DEFAULT.dd_phase_rotation_diversity_threshold
-            amp_score = 1 - amp_rot / config.DEFAULT.dd_amplitude_rotation_diversity_threshold
+            amp_score = 1 - amp_rot / amp_thresh
             weight_sum = (
                 config.DEFAULT.dd_sparsity_weight
                 + config.DEFAULT.dd_nnz_weight

--- a/quasar/scheduler.py
+++ b/quasar/scheduler.py
@@ -156,14 +156,15 @@ class Scheduler:
 
         nnz_estimate = int((1 - sparsity) * (2**num_qubits))
         s_thresh = adaptive_dd_sparsity_threshold(num_qubits)
+        amp_thresh = config.adaptive_dd_amplitude_rotation_threshold(
+            num_qubits, sparsity
+        )
         s_score = sparsity / s_thresh if s_thresh > 0 else 0.0
         nnz_score = 1 - nnz_estimate / config.DEFAULT.dd_nnz_threshold
         phase_score = (
             1 - phase_rot / config.DEFAULT.dd_phase_rotation_diversity_threshold
         )
-        amp_score = (
-            1 - amp_rot / config.DEFAULT.dd_amplitude_rotation_diversity_threshold
-        )
+        amp_score = 1 - amp_rot / amp_thresh
         weight_sum = (
             config.DEFAULT.dd_sparsity_weight
             + config.DEFAULT.dd_nnz_weight
@@ -181,7 +182,7 @@ class Scheduler:
             sparsity >= s_thresh
             and nnz_estimate <= config.DEFAULT.dd_nnz_threshold
             and phase_rot <= config.DEFAULT.dd_phase_rotation_diversity_threshold
-            and amp_rot <= config.DEFAULT.dd_amplitude_rotation_diversity_threshold
+            and amp_rot <= amp_thresh
         )
         dd_metric = passes and metric >= config.DEFAULT.dd_metric_threshold
 

--- a/tests/test_backend_selection.py
+++ b/tests/test_backend_selection.py
@@ -34,6 +34,25 @@ def test_planner_selects_dd_when_sparsity_weighted(monkeypatch):
     assert plan.final_backend == Backend.DECISION_DIAGRAM
 
 
+def test_w_state_amplitude_threshold_scales(monkeypatch):
+    base = config.DEFAULT.dd_amplitude_rotation_diversity_threshold
+    circuit = w_state_circuit(base + 5)
+    # Skew the estimator to strongly prefer decision diagrams over MPS.
+    est = CostEstimator(
+        coeff={
+            "dd_gate": 1e-6,
+            "dd_mem": 1e-6,
+            "mps_gate_1q": 1000.0,
+            "mps_gate_2q": 1000.0,
+            "mps_mem": 1000.0,
+            "mps_temp_mem": 1000.0,
+        }
+    )
+    engine = SimulationEngine(estimator=est)
+    plan = engine.planner.plan(circuit)
+    assert plan.final_backend == Backend.DECISION_DIAGRAM
+
+
 def test_mps_target_fidelity_controls_selection(monkeypatch):
     circuit = qft_circuit(7)
     circuit.symmetry = 0.0


### PR DESCRIPTION
## Summary
- grow Decision Diagram amplitude rotation limit with circuit width and sparsity
- apply adaptive threshold throughout backend selection heuristics
- document new heuristic and add regression test for wide W-state circuits

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68be965448448321b92a773fbd8ac7d5