### PR TITLE
Add surface-corrected QAOA circuit with surface code cycles

### DIFF
--- a/benchmarks/circuits.py
+++ b/benchmarks/circuits.py
@@ -753,6 +753,40 @@ def random_hybrid_circuit(num_qubits: int = 6, depth: int = 10, seed: int | None
     return Circuit(gates)
 
 
+def surface_corrected_qaoa_circuit(
+    bit_width: int, distance: int = 3, rounds: int = 1
+) -> Circuit:
+    """QAOA on a ring with interleaved surface-code stabiliser cycles.
+
+    This is a thin wrapper around
+    :func:`benchmarks.large_scale_circuits.surface_corrected_qaoa` that exposes
+    the combined error-correction and algorithmic layers through the CLI.  The
+    function accepts a ``bit_width`` for the problem size and inserts a single
+    surface-code cycle after each of ``rounds`` QAOA layers on a
+    ``distance`` x ``distance`` lattice.
+
+    Parameters
+    ----------
+    bit_width:
+        Number of problem qubits arranged on a cycle graph.
+    distance:
+        Code distance of the surface-code cycles.  The lattice must contain at
+        least ``bit_width`` data qubits.
+    rounds:
+        Number of QAOA layers, each followed by one surface-code round.
+
+    Returns
+    -------
+    Circuit
+        The assembled circuit interleaving algorithmic and error-correction
+        layers.
+    """
+
+    from .large_scale_circuits import surface_corrected_qaoa
+
+    return surface_corrected_qaoa(bit_width, distance, rounds)
+
+
 def recur_subroutine_circuit(num_qubits: int = 4, depth: int = 3) -> Circuit:
     """Circuit invoking a repeated subroutine across layers."""
 

--- a/benchmarks/run_benchmarks.py
+++ b/benchmarks/run_benchmarks.py
@@ -8,6 +8,9 @@ avoid measuring trivial stabiliser workloads.
 
 from benchmark_cli import main
 
+# Import surface-code protected circuits so the CLI can discover them.
+from circuits import surface_corrected_qaoa_circuit  # noqa: F401
+
 
 if __name__ == "__main__":  # pragma: no cover - script entry point
     main()

--- a/tests/test_large_scale_circuits.py
+++ b/tests/test_large_scale_circuits.py
@@ -6,6 +6,7 @@ from benchmarks.large_scale_circuits import (
     surface_code_cycle,
     deep_qaoa_circuit,
     phase_estimation_classical_unitary,
+    surface_corrected_qaoa,
 )
 from benchmarks.circuits import _cdkm_adder_gates
 
@@ -47,6 +48,14 @@ def test_deep_qaoa_circuit_structure():
     circ = deep_qaoa_circuit(g, p_layers=2)
     assert len(circ.gates) == 12
     assert all(gate.gate in {"RZZ", "RX"} for gate in circ.gates)
+
+
+def test_surface_corrected_qaoa_interleaves_cycles():
+    circ = surface_corrected_qaoa(3, distance=2, rounds=2)
+    assert len(circ.gates) == 44
+    assert [g.gate for g in circ.gates[:6]] == ["RZZ", "RZZ", "RZZ", "RX", "RX", "RX"]
+    assert circ.gates[6].gate == "H"
+    assert circ.gates[22].gate == "RZZ"
 
 
 def test_phase_estimation_gate_count():


### PR DESCRIPTION
## Summary
- implement `surface_corrected_qaoa` generator that interleaves QAOA layers with surface-code cycles
- expose surface-corrected circuit through benchmark CLI
- test the new circuit to ensure stabiliser rounds are inserted between QAOA layers

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c03dc1428c832180b5de196d2e05b1