### PR TITLE
Use backend classes directly in experimental evaluation notebook

### DIFF
--- a/benchmarks/notebooks/experimental_evaluation.ipynb
+++ b/benchmarks/notebooks/experimental_evaluation.ipynb
@@ -1348,8 +1348,7 @@
     "sys.path.append(os.path.abspath('../..'))\n",
     "import pandas as pd\n",
     "from benchmarks.runner import BenchmarkRunner\n",
-    "from quasar.backends import StatevectorBackend\n",
-    "from benchmarks.backends import DecisionDiagramAdapter, MPSAdapter, StimAdapter\n",
+    "from quasar.backends import StatevectorBackend, DecisionDiagramBackend, MPSBackend, StimBackend\n",
     "from benchmarks import circuits\n",
     "from quasar.simulation_engine import SimulationEngine\n",
     "from quasar_convert import ConversionEngine\n",
@@ -1403,9 +1402,9 @@
     "}\n",
     "backends = {\n",
     "    'statevector': StatevectorBackend(),\n",
-    "    'mqt_dd': DecisionDiagramAdapter(),\n",
-    "    'mps': MPSAdapter(),\n",
-    "    'stim': StimAdapter(),\n",
+    "    'mqt_dd': DecisionDiagramBackend(),\n",
+    "    'mps': MPSBackend(),\n",
+    "    'stim': StimBackend(),\n",
     "}\n",
     "REPETITIONS = 5\n",
     "NUM_QUBITS = 16\n",
@@ -1751,15 +1750,15 @@
     "    sns.heatmap(heat_numeric, annot=heat, fmt='', cmap='tab10', cbar=False)\n",
     "    plt.title(f'Backend per fragment for {name}')\n",
     "    plt.xlabel('Fragment')\n",
-    "    plt.ylabel('α')\n",
+    "    plt.ylabel('\u03b1')\n",
     "    plt.show()\n",
     "\n",
     "    runtime_df = pd.DataFrame({'alpha': [r['alpha'] for r in subset],\n",
     "                               'runtime': [r['runtime'] for r in subset]})\n",
     "    plt.figure()\n",
     "    sns.lineplot(data=runtime_df, x='alpha', y='runtime', marker='o')\n",
-    "    plt.title(f'Runtime vs α for {name}')\n",
-    "    plt.xlabel('α')\n",
+    "    plt.title(f'Runtime vs \u03b1 for {name}')\n",
+    "    plt.xlabel('\u03b1')\n",
     "    plt.ylabel('Runtime (s)')\n",
     "    plt.show()\n"
    ]
@@ -2584,7 +2583,7 @@
    "source": [
     "# Planner quality\n",
     "\n",
-    "This notebook compares exhaustive oracle, greedy, and dynamic programming strategies on small circuits (≤ 20 qubits) using the planner's public interface and updated cost heuristics (entanglement-aware MPS, decision-diagram weighting).\n"
+    "This notebook compares exhaustive oracle, greedy, and dynamic programming strategies on small circuits (\u2264 20 qubits) using the planner's public interface and updated cost heuristics (entanglement-aware MPS, decision-diagram weighting).\n"
    ]
   },
   {
@@ -2939,8 +2938,8 @@
     "\n",
     "This notebook evaluates the scheduler's ability to recover from unexpected changes. Two perturbation types are applied during execution:\n",
     "\n",
-    "* **Gate injection** – extra entangling operations are inserted while the circuit is already running.\n",
-    "* **Cost corruption** – cost model coefficients are perturbed to trigger re-planning.\n",
+    "* **Gate injection** \u2013 extra entangling operations are inserted while the circuit is already running.\n",
+    "* **Cost corruption** \u2013 cost model coefficients are perturbed to trigger re-planning.\n",
     "\n",
     "For each magnitude we perform multiple repetitions, measuring the time to recover and the runtime overhead. Timelines highlight when re-planning occurs and a table summarises recovery statistics."
    ]


### PR DESCRIPTION
## Summary
- Import backend implementations from `quasar.backends` in experimental evaluation notebook
- Instantiate `DecisionDiagramBackend`, `MPSBackend`, and `StimBackend` directly in benchmark configuration
- Remove all leftover adapter references

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68bed45365848321b76c1d1d353742dd