### PR TITLE
Use MPSBackend in benchmark notebook

### DIFF
--- a/benchmarks/notebooks/mps_backend.ipynb
+++ b/benchmarks/notebooks/mps_backend.ipynb
@@ -17,7 +17,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from benchmarks.backends import MPSAdapter\n",
+    "from quasar.backends import MPSBackend\n",
     "from benchmarks.runner import BenchmarkRunner\n",
     "from benchmarks import circuits\n",
     "import pandas as pd"
@@ -38,7 +38,7 @@
     "]\n",
     "\n",
     "runner = BenchmarkRunner()\n",
-    "backend = MPSAdapter()\n",
+    "backend = MPSBackend()\n",
     "for name, circ in circuits_to_run:\n",
     "    res = runner.run_multiple(circ, backend, return_state=False, repetitions=3)\n",
     "    res[\"circuit\"] = name\n",


### PR DESCRIPTION
## Summary
- Import `MPSBackend` from `quasar.backends` in the MPS benchmark notebook
- Instantiate `MPSBackend` instead of `MPSAdapter`

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68bed7d45ff48321a3dc1661a823154e