### PR TITLE
Persist benchmark notebook outputs

### DIFF
--- a/benchmarks/notebooks/00_environment_setup.ipynb
+++ b/benchmarks/notebooks/00_environment_setup.ipynb
@@ -7,7 +7,26 @@
    "source": [
     "# Environment Setup\n",
     "\n",
-    "This notebook captures system information for benchmarking and saves it to `environment.json`.\n"
+    "This notebook captures system information for benchmarking and saves it to `environment.json`.\n",
+    "\n\nFigures are saved to `../figures/` and tables to `../results/`.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from pathlib import Path\n",
+    "FIGURES_DIR = Path('../figures')\n",
+    "RESULTS_DIR = Path('../results')\n",
+    "FIGURES_DIR.mkdir(exist_ok=True)\n",
+    "RESULTS_DIR.mkdir(exist_ok=True)\n",
+    "try:\n",
+    "    import ipynbname\n",
+    "    NB_NAME = ipynbname.path().stem\n",
+    "except Exception:  # pragma: no cover\n",
+    "    NB_NAME = 'notebook'\n"
    ]
   },
   {
@@ -300,6 +319,26 @@
     "    except TypeError:\n",
     "        pass\n",
     "print(json.dumps(_params, indent=2, default=str))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import pandas as pd\n",
+    "import matplotlib.pyplot as plt\n",
+    "for i, num in enumerate(plt.get_fignums(), start=1):\n",
+    "    plt.figure(num)\n",
+    "    plt.savefig(FIGURES_DIR / f'{NB_NAME}_plot{i}.png')\n",
+    "for _name, _obj in globals().items():\n",
+    "    if isinstance(_obj, pd.DataFrame):\n",
+    "        _obj.to_csv(RESULTS_DIR / f'{NB_NAME}_{_name}.csv', index=False)\n",
+    "        try:\n",
+    "            _obj.to_latex(RESULTS_DIR / f'{NB_NAME}_{_name}.tex', index=False)\n",
+    "        except Exception:\n",
+    "            pass\n"
    ]
   }
  ],

--- a/benchmarks/notebooks/01_microbenchmarks.ipynb
+++ b/benchmarks/notebooks/01_microbenchmarks.ipynb
@@ -5,7 +5,26 @@
    "id": "1aecd9ff",
    "metadata": {},
    "source": [
-    "# Microbenchmarks"
+    "# Microbenchmarks",
+    "\n\nFigures are saved to `../figures/` and tables to `../results/`.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from pathlib import Path\n",
+    "FIGURES_DIR = Path('../figures')\n",
+    "RESULTS_DIR = Path('../results')\n",
+    "FIGURES_DIR.mkdir(exist_ok=True)\n",
+    "RESULTS_DIR.mkdir(exist_ok=True)\n",
+    "try:\n",
+    "    import ipynbname\n",
+    "    NB_NAME = ipynbname.path().stem\n",
+    "except Exception:  # pragma: no cover\n",
+    "    NB_NAME = 'notebook'\n"
    ]
   },
   {
@@ -1046,6 +1065,26 @@
     "    except TypeError:\n",
     "        pass\n",
     "print(json.dumps(_params, indent=2, default=str))\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import pandas as pd\n",
+    "import matplotlib.pyplot as plt\n",
+    "for i, num in enumerate(plt.get_fignums(), start=1):\n",
+    "    plt.figure(num)\n",
+    "    plt.savefig(FIGURES_DIR / f'{NB_NAME}_plot{i}.png')\n",
+    "for _name, _obj in globals().items():\n",
+    "    if isinstance(_obj, pd.DataFrame):\n",
+    "        _obj.to_csv(RESULTS_DIR / f'{NB_NAME}_{_name}.csv', index=False)\n",
+    "        try:\n",
+    "            _obj.to_latex(RESULTS_DIR / f'{NB_NAME}_{_name}.tex', index=False)\n",
+    "        except Exception:\n",
+    "            pass\n"
    ]
   }
  ],

--- a/benchmarks/notebooks/02_end_to_end.ipynb
+++ b/benchmarks/notebooks/02_end_to_end.ipynb
@@ -5,7 +5,26 @@
    "id": "91c52cd8",
    "metadata": {},
    "source": [
-    "# End-to-End Benchmark"
+    "# End-to-End Benchmark",
+    "\n\nFigures are saved to `../figures/` and tables to `../results/`.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from pathlib import Path\n",
+    "FIGURES_DIR = Path('../figures')\n",
+    "RESULTS_DIR = Path('../results')\n",
+    "FIGURES_DIR.mkdir(exist_ok=True)\n",
+    "RESULTS_DIR.mkdir(exist_ok=True)\n",
+    "try:\n",
+    "    import ipynbname\n",
+    "    NB_NAME = ipynbname.path().stem\n",
+    "except Exception:  # pragma: no cover\n",
+    "    NB_NAME = 'notebook'\n"
    ]
   },
   {
@@ -656,6 +675,26 @@
     "    print(json.dumps(_params, indent=2))\n",
     "except TypeError:\n",
     "    print(_params)\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import pandas as pd\n",
+    "import matplotlib.pyplot as plt\n",
+    "for i, num in enumerate(plt.get_fignums(), start=1):\n",
+    "    plt.figure(num)\n",
+    "    plt.savefig(FIGURES_DIR / f'{NB_NAME}_plot{i}.png')\n",
+    "for _name, _obj in globals().items():\n",
+    "    if isinstance(_obj, pd.DataFrame):\n",
+    "        _obj.to_csv(RESULTS_DIR / f'{NB_NAME}_{_name}.csv', index=False)\n",
+    "        try:\n",
+    "            _obj.to_latex(RESULTS_DIR / f'{NB_NAME}_{_name}.tex', index=False)\n",
+    "        except Exception:\n",
+    "            pass\n"
    ]
   }
  ],

--- a/benchmarks/notebooks/03_switching_ablation.ipynb
+++ b/benchmarks/notebooks/03_switching_ablation.ipynb
@@ -10,7 +10,26 @@
     "This notebook studies how scaling conversion costs by a factor $\\alpha$ and enabling the planner's pre-pass cost comparison impacts\n",
     "QuASAr's backend selection and runtime.  For a small set of representative\n",
     "circuits we evaluate $\\alpha \\in \\{0.5, 1, 2, 5\\}$ and visualise the resulting\n",
-    "plans.\n"
+    "plans.\n",
+    "\n\nFigures are saved to `../figures/` and tables to `../results/`.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from pathlib import Path\n",
+    "FIGURES_DIR = Path('../figures')\n",
+    "RESULTS_DIR = Path('../results')\n",
+    "FIGURES_DIR.mkdir(exist_ok=True)\n",
+    "RESULTS_DIR.mkdir(exist_ok=True)\n",
+    "try:\n",
+    "    import ipynbname\n",
+    "    NB_NAME = ipynbname.path().stem\n",
+    "except Exception:  # pragma: no cover\n",
+    "    NB_NAME = 'notebook'\n"
    ]
   },
   {
@@ -163,15 +182,15 @@
     "    sns.heatmap(heat_numeric, annot=heat, fmt='', cmap='tab10', cbar=False)\n",
     "    plt.title(f'Backend per fragment for {name}')\n",
     "    plt.xlabel('Fragment')\n",
-    "    plt.ylabel('α')\n",
+    "    plt.ylabel('\u03b1')\n",
     "    plt.show()\n",
     "\n",
     "    runtime_df = pd.DataFrame({'alpha': [r['alpha'] for r in subset],\n",
     "                               'runtime': [r['runtime'] for r in subset]})\n",
     "    plt.figure()\n",
     "    sns.lineplot(data=runtime_df, x='alpha', y='runtime', marker='o')\n",
-    "    plt.title(f'Runtime vs α for {name}')\n",
-    "    plt.xlabel('α')\n",
+    "    plt.title(f'Runtime vs \u03b1 for {name}')\n",
+    "    plt.xlabel('\u03b1')\n",
     "    plt.ylabel('Runtime (s)')\n",
     "    plt.show()\n"
    ]
@@ -979,6 +998,26 @@
     "    except TypeError:\n",
     "        pass\n",
     "print(json.dumps(_params, indent=2))\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import pandas as pd\n",
+    "import matplotlib.pyplot as plt\n",
+    "for i, num in enumerate(plt.get_fignums(), start=1):\n",
+    "    plt.figure(num)\n",
+    "    plt.savefig(FIGURES_DIR / f'{NB_NAME}_plot{i}.png')\n",
+    "for _name, _obj in globals().items():\n",
+    "    if isinstance(_obj, pd.DataFrame):\n",
+    "        _obj.to_csv(RESULTS_DIR / f'{NB_NAME}_{_name}.csv', index=False)\n",
+    "        try:\n",
+    "            _obj.to_latex(RESULTS_DIR / f'{NB_NAME}_{_name}.tex', index=False)\n",
+    "        except Exception:\n",
+    "            pass\n"
    ]
   }
  ],

--- a/benchmarks/notebooks/04_planner_quality.ipynb
+++ b/benchmarks/notebooks/04_planner_quality.ipynb
@@ -7,7 +7,26 @@
    "source": [
     "# Planner quality\n",
     "\n",
-    "This notebook compares exhaustive oracle, greedy, and dynamic programming strategies on small circuits (≤ 20 qubits) using the planner's public interface and updated cost heuristics (entanglement-aware MPS, decision-diagram weighting).\n"
+    "This notebook compares exhaustive oracle, greedy, and dynamic programming strategies on small circuits (\u2264 20 qubits) using the planner's public interface and updated cost heuristics (entanglement-aware MPS, decision-diagram weighting).\n",
+    "\n\nFigures are saved to `../figures/` and tables to `../results/`.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from pathlib import Path\n",
+    "FIGURES_DIR = Path('../figures')\n",
+    "RESULTS_DIR = Path('../results')\n",
+    "FIGURES_DIR.mkdir(exist_ok=True)\n",
+    "RESULTS_DIR.mkdir(exist_ok=True)\n",
+    "try:\n",
+    "    import ipynbname\n",
+    "    NB_NAME = ipynbname.path().stem\n",
+    "except Exception:  # pragma: no cover\n",
+    "    NB_NAME = 'notebook'\n"
    ]
   },
   {
@@ -773,6 +792,26 @@
     "    except TypeError:\n",
     "        pass\n",
     "print(json.dumps(_params, indent=2, default=str))\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import pandas as pd\n",
+    "import matplotlib.pyplot as plt\n",
+    "for i, num in enumerate(plt.get_fignums(), start=1):\n",
+    "    plt.figure(num)\n",
+    "    plt.savefig(FIGURES_DIR / f'{NB_NAME}_plot{i}.png')\n",
+    "for _name, _obj in globals().items():\n",
+    "    if isinstance(_obj, pd.DataFrame):\n",
+    "        _obj.to_csv(RESULTS_DIR / f'{NB_NAME}_{_name}.csv', index=False)\n",
+    "        try:\n",
+    "            _obj.to_latex(RESULTS_DIR / f'{NB_NAME}_{_name}.tex', index=False)\n",
+    "        except Exception:\n",
+    "            pass\n"
    ]
   }
  ],

--- a/benchmarks/notebooks/05_robustness.ipynb
+++ b/benchmarks/notebooks/05_robustness.ipynb
@@ -9,10 +9,29 @@
     "\n",
     "This notebook evaluates the scheduler's ability to recover from unexpected changes. Two perturbation types are applied during execution:\n",
     "\n",
-    "* **Gate injection** – extra entangling operations are inserted while the circuit is already running.\n",
-    "* **Cost corruption** – cost model coefficients are perturbed to trigger re-planning.\n",
+    "* **Gate injection** \u2013 extra entangling operations are inserted while the circuit is already running.\n",
+    "* **Cost corruption** \u2013 cost model coefficients are perturbed to trigger re-planning.\n",
     "\n",
-    "For each magnitude we perform multiple repetitions, measuring the time to recover and the runtime overhead. Timelines highlight when re-planning occurs and a table summarises recovery statistics."
+    "For each magnitude we perform multiple repetitions, measuring the time to recover and the runtime overhead. Timelines highlight when re-planning occurs and a table summarises recovery statistics.",
+    "\n\nFigures are saved to `../figures/` and tables to `../results/`.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from pathlib import Path\n",
+    "FIGURES_DIR = Path('../figures')\n",
+    "RESULTS_DIR = Path('../results')\n",
+    "FIGURES_DIR.mkdir(exist_ok=True)\n",
+    "RESULTS_DIR.mkdir(exist_ok=True)\n",
+    "try:\n",
+    "    import ipynbname\n",
+    "    NB_NAME = ipynbname.path().stem\n",
+    "except Exception:  # pragma: no cover\n",
+    "    NB_NAME = 'notebook'\n"
    ]
   },
   {
@@ -2322,6 +2341,26 @@
     "    except TypeError:\n",
     "        pass\n",
     "print(json.dumps(_params, indent=2, default=str))\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import pandas as pd\n",
+    "import matplotlib.pyplot as plt\n",
+    "for i, num in enumerate(plt.get_fignums(), start=1):\n",
+    "    plt.figure(num)\n",
+    "    plt.savefig(FIGURES_DIR / f'{NB_NAME}_plot{i}.png')\n",
+    "for _name, _obj in globals().items():\n",
+    "    if isinstance(_obj, pd.DataFrame):\n",
+    "        _obj.to_csv(RESULTS_DIR / f'{NB_NAME}_{_name}.csv', index=False)\n",
+    "        try:\n",
+    "            _obj.to_latex(RESULTS_DIR / f'{NB_NAME}_{_name}.tex', index=False)\n",
+    "        except Exception:\n",
+    "            pass\n"
    ]
   }
  ],

--- a/benchmarks/notebooks/06_plan_cache.ipynb
+++ b/benchmarks/notebooks/06_plan_cache.ipynb
@@ -6,7 +6,26 @@
    "metadata": {},
    "source": [
     "# Plan Cache Exploration\n",
-    "This notebook demonstrates QuASAr's plan cache when executing a parameterized circuit multiple times. It records cache hit rates, cumulative speedup from warm vs cold cache runs, and reuse within the conversion engine."
+    "This notebook demonstrates QuASAr's plan cache when executing a parameterized circuit multiple times. It records cache hit rates, cumulative speedup from warm vs cold cache runs, and reuse within the conversion engine.",
+    "\n\nFigures are saved to `../figures/` and tables to `../results/`.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from pathlib import Path\n",
+    "FIGURES_DIR = Path('../figures')\n",
+    "RESULTS_DIR = Path('../results')\n",
+    "FIGURES_DIR.mkdir(exist_ok=True)\n",
+    "RESULTS_DIR.mkdir(exist_ok=True)\n",
+    "try:\n",
+    "    import ipynbname\n",
+    "    NB_NAME = ipynbname.path().stem\n",
+    "except Exception:  # pragma: no cover\n",
+    "    NB_NAME = 'notebook'\n"
    ]
   },
   {
@@ -690,6 +709,26 @@
     "        pass\n",
     "print(json.dumps(_params, indent=2, default=str))\n",
     "\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import pandas as pd\n",
+    "import matplotlib.pyplot as plt\n",
+    "for i, num in enumerate(plt.get_fignums(), start=1):\n",
+    "    plt.figure(num)\n",
+    "    plt.savefig(FIGURES_DIR / f'{NB_NAME}_plot{i}.png')\n",
+    "for _name, _obj in globals().items():\n",
+    "    if isinstance(_obj, pd.DataFrame):\n",
+    "        _obj.to_csv(RESULTS_DIR / f'{NB_NAME}_{_name}.csv', index=False)\n",
+    "        try:\n",
+    "            _obj.to_latex(RESULTS_DIR / f'{NB_NAME}_{_name}.tex', index=False)\n",
+    "        except Exception:\n",
+    "            pass\n"
    ]
   }
  ],

--- a/benchmarks/notebooks/07_parallelism.ipynb
+++ b/benchmarks/notebooks/07_parallelism.ipynb
@@ -6,7 +6,26 @@
    "metadata": {},
    "source": [
     "# Parallelism Benchmarks\n",
-    "This notebook illustrates the effect of enabling scheduler parallel execution across backends using real simulators."
+    "This notebook illustrates the effect of enabling scheduler parallel execution across backends using real simulators.",
+    "\n\nFigures are saved to `../figures/` and tables to `../results/`.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from pathlib import Path\n",
+    "FIGURES_DIR = Path('../figures')\n",
+    "RESULTS_DIR = Path('../results')\n",
+    "FIGURES_DIR.mkdir(exist_ok=True)\n",
+    "RESULTS_DIR.mkdir(exist_ok=True)\n",
+    "try:\n",
+    "    import ipynbname\n",
+    "    NB_NAME = ipynbname.path().stem\n",
+    "except Exception:  # pragma: no cover\n",
+    "    NB_NAME = 'notebook'\n"
    ]
   },
   {
@@ -180,6 +199,26 @@
     "    except TypeError:\n",
     "        pass\n",
     "print(json.dumps(_params, indent=2, default=str))\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import pandas as pd\n",
+    "import matplotlib.pyplot as plt\n",
+    "for i, num in enumerate(plt.get_fignums(), start=1):\n",
+    "    plt.figure(num)\n",
+    "    plt.savefig(FIGURES_DIR / f'{NB_NAME}_plot{i}.png')\n",
+    "for _name, _obj in globals().items():\n",
+    "    if isinstance(_obj, pd.DataFrame):\n",
+    "        _obj.to_csv(RESULTS_DIR / f'{NB_NAME}_{_name}.csv', index=False)\n",
+    "        try:\n",
+    "            _obj.to_latex(RESULTS_DIR / f'{NB_NAME}_{_name}.tex', index=False)\n",
+    "        except Exception:\n",
+    "            pass\n"
    ]
   }
  ],

--- a/benchmarks/notebooks/comparison.ipynb
+++ b/benchmarks/notebooks/comparison.ipynb
@@ -5,7 +5,26 @@
    "id": "21b8aac9",
    "metadata": {},
    "source": [
-    "# Benchmark Comparison"
+    "# Benchmark Comparison",
+    "\n\nFigures are saved to `../figures/` and tables to `../results/`.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from pathlib import Path\n",
+    "FIGURES_DIR = Path('../figures')\n",
+    "RESULTS_DIR = Path('../results')\n",
+    "FIGURES_DIR.mkdir(exist_ok=True)\n",
+    "RESULTS_DIR.mkdir(exist_ok=True)\n",
+    "try:\n",
+    "    import ipynbname\n",
+    "    NB_NAME = ipynbname.path().stem\n",
+    "except Exception:  # pragma: no cover\n",
+    "    NB_NAME = 'notebook'\n"
    ]
   },
   {
@@ -323,6 +342,26 @@
     "            json.dump(results, f, indent=2)\n",
     "    except TypeError:\n",
     "        pass\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import pandas as pd\n",
+    "import matplotlib.pyplot as plt\n",
+    "for i, num in enumerate(plt.get_fignums(), start=1):\n",
+    "    plt.figure(num)\n",
+    "    plt.savefig(FIGURES_DIR / f'{NB_NAME}_plot{i}.png')\n",
+    "for _name, _obj in globals().items():\n",
+    "    if isinstance(_obj, pd.DataFrame):\n",
+    "        _obj.to_csv(RESULTS_DIR / f'{NB_NAME}_{_name}.csv', index=False)\n",
+    "        try:\n",
+    "            _obj.to_latex(RESULTS_DIR / f'{NB_NAME}_{_name}.tex', index=False)\n",
+    "        except Exception:\n",
+    "            pass\n"
    ]
   }
  ],

--- a/benchmarks/notebooks/experimental_evaluation.ipynb
+++ b/benchmarks/notebooks/experimental_evaluation.ipynb
@@ -6,7 +6,26 @@
    "metadata": {},
    "source": [
     "# Experimental Evaluation Figures\n",
-    "This notebook aggregates all benchmarking workflows to reproduce the figures and plots for the experimental evaluation section of [Littau_QuASAr.pdf](../../Littau_QuASAr.pdf)."
+    "This notebook aggregates all benchmarking workflows to reproduce the figures and plots for the experimental evaluation section of [Littau_QuASAr.pdf](../../Littau_QuASAr.pdf).",
+    "\n\nFigures are saved to `../figures/` and tables to `../results/`.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from pathlib import Path\n",
+    "FIGURES_DIR = Path('../figures')\n",
+    "RESULTS_DIR = Path('../results')\n",
+    "FIGURES_DIR.mkdir(exist_ok=True)\n",
+    "RESULTS_DIR.mkdir(exist_ok=True)\n",
+    "try:\n",
+    "    import ipynbname\n",
+    "    NB_NAME = ipynbname.path().stem\n",
+    "except Exception:  # pragma: no cover\n",
+    "    NB_NAME = 'notebook'\n"
    ]
   },
   {
@@ -4147,6 +4166,26 @@
     "    except TypeError:\n",
     "        pass\n",
     "print(json.dumps(_params, indent=2, default=str))\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import pandas as pd\n",
+    "import matplotlib.pyplot as plt\n",
+    "for i, num in enumerate(plt.get_fignums(), start=1):\n",
+    "    plt.figure(num)\n",
+    "    plt.savefig(FIGURES_DIR / f'{NB_NAME}_plot{i}.png')\n",
+    "for _name, _obj in globals().items():\n",
+    "    if isinstance(_obj, pd.DataFrame):\n",
+    "        _obj.to_csv(RESULTS_DIR / f'{NB_NAME}_{_name}.csv', index=False)\n",
+    "        try:\n",
+    "            _obj.to_latex(RESULTS_DIR / f'{NB_NAME}_{_name}.tex', index=False)\n",
+    "        except Exception:\n",
+    "            pass\n"
    ]
   }
  ],

--- a/benchmarks/notebooks/large_scale_circuits.ipynb
+++ b/benchmarks/notebooks/large_scale_circuits.ipynb
@@ -8,7 +8,26 @@
     "\n",
     "# Large-scale circuit benchmarks\n",
     "\n",
-    "This notebook benchmarks complex circuit generators on multiple backends and QuASAr's planner. Small and large instances highlight when hybrid planning outperforms single-method simulations.\n"
+    "This notebook benchmarks complex circuit generators on multiple backends and QuASAr's planner. Small and large instances highlight when hybrid planning outperforms single-method simulations.\n",
+    "\n\nFigures are saved to `../figures/` and tables to `../results/`.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from pathlib import Path\n",
+    "FIGURES_DIR = Path('../figures')\n",
+    "RESULTS_DIR = Path('../results')\n",
+    "FIGURES_DIR.mkdir(exist_ok=True)\n",
+    "RESULTS_DIR.mkdir(exist_ok=True)\n",
+    "try:\n",
+    "    import ipynbname\n",
+    "    NB_NAME = ipynbname.path().stem\n",
+    "except Exception:  # pragma: no cover\n",
+    "    NB_NAME = 'notebook'\n"
    ]
   },
   {
@@ -49,7 +68,7 @@
     "\n",
     "## Benchmark setup\n",
     "\n",
-    "Each circuit generator from `large_scale_circuits.py` is instantiated at two scales. The circuits are executed on pure backends – dense statevector, Stim's tableau simulator, the tensor-network MPS backend and the decision-diagram backend – and via QuASAr's planner. Runtimes and memory consumption are recorded for comparison.\n"
+    "Each circuit generator from `large_scale_circuits.py` is instantiated at two scales. The circuits are executed on pure backends \u2013 dense statevector, Stim's tableau simulator, the tensor-network MPS backend and the decision-diagram backend \u2013 and via QuASAr's planner. Runtimes and memory consumption are recorded for comparison.\n"
    ]
   },
   {
@@ -280,6 +299,26 @@
     "1. Install dependencies as described in the *Environment* section.\n",
     "2. Start Jupyter and open `benchmarks/notebooks/large_scale_circuits.ipynb`.\n",
     "3. Run all cells to generate the results and plots.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import pandas as pd\n",
+    "import matplotlib.pyplot as plt\n",
+    "for i, num in enumerate(plt.get_fignums(), start=1):\n",
+    "    plt.figure(num)\n",
+    "    plt.savefig(FIGURES_DIR / f'{NB_NAME}_plot{i}.png')\n",
+    "for _name, _obj in globals().items():\n",
+    "    if isinstance(_obj, pd.DataFrame):\n",
+    "        _obj.to_csv(RESULTS_DIR / f'{NB_NAME}_{_name}.csv', index=False)\n",
+    "        try:\n",
+    "            _obj.to_latex(RESULTS_DIR / f'{NB_NAME}_{_name}.tex', index=False)\n",
+    "        except Exception:\n",
+    "            pass\n"
    ]
   }
  ],

--- a/benchmarks/notebooks/mps_backend.ipynb
+++ b/benchmarks/notebooks/mps_backend.ipynb
@@ -7,7 +7,26 @@
    "source": [
     "# Matrix Product State (MPS) backend benchmark\n",
     "\n",
-    "This notebook runs a small selection of example circuits solely on the `Matrix Product State (MPS)` simulator. It demonstrates how to use `BenchmarkRunner` for collecting timing and memory metrics. Extend the `circuits_to_run` list or adjust parameters to analyze additional workloads.\n"
+    "This notebook runs a small selection of example circuits solely on the `Matrix Product State (MPS)` simulator. It demonstrates how to use `BenchmarkRunner` for collecting timing and memory metrics. Extend the `circuits_to_run` list or adjust parameters to analyze additional workloads.\n",
+    "\n\nFigures are saved to `../figures/` and tables to `../results/`.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from pathlib import Path\n",
+    "FIGURES_DIR = Path('../figures')\n",
+    "RESULTS_DIR = Path('../results')\n",
+    "FIGURES_DIR.mkdir(exist_ok=True)\n",
+    "RESULTS_DIR.mkdir(exist_ok=True)\n",
+    "try:\n",
+    "    import ipynbname\n",
+    "    NB_NAME = ipynbname.path().stem\n",
+    "except Exception:  # pragma: no cover\n",
+    "    NB_NAME = 'notebook'\n"
    ]
   },
   {
@@ -120,6 +139,26 @@
     "    except TypeError:\n",
     "        pass\n",
     "print(json.dumps(_params, indent=2))\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import pandas as pd\n",
+    "import matplotlib.pyplot as plt\n",
+    "for i, num in enumerate(plt.get_fignums(), start=1):\n",
+    "    plt.figure(num)\n",
+    "    plt.savefig(FIGURES_DIR / f'{NB_NAME}_plot{i}.png')\n",
+    "for _name, _obj in globals().items():\n",
+    "    if isinstance(_obj, pd.DataFrame):\n",
+    "        _obj.to_csv(RESULTS_DIR / f'{NB_NAME}_{_name}.csv', index=False)\n",
+    "        try:\n",
+    "            _obj.to_latex(RESULTS_DIR / f'{NB_NAME}_{_name}.tex', index=False)\n",
+    "        except Exception:\n",
+    "            pass\n"
    ]
   }
  ],

--- a/benchmarks/notebooks/mqt_dd_backend.ipynb
+++ b/benchmarks/notebooks/mqt_dd_backend.ipynb
@@ -7,7 +7,26 @@
    "source": [
     "# MQT Decision Diagram backend benchmark\n",
     "\n",
-    "This notebook runs a small selection of example circuits solely on the `MQT Decision Diagram` simulator. It demonstrates how to use `BenchmarkRunner` for collecting timing and memory metrics. Extend the `circuits_to_run` list or adjust parameters to analyze additional workloads.\n"
+    "This notebook runs a small selection of example circuits solely on the `MQT Decision Diagram` simulator. It demonstrates how to use `BenchmarkRunner` for collecting timing and memory metrics. Extend the `circuits_to_run` list or adjust parameters to analyze additional workloads.\n",
+    "\n\nFigures are saved to `../figures/` and tables to `../results/`.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from pathlib import Path\n",
+    "FIGURES_DIR = Path('../figures')\n",
+    "RESULTS_DIR = Path('../results')\n",
+    "FIGURES_DIR.mkdir(exist_ok=True)\n",
+    "RESULTS_DIR.mkdir(exist_ok=True)\n",
+    "try:\n",
+    "    import ipynbname\n",
+    "    NB_NAME = ipynbname.path().stem\n",
+    "except Exception:  # pragma: no cover\n",
+    "    NB_NAME = 'notebook'\n"
    ]
   },
   {
@@ -278,6 +297,26 @@
     "    except TypeError:\n",
     "        pass\n",
     "print(json.dumps(_params, indent=2, default=str))\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import pandas as pd\n",
+    "import matplotlib.pyplot as plt\n",
+    "for i, num in enumerate(plt.get_fignums(), start=1):\n",
+    "    plt.figure(num)\n",
+    "    plt.savefig(FIGURES_DIR / f'{NB_NAME}_plot{i}.png')\n",
+    "for _name, _obj in globals().items():\n",
+    "    if isinstance(_obj, pd.DataFrame):\n",
+    "        _obj.to_csv(RESULTS_DIR / f'{NB_NAME}_{_name}.csv', index=False)\n",
+    "        try:\n",
+    "            _obj.to_latex(RESULTS_DIR / f'{NB_NAME}_{_name}.tex', index=False)\n",
+    "        except Exception:\n",
+    "            pass\n"
    ]
   }
  ],

--- a/benchmarks/notebooks/statevector_backend.ipynb
+++ b/benchmarks/notebooks/statevector_backend.ipynb
@@ -7,7 +7,26 @@
    "source": [
     "# Statevector backend benchmark\n",
     "\n",
-    "This notebook runs a small selection of example circuits solely on the `Statevector` simulator. It demonstrates how to use `BenchmarkRunner` for collecting timing and memory metrics. Extend the `circuits_to_run` list or adjust parameters to analyze additional workloads.\n"
+    "This notebook runs a small selection of example circuits solely on the `Statevector` simulator. It demonstrates how to use `BenchmarkRunner` for collecting timing and memory metrics. Extend the `circuits_to_run` list or adjust parameters to analyze additional workloads.\n",
+    "\n\nFigures are saved to `../figures/` and tables to `../results/`.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from pathlib import Path\n",
+    "FIGURES_DIR = Path('../figures')\n",
+    "RESULTS_DIR = Path('../results')\n",
+    "FIGURES_DIR.mkdir(exist_ok=True)\n",
+    "RESULTS_DIR.mkdir(exist_ok=True)\n",
+    "try:\n",
+    "    import ipynbname\n",
+    "    NB_NAME = ipynbname.path().stem\n",
+    "except Exception:  # pragma: no cover\n",
+    "    NB_NAME = 'notebook'\n"
    ]
   },
   {
@@ -236,6 +255,26 @@
     "    print(json.dumps(_params, indent=2, default=str))\n",
     "except TypeError:\n",
     "    print(_params)\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import pandas as pd\n",
+    "import matplotlib.pyplot as plt\n",
+    "for i, num in enumerate(plt.get_fignums(), start=1):\n",
+    "    plt.figure(num)\n",
+    "    plt.savefig(FIGURES_DIR / f'{NB_NAME}_plot{i}.png')\n",
+    "for _name, _obj in globals().items():\n",
+    "    if isinstance(_obj, pd.DataFrame):\n",
+    "        _obj.to_csv(RESULTS_DIR / f'{NB_NAME}_{_name}.csv', index=False)\n",
+    "        try:\n",
+    "            _obj.to_latex(RESULTS_DIR / f'{NB_NAME}_{_name}.tex', index=False)\n",
+    "        except Exception:\n",
+    "            pass\n"
    ]
   }
  ],

--- a/benchmarks/notebooks/stim_backend.ipynb
+++ b/benchmarks/notebooks/stim_backend.ipynb
@@ -7,7 +7,26 @@
    "source": [
     "# Stim backend benchmark\n",
     "\n",
-    "This notebook runs a small selection of example circuits solely on the `Stim` simulator. It demonstrates how to use `BenchmarkRunner` for collecting timing and memory metrics. Extend the `circuits_to_run` list or adjust parameters to analyze additional workloads.\n"
+    "This notebook runs a small selection of example circuits solely on the `Stim` simulator. It demonstrates how to use `BenchmarkRunner` for collecting timing and memory metrics. Extend the `circuits_to_run` list or adjust parameters to analyze additional workloads.\n",
+    "\n\nFigures are saved to `../figures/` and tables to `../results/`.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from pathlib import Path\n",
+    "FIGURES_DIR = Path('../figures')\n",
+    "RESULTS_DIR = Path('../results')\n",
+    "FIGURES_DIR.mkdir(exist_ok=True)\n",
+    "RESULTS_DIR.mkdir(exist_ok=True)\n",
+    "try:\n",
+    "    import ipynbname\n",
+    "    NB_NAME = ipynbname.path().stem\n",
+    "except Exception:  # pragma: no cover\n",
+    "    NB_NAME = 'notebook'\n"
    ]
   },
   {
@@ -120,6 +139,26 @@
     "    except TypeError:\n",
     "        pass\n",
     "print(json.dumps(_params, indent=2, default=str))\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import pandas as pd\n",
+    "import matplotlib.pyplot as plt\n",
+    "for i, num in enumerate(plt.get_fignums(), start=1):\n",
+    "    plt.figure(num)\n",
+    "    plt.savefig(FIGURES_DIR / f'{NB_NAME}_plot{i}.png')\n",
+    "for _name, _obj in globals().items():\n",
+    "    if isinstance(_obj, pd.DataFrame):\n",
+    "        _obj.to_csv(RESULTS_DIR / f'{NB_NAME}_{_name}.csv', index=False)\n",
+    "        try:\n",
+    "            _obj.to_latex(RESULTS_DIR / f'{NB_NAME}_{_name}.tex', index=False)\n",
+    "        except Exception:\n",
+    "            pass\n"
    ]
   }
  ],

--- a/benchmarks/notebooks/summary.ipynb
+++ b/benchmarks/notebooks/summary.ipynb
@@ -6,7 +6,26 @@
    "metadata": {},
    "source": [
     "# Benchmark Summary\n",
-    "This notebook aggregates runtime measurements for multiple circuit families and highlights backend crossover points."
+    "This notebook aggregates runtime measurements for multiple circuit families and highlights backend crossover points.",
+    "\n\nFigures are saved to `../figures/` and tables to `../results/`.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from pathlib import Path\n",
+    "FIGURES_DIR = Path('../figures')\n",
+    "RESULTS_DIR = Path('../results')\n",
+    "FIGURES_DIR.mkdir(exist_ok=True)\n",
+    "RESULTS_DIR.mkdir(exist_ok=True)\n",
+    "try:\n",
+    "    import ipynbname\n",
+    "    NB_NAME = ipynbname.path().stem\n",
+    "except Exception:  # pragma: no cover\n",
+    "    NB_NAME = 'notebook'\n"
    ]
   },
   {
@@ -170,6 +189,26 @@
     "    except TypeError:\n",
     "        pass\n",
     "print(json.dumps(_params, indent=2))\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import pandas as pd\n",
+    "import matplotlib.pyplot as plt\n",
+    "for i, num in enumerate(plt.get_fignums(), start=1):\n",
+    "    plt.figure(num)\n",
+    "    plt.savefig(FIGURES_DIR / f'{NB_NAME}_plot{i}.png')\n",
+    "for _name, _obj in globals().items():\n",
+    "    if isinstance(_obj, pd.DataFrame):\n",
+    "        _obj.to_csv(RESULTS_DIR / f'{NB_NAME}_{_name}.csv', index=False)\n",
+    "        try:\n",
+    "            _obj.to_latex(RESULTS_DIR / f'{NB_NAME}_{_name}.tex', index=False)\n",
+    "        except Exception:\n",
+    "            pass\n"
    ]
   }
  ],


### PR DESCRIPTION
## Summary
- Document figure and results output directories in each benchmark notebook
- Save all generated plots to `benchmarks/figures` with deterministic names
- Export DataFrames to CSV and LaTeX in `benchmarks/results`

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68bfd69733f88321a0a96b44da42bc19