### PR TITLE
Skip Clifford-only benchmark circuits

### DIFF
--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -27,6 +27,9 @@ python benchmarks/run_benchmarks.py --circuit ghz --qubits 4:12:2 --repetitions 
 - `--qubits` specifies a `start:end[:step]` range.
 - `--repetitions` repeats each configuration to compute a mean and variance.
 - `--output` is the base path for the generated `.json` and `.csv` files.
+- Circuit families composed solely of Clifford gates (`H`, `S`, `CX`, `CZ`, etc.)
+  are skipped to avoid benchmarking workloads that are trivial for stabiliser
+  simulators.
 
 Each benchmark records separate timings for the preparation and execution
 phases as well as their sum:

--- a/benchmarks/benchmark_cli.py
+++ b/benchmarks/benchmark_cli.py
@@ -16,6 +16,7 @@ from runner import BenchmarkRunner
 from quasar import SimulationEngine
 from quasar.cost import Backend
 import circuits as circuit_lib
+from circuits import is_clifford
 
 
 def parse_qubit_range(spec: str) -> List[int]:
@@ -50,13 +51,14 @@ def run_suite(
 ) -> List[dict]:
     """Execute ``circuit_fn`` for each qubit count using a fixed backend.
 
-    The helper runs QuASAr's scheduler multiple times, forcing the
+    Circuits consisting solely of Clifford gates are ignored.  The helper runs
+    QuASAr's scheduler multiple times, forcing the
     :class:`~quasar.cost.Backend.STATEVECTOR` backend so that results are
     comparable to single-method simulators.  Each summary record returned by
     :meth:`BenchmarkRunner.run_quasar_multiple` is expected to include the
-    final simulation state under the ``"result"`` key.  The state is retained
-    in memory for potential downstream analysis but is intentionally omitted
-    from serialised output.
+    final simulation state under the ``"result"`` key.  The state is retained in
+    memory for potential downstream analysis but is intentionally omitted from
+    serialised output.
     """
 
     engine = SimulationEngine()
@@ -76,6 +78,8 @@ def run_suite(
                     circuit.use_classical_simplification = True
             else:
                 circuit.use_classical_simplification = False
+        if is_clifford(circuit):
+            continue
         runner = BenchmarkRunner()
         rec = runner.run_quasar_multiple(
             circuit,

--- a/benchmarks/circuits.py
+++ b/benchmarks/circuits.py
@@ -9,6 +9,28 @@ import numpy as np
 from quasar.circuit import Circuit, Gate
 
 
+# Names of gates forming the Clifford group used in benchmark filtering.
+CLIFFORD_GATES = {
+    "I",
+    "X",
+    "Y",
+    "Z",
+    "H",
+    "S",
+    "SDG",
+    "CX",
+    "CY",
+    "CZ",
+    "SWAP",
+}
+
+
+def is_clifford(circuit: Circuit) -> bool:
+    """Return ``True`` if ``circuit`` contains only Clifford gates."""
+
+    return all(g.gate in CLIFFORD_GATES for g in circuit.gates)
+
+
 def ghz_circuit(
     n_qubits: int, *, use_classical_simplification: bool = False
 ) -> Circuit:

--- a/benchmarks/large_scale_circuits.py
+++ b/benchmarks/large_scale_circuits.py
@@ -15,6 +15,27 @@ from typing import List
 from quasar.circuit import Circuit, Gate
 from .circuits import _cdkm_adder_gates, _vbe_adder_gates, _iqft_gates
 
+# Names of gates forming the Clifford group used in benchmark filtering.
+CLIFFORD_GATES = {
+    "I",
+    "X",
+    "Y",
+    "Z",
+    "H",
+    "S",
+    "SDG",
+    "CX",
+    "CY",
+    "CZ",
+    "SWAP",
+}
+
+
+def is_clifford(circuit: Circuit) -> bool:
+    """Return ``True`` if ``circuit`` contains only Clifford gates."""
+
+    return all(g.gate in CLIFFORD_GATES for g in circuit.gates)
+
 
 def ripple_carry_modular_circuit(
     bit_width: int, modulus: int | None = None, arithmetic: str = "cdkm"

--- a/benchmarks/run_benchmarks.py
+++ b/benchmarks/run_benchmarks.py
@@ -1,9 +1,14 @@
 """Convenience wrapper for the benchmark command line interface.
 
 The CLI executes circuits through QuASAr's scheduler and can force
-individual backends via :mod:`quasar.cost.Backend`.
+individual backends via :mod:`quasar.cost.Backend`. Circuit families that
+consist solely of Clifford gates are skipped automatically by the CLI to
+avoid measuring trivial stabiliser workloads.
 """
+
 from benchmark_cli import main
+
 
 if __name__ == "__main__":  # pragma: no cover - script entry point
     main()
+

--- a/tests/test_clifford_filter.py
+++ b/tests/test_clifford_filter.py
@@ -1,0 +1,17 @@
+from benchmarks.circuits import ghz_circuit, w_state_circuit, is_clifford as is_clifford_small
+from benchmarks.large_scale_circuits import (
+    ripple_carry_modular_circuit,
+    surface_code_cycle,
+    is_clifford as is_clifford_large,
+)
+
+
+def test_is_clifford_small_circuits():
+    assert is_clifford_small(ghz_circuit(3))
+    assert not is_clifford_small(w_state_circuit(3))
+
+
+def test_is_clifford_large_circuits():
+    assert not is_clifford_large(ripple_carry_modular_circuit(2, arithmetic="cdkm"))
+    assert is_clifford_large(surface_code_cycle(3, rounds=1, scheme="surface"))
+


### PR DESCRIPTION
## Summary
- add `is_clifford` helper to benchmark circuit libraries
- skip pure Clifford circuits in the benchmarking CLI and document the behaviour
- cover Clifford filtering with new tests

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68c0399d1c348321a393e3b47971b0e4