### PR TITLE
Add benchmark run timeout and skip slow results

### DIFF
--- a/benchmarks/notebooks/comparison.ipynb
+++ b/benchmarks/notebooks/comparison.ipynb
@@ -47,7 +47,7 @@
    "id": "3a776a36",
    "metadata": {},
    "source": [
-    "The figure below compares execution times for QuASAr backends. A later plot shows peak memory usage for the same circuits."
+    "The figure below compares execution times for QuASAr backends. A later plot shows peak memory usage for the same circuits. Simulations that exceed a configurable timeout are skipped to avoid excessive runtimes."
    ]
   },
   {
@@ -90,6 +90,7 @@
     "backends = [Backend.STATEVECTOR, Backend.MPS, Backend.TABLEAU, Backend.MQT_DD]\n",
     "runner = BenchmarkRunner()\n",
     "engine = SimulationEngine()\n",
+    "RUN_TIMEOUT = 5.0\n",
     "\n",
     "circuits = {\n",
     "    'ghz': circuit_lib.ghz_circuit,\n",
@@ -109,14 +110,22 @@
     "            if name == 'wstate' and b == Backend.TABLEAU:\n",
     "                continue\n",
     "            try:\n",
-    "                rec = runner.run_quasar_multiple(base_circ, engine, backend=b, repetitions=3)\n",
+    "                rec = runner.run_quasar_multiple(\n",
+    "                    base_circ, engine, backend=b, repetitions=3, run_timeout=RUN_TIMEOUT\n",
+    "                )\n",
+    "                if 'failed_runs' in rec:\n",
+    "                    continue\n",
     "                _ = rec['result']\n",
     "                rec.update({'circuit': name, 'qubits': n, 'mode': 'forced'})\n",
     "            except Exception:\n",
     "                pass\n",
     "        try:\n",
     "            auto_circ = build(n, use_classical_simplification=True)\n",
-    "            rec = runner.run_quasar_multiple(auto_circ, engine, repetitions=3)\n",
+    "            rec = runner.run_quasar_multiple(\n",
+    "                auto_circ, engine, repetitions=3, run_timeout=RUN_TIMEOUT\n",
+    "            )\n",
+    "            if 'failed_runs' in rec:\n",
+    "                continue\n",
     "            _ = rec['result']\n",
     "            rec.update({'circuit': name, 'qubits': n, 'mode': 'auto'})\n",
     "        except Exception:\n",

--- a/tests/test_runner_timeout.py
+++ b/tests/test_runner_timeout.py
@@ -1,0 +1,56 @@
+import time
+from types import SimpleNamespace
+
+import pytest
+
+from benchmarks.runner import BenchmarkRunner
+from quasar.cost import Backend
+
+
+class SlowSim:
+    name = "slow"
+
+    def load(self, n: int) -> None:
+        pass
+
+    def apply_gate(self, gate, qubits, params) -> None:  # pragma: no cover
+        pass
+
+    def extract_ssd(self):
+        time.sleep(0.05)
+        return None
+
+
+class DummyScheduler:
+    def __init__(self) -> None:
+        self.backends = {Backend.STATEVECTOR: SlowSim()}
+
+    def select_backend(self, circuit, backend=None):
+        return backend or Backend.STATEVECTOR
+
+
+def test_run_quasar_multiple_timeout() -> None:
+    runner = BenchmarkRunner()
+    engine = SimpleNamespace(scheduler=DummyScheduler())
+    circuit = SimpleNamespace(num_qubits=1, gates=[], ssd=None)
+
+    with pytest.raises(RuntimeError):
+        runner.run_quasar_multiple(
+            circuit,
+            engine,
+            backend=Backend.STATEVECTOR,
+            repetitions=1,
+            run_timeout=0.01,
+            quick=True,
+        )
+
+    res = runner.run_quasar_multiple(
+        circuit,
+        engine,
+        backend=Backend.STATEVECTOR,
+        repetitions=1,
+        run_timeout=0.2,
+        quick=True,
+    )
+    assert res["backend"] == Backend.STATEVECTOR.name
+


### PR DESCRIPTION
## Summary
- abort long-running benchmark runs using a signal-based timeout helper
- skip timed-out simulations in comparison notebook
- test timeout handling in `BenchmarkRunner`

## Testing
- `pytest tests/test_runner_timeout.py -q`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bf09c294d883218ec486947d932506