### PR TITLE
Calibrate statevector baseline overhead

### DIFF
--- a/CALIBRATION.md
+++ b/CALIBRATION.md
@@ -9,8 +9,9 @@ The matrix product state (MPS) calibration distinguishes between costs
 for single- and two-qubit gates and an additional optional
 singular-value-decomposition (SVD) truncation step.  Separate
 coefficients for these components are produced by the calibration
-script.  A small W-state benchmark also records fixed runtime and
-memory overheads, exposed as ``mps_base_time`` and ``mps_base_mem``.
+script.  Small benchmark circuits also record fixed runtime and memory
+overheads for the statevector and MPS simulators, exposed as
+``sv_base_time``, ``sv_base_mem``, ``mps_base_time`` and ``mps_base_mem``.
 
 ## Default coefficients
 

--- a/tests/test_backend_selection.py
+++ b/tests/test_backend_selection.py
@@ -22,6 +22,8 @@ def test_planner_selects_mps_for_qft():
         coeff={
             "sv_gate_1q": 50.0,
             "sv_gate_2q": 50.0,
+            "sv_base_time": 0.0,
+            "sv_base_mem": 0.0,
             "mps_base_time": 0.0,
             "mps_base_mem": 0.0,
         }
@@ -68,6 +70,8 @@ def test_mps_target_fidelity_controls_selection(monkeypatch):
         coeff={
             "sv_gate_1q": 50.0,
             "sv_gate_2q": 50.0,
+            "sv_base_time": 0.0,
+            "sv_base_mem": 0.0,
             "mps_base_time": 0.0,
             "mps_base_mem": 0.0,
         }
@@ -91,6 +95,8 @@ def test_memory_threshold_limits_mps(monkeypatch):
         coeff={
             "sv_gate_1q": 50.0,
             "sv_gate_2q": 50.0,
+            "sv_base_time": 0.0,
+            "sv_base_mem": 0.0,
             "mps_base_time": 0.0,
             "mps_base_mem": 0.0,
         }

--- a/tests/test_cost.py
+++ b/tests/test_cost.py
@@ -6,8 +6,10 @@ def test_statevector_scaling():
     est = CostEstimator()
     small = est.statevector(num_qubits=3, num_1q_gates=1, num_2q_gates=0, num_meas=0)
     large = est.statevector(num_qubits=4, num_1q_gates=1, num_2q_gates=0, num_meas=0)
-    assert large.time == 2 * small.time
-    assert large.memory == 2 * small.memory
+    base_t = est.coeff["sv_base_time"]
+    base_m = est.coeff["sv_base_mem"]
+    assert large.time - base_t == 2 * (small.time - base_t)
+    assert large.memory - base_m == 2 * (small.memory - base_m)
     assert small.log_depth == math.log2(3)
     assert large.log_depth == math.log2(4)
 
@@ -28,7 +30,18 @@ def test_statevector_precision_memory():
         num_meas=0,
         precision="complex128",
     )
-    assert double.memory == 2 * single.memory
+    base = est.coeff["sv_base_mem"]
+    assert double.memory - base == 2 * (single.memory - base)
+
+
+def test_statevector_base_overhead():
+    est = CostEstimator()
+    cost = est.statevector(num_qubits=0, num_1q_gates=0, num_2q_gates=0, num_meas=0)
+    base_t = est.coeff["sv_base_time"]
+    base_m = est.coeff["sv_base_mem"]
+    expected_mem = base_m + est.coeff["sv_bytes_per_amp"] * 1 * 16
+    assert cost.time == base_t
+    assert cost.memory == expected_mem
 
 
 def test_tableau_qubit_scaling():

--- a/tests/test_cost_planner_regression.py
+++ b/tests/test_cost_planner_regression.py
@@ -10,8 +10,10 @@ from quasar import config
 def test_statevector_cost_regression():
     est = CostEstimator()
     cost = est.statevector(num_qubits=3, num_1q_gates=1, num_2q_gates=1, num_meas=1)
-    assert cost.time == 24.0
-    assert cost.memory == 160.0
+    expected_time = 24.0 + est.coeff["sv_base_time"]
+    assert cost.time == expected_time
+    expected_mem = 160.0 + est.coeff["sv_base_mem"]
+    assert cost.memory == expected_mem
     assert math.isclose(cost.log_depth, math.log2(3))
 
 

--- a/tests/test_planner_scheduler_conversions.py
+++ b/tests/test_planner_scheduler_conversions.py
@@ -87,7 +87,13 @@ def test_planner_conversions_used():
     )
     planner = Planner(
         estimator=CostEstimator(
-            coeff={"sv_gate_1q": 1e6, "sv_gate_2q": 1e6, "sv_meas": 1e6}
+            coeff={
+                "sv_gate_1q": 1e6,
+                "sv_gate_2q": 1e6,
+                "sv_meas": 1e6,
+                "sv_base_time": 0.0,
+                "sv_base_mem": 0.0,
+            }
         ),
         conversion_cost_multiplier=0.0,
     )


### PR DESCRIPTION
## Summary
- model Qiskit startup costs for statevector simulation via `sv_base_time` and `sv_base_mem`
- expand calibration utilities with statevector baseline benchmark and document constants
- adjust tests for updated statevector cost estimates

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68bea3b474588321922b0ca08bee3316