### PR TITLE
Expand experimental evaluation ranges

### DIFF
--- a/benchmarks/notebooks/experimental_evaluation.ipynb
+++ b/benchmarks/notebooks/experimental_evaluation.ipynb
@@ -410,7 +410,7 @@
     }
    ],
    "source": [
-    "chis = [8, 16, 32, 64, 128]\n",
+    "chis = [8, 16, 32, 64, 128, 256, 512]\n",
     "reps = 5\n",
     "svd_results = []\n",
     "for chi in chis:\n",
@@ -597,7 +597,7 @@
     }
    ],
    "source": [
-    "frontiers = [10, 50, 200, 1000]\n",
+    "frontiers = [10, 50, 200, 1000, 5000, 20000]\n",
     "reps = 5\n",
     "dd_results = []\n",
     "for r in frontiers:\n",
@@ -807,7 +807,7 @@
     }
    ],
    "source": [
-    "windows = list(range(2, 9))\n",
+    "windows = list(range(2, 17))\n",
     "reps = 5\n",
     "st_results = []\n",
     "for w in windows:\n",
@@ -1407,7 +1407,7 @@
     "    'stim': StimAdapter(),\n",
     "}\n",
     "REPETITIONS = 5\n",
-    "NUM_QUBITS = 2\n",
+    "NUM_QUBITS = 16\n",
     "records = []\n",
     "for cname, cfn in circuit_fns.items():\n",
     "    circuit = cfn(NUM_QUBITS)\n",
@@ -2796,7 +2796,7 @@
     "\n",
     "results=[]\n",
     "for seed in range(10):\n",
-    "    num_qubits = random.randint(2,20)\n",
+    "    num_qubits = random.randint(20,50)\n",
     "    circuit = circuit_lib.random_circuit(num_qubits, seed=seed)\n",
     "    gates=circuit.gates[:8]\n",
     "    c=Circuit(gates)\n",


### PR DESCRIPTION
## Summary
- enlarge SVD chi sweep to include 256 and 512
- extend decision-diagram frontier sizes and local window search range
- test larger circuits by bumping qubit counts in benchmarks

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68beb89acbe48321b1de25af19744b72