### PR TITLE
Use StimBackend in notebook

### DIFF
--- a/benchmarks/notebooks/stim_backend.ipynb
+++ b/benchmarks/notebooks/stim_backend.ipynb
@@ -17,7 +17,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from benchmarks.backends import StimAdapter\n",
+    "from quasar.backends import StimBackend\n",
     "from benchmarks.runner import BenchmarkRunner\n",
     "from benchmarks import circuits\n",
     "import pandas as pd"
@@ -38,7 +38,7 @@
     "]\n",
     "\n",
     "runner = BenchmarkRunner()\n",
-    "backend = StimAdapter()\n",
+    "backend = StimBackend()\n",
     "for name, circ in circuits_to_run:\n",
     "    res = runner.run_multiple(circ, backend, return_state=False, repetitions=3)\n",
     "    res[\"circuit\"] = name\n",


### PR DESCRIPTION
## Summary
- use quasar StimBackend in stim backend benchmark notebook

## Testing
- `pytest` *(failed: comparison failed)*

------
https://chatgpt.com/codex/tasks/task_e_68bed7d4b8688321a51b3c5853436d01