### PR TITLE
Fix benchmark conversions and runner failures

### DIFF
--- a/quasar/circuit.py
+++ b/quasar/circuit.py
@@ -300,6 +300,15 @@ class Circuit:
         gates = []
         for ci in circuit.data:
             op = ci.operation
+
+            # Measurements require classical bits for the destination which
+            # ``Circuit`` does not track.  Since measurements collapse qubits
+            # and QuASAr focuses on unitary evolution, simply drop them during
+            # conversion so that benchmark circuits containing measurements can
+            # still be simulated on unitary backends.
+            if op.name.lower() == "measure":
+                continue
+
             qubits = [q._index for q in ci.qubits]
             params: Dict[str, Any] = {}
             if getattr(op, "params", None):

--- a/tests/test_benchmark_run_multiple.py
+++ b/tests/test_benchmark_run_multiple.py
@@ -376,11 +376,12 @@ def test_run_quasar_returns_failure_record_on_run_error():
     assert record["backend"] is None
 
 
-def test_run_quasar_multiple_raises_runtime_error_with_failures():
+def test_run_quasar_multiple_reports_failures():
     runner = BenchmarkRunner()
     scheduler = RunErrorScheduler()
-    with pytest.raises(RuntimeError) as exc:
-        runner.run_quasar_multiple(None, scheduler, repetitions=2)
-    assert "run boom" in str(exc.value)
+    record = runner.run_quasar_multiple(None, scheduler, repetitions=2)
+    assert record["repetitions"] == 0
+    assert record.get("failed") is True
+    assert record.get("failed_runs")
 
 

--- a/tests/test_large_scale_benchmarks.py
+++ b/tests/test_large_scale_benchmarks.py
@@ -1,0 +1,68 @@
+from __future__ import annotations
+
+import networkx as nx
+
+from benchmarks import large_scale_circuits as lsc
+from benchmarks.runner import BenchmarkRunner
+from quasar import SimulationEngine
+from quasar.cost import Backend
+
+
+def test_large_scale_benchmark_runs_execute() -> None:
+    """Ensure benchmark circuits from the notebook execute on all backends.
+
+    The notebook ``benchmarks/notebooks/large_scale_circuits.ipynb``
+    benchmarks several circuit families across multiple backends.  This test
+    exercises the same builders with small configurations and verifies that the
+    benchmark runner returns a result dictionary for each backend and for
+    QuASAr's planner without raising exceptions.
+    """
+
+    circuit_builders = {
+        "ripple_carry": (
+            lsc.ripple_carry_modular_circuit,
+            dict(bit_width=4, modulus=None, arithmetic="cdkm"),
+        ),
+        "surface_code": (
+            lsc.surface_code_cycle,
+            dict(distance=3, rounds=1),
+        ),
+        "grover": (
+            lsc.grover_with_oracle_circuit,
+            dict(n_qubits=4, oracle_depth=2, iterations=1),
+        ),
+        "qaoa": (
+            lsc.deep_qaoa_circuit,
+            dict(graph=nx.cycle_graph(4), p_layers=2),
+        ),
+        "phase_est": (
+            lsc.phase_estimation_classical_unitary,
+            dict(eigen_qubits=2, precision_qubits=2, classical_depth=1),
+        ),
+    }
+
+    backends = [
+        Backend.STATEVECTOR,
+        Backend.TABLEAU,
+        Backend.MPS,
+        Backend.DECISION_DIAGRAM,
+    ]
+
+    runner = BenchmarkRunner()
+    engine = SimulationEngine()
+
+    for name, (builder, params) in circuit_builders.items():
+        circuit = builder(**params)
+        # Ensure the circuit executes on each individual backend
+        for backend in backends:
+            record = runner.run_quasar_multiple(
+                circuit, engine, backend=backend, repetitions=1
+            )
+            assert "repetitions" in record
+            if backend is Backend.STATEVECTOR:
+                # The reference backend should always succeed
+                assert not record.get("failed")
+        # And via QuASAr's backend selection
+        record = runner.run_quasar_multiple(circuit, engine, repetitions=1)
+        assert "repetitions" in record
+        assert not record.get("failed")

--- a/tests/test_runner_timeout.py
+++ b/tests/test_runner_timeout.py
@@ -34,15 +34,16 @@ def test_run_quasar_multiple_timeout() -> None:
     engine = SimpleNamespace(scheduler=DummyScheduler())
     circuit = SimpleNamespace(num_qubits=1, gates=[], ssd=None)
 
-    with pytest.raises(RuntimeError):
-        runner.run_quasar_multiple(
-            circuit,
-            engine,
-            backend=Backend.STATEVECTOR,
-            repetitions=1,
-            run_timeout=0.01,
-            quick=True,
-        )
+    res = runner.run_quasar_multiple(
+        circuit,
+        engine,
+        backend=Backend.STATEVECTOR,
+        repetitions=1,
+        run_timeout=0.01,
+        quick=True,
+    )
+    assert res["repetitions"] == 0
+    assert res.get("failed_runs")
 
     res = runner.run_quasar_multiple(
         circuit,


### PR DESCRIPTION
## Summary
- skip measurement operations when converting from Qiskit circuits so benchmark circuits with measurements compile
- make `BenchmarkRunner.run_quasar_multiple` return records for unsupported backends and failed runs instead of raising
- add regression test covering large-scale benchmark circuits and update tests for new runner behaviour

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c0007827748321a0f8a9bde71ce9d4