### PR TITLE
Replace Grover circuits with Gate sequences

### DIFF
--- a/benchmarks/circuits.py
+++ b/benchmarks/circuits.py
@@ -101,27 +101,39 @@ def grover_circuit(n_qubits: int, n_iterations: int = 1) -> Circuit:
         A :class:`Circuit` implementing the algorithm.
     """
 
-    qc = QuantumCircuit(n_qubits)
-    qc.h(range(n_qubits))
+    if n_qubits <= 0:
+        return Circuit([])
+
+    gates: List[Gate] = []
+
+    # Initial Hadamards
+    for q in range(n_qubits):
+        gates.append(Gate("H", [q]))
+
+    controls = list(range(n_qubits - 1))
+    target = n_qubits - 1
+    mcx_name = "C" * len(controls) + "X" if controls else "X"
+
     for _ in range(n_iterations):
         # Oracle marking the all-ones state
-        qc.h(n_qubits - 1)
-        if n_qubits > 1:
-            qc.mcx(list(range(n_qubits - 1)), n_qubits - 1)
-        qc.h(n_qubits - 1)
+        gates.append(Gate("H", [target]))
+        gates.append(Gate(mcx_name, controls + [target]))
+        gates.append(Gate("H", [target]))
 
         # Diffuser
-        qc.h(range(n_qubits))
-        qc.x(range(n_qubits))
-        qc.h(n_qubits - 1)
-        if n_qubits > 1:
-            qc.mcx(list(range(n_qubits - 1)), n_qubits - 1)
-        qc.h(n_qubits - 1)
-        qc.x(range(n_qubits))
-        qc.h(range(n_qubits))
+        for q in range(n_qubits):
+            gates.append(Gate("H", [q]))
+        for q in range(n_qubits):
+            gates.append(Gate("X", [q]))
+        gates.append(Gate("H", [target]))
+        gates.append(Gate(mcx_name, controls + [target]))
+        gates.append(Gate("H", [target]))
+        for q in range(n_qubits):
+            gates.append(Gate("X", [q]))
+        for q in range(n_qubits):
+            gates.append(Gate("H", [q]))
 
-    qc = transpile(qc, basis_gates=["u", "p", "cx", "h", "x"])
-    return Circuit.from_qiskit(qc)
+    return Circuit(gates)
 
 
 def bernstein_vazirani_circuit(n_qubits: int, secret: int = 0) -> Circuit:

--- a/benchmarks/large_scale_circuits.py
+++ b/benchmarks/large_scale_circuits.py
@@ -12,8 +12,9 @@ from __future__ import annotations
 from qiskit import QuantumCircuit, transpile
 from qiskit.circuit.library import QFT, VBERippleCarryAdder, CDKMRippleCarryAdder
 import networkx as nx
+from typing import List
 
-from quasar.circuit import Circuit
+from quasar.circuit import Circuit, Gate
 
 
 def ripple_carry_modular_circuit(
@@ -197,38 +198,41 @@ def grover_with_oracle_circuit(
     if n_qubits <= 0:
         return Circuit([])
 
-    qc = QuantumCircuit(n_qubits)
-    qc.h(range(n_qubits))
+    gates: List[Gate] = []
+
+    # Initial Hadamards
+    for q in range(n_qubits):
+        gates.append(Gate("H", [q]))
 
     controls = list(range(n_qubits - 1))
     target = n_qubits - 1
+    mcx_name = "C" * len(controls) + "X" if controls else "X"
 
     for _ in range(iterations):
         # Oracle composed from cascaded Toffoli/CNOT layers.
-        qc.h(target)
+        gates.append(Gate("H", [target]))
         for _ in range(oracle_depth):
-            if n_qubits > 1:
-                qc.mcx(controls, target)
-            else:
-                qc.x(target)
+            gates.append(Gate(mcx_name, controls + [target]))
             for q in range(n_qubits - 1):
-                qc.cx(q, q + 1)
+                gates.append(Gate("CX", [q, q + 1]))
             for q in reversed(range(n_qubits - 1)):
-                qc.cx(q, q + 1)
-        qc.h(target)
+                gates.append(Gate("CX", [q, q + 1]))
+        gates.append(Gate("H", [target]))
 
         # Standard Grover diffusion operator.
-        qc.h(range(n_qubits))
-        qc.x(range(n_qubits))
-        qc.h(target)
-        if n_qubits > 1:
-            qc.mcx(controls, target)
-        qc.h(target)
-        qc.x(range(n_qubits))
-        qc.h(range(n_qubits))
+        for q in range(n_qubits):
+            gates.append(Gate("H", [q]))
+        for q in range(n_qubits):
+            gates.append(Gate("X", [q]))
+        gates.append(Gate("H", [target]))
+        gates.append(Gate(mcx_name, controls + [target]))
+        gates.append(Gate("H", [target]))
+        for q in range(n_qubits):
+            gates.append(Gate("X", [q]))
+        for q in range(n_qubits):
+            gates.append(Gate("H", [q]))
 
-    qc = transpile(qc, basis_gates=["u", "p", "cx", "ccx", "h", "x", "t"])
-    return Circuit.from_qiskit(qc)
+    return Circuit(gates)
 
 
 def deep_qaoa_circuit(graph: nx.Graph, p_layers: int) -> Circuit:


### PR DESCRIPTION
## Summary
- Reimplement Grover benchmark circuits using `Gate` objects rather than `QuantumCircuit`
- Remove Qiskit transpilation steps from Grover circuit generation
- Build oracle and diffusion steps explicitly with Hadamard, CNOT and multi-controlled-X gates

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68c02b5f91a08321a883f93e1301b09c