### PR TITLE
Enforce statevector qubit cap in benchmarks

### DIFF
--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -41,6 +41,12 @@ phases as well as their sum:
 - For QuASAr runs, **backend** – the simulator backend selected by the
   scheduler.
 
+Statevector simulations are skipped when the circuit width exceeds the
+available memory. A default budget of 64 GiB (about 32 qubits) is assumed but
+can be adjusted via the ``QUASAR_STATEVECTOR_MAX_MEMORY_BYTES`` environment
+variable or by passing ``memory_bytes`` to
+``BenchmarkRunner.run_quasar``/``run_quasar_multiple``.
+
 ### Timing semantics
 
 The recorded times capture only backend execution and the minimal preparation

--- a/benchmarks/memory_utils.py
+++ b/benchmarks/memory_utils.py
@@ -1,0 +1,41 @@
+from __future__ import annotations
+
+"""Helpers for memory related benchmark utilities."""
+
+import math
+import os
+from typing import Optional
+
+DEFAULT_MEMORY_BYTES = 64 * 1024 ** 3
+"""Default memory budget (64 GiB) for statevector simulations."""
+
+ENV_VAR = "QUASAR_STATEVECTOR_MAX_MEMORY_BYTES"
+"""Environment variable to override the default statevector memory budget."""
+
+
+def max_qubits_statevector(memory_bytes: Optional[int] = None) -> int:
+    """Return the maximum number of qubits for dense statevectors.
+
+    Parameters
+    ----------
+    memory_bytes:
+        Number of bytes available for amplitudes. When ``None`` the value is
+        taken from :data:`ENV_VAR` and falls back to
+        :data:`DEFAULT_MEMORY_BYTES`.
+
+    Returns
+    -------
+    int
+        Maximum number of qubits that fit into memory assuming 16 bytes per
+        amplitude.
+    """
+
+    if memory_bytes is None:
+        env = os.getenv(ENV_VAR)
+        memory_bytes = int(env) if env is not None else DEFAULT_MEMORY_BYTES
+    if memory_bytes < 16:
+        return 0
+    return int(math.floor(math.log2(memory_bytes / 16)))
+
+
+__all__ = ["max_qubits_statevector"]

--- a/tests/test_statevector_qubit_cap.py
+++ b/tests/test_statevector_qubit_cap.py
@@ -1,0 +1,103 @@
+import pytest
+from benchmarks.runner import BenchmarkRunner
+from quasar.cost import Backend
+from quasar.planner import PlanResult, PlanStep
+from quasar.ssd import SSD
+from types import SimpleNamespace
+
+
+class DummySimBackend:
+    backend = Backend.STATEVECTOR
+
+    def load(self, num_qubits):
+        pass
+
+    def apply_gate(self, gate, qubits, params):
+        pass
+
+    def extract_ssd(self):
+        return SSD([])
+
+
+class SimpleScheduler:
+    def __init__(self):
+        self.backends = {Backend.STATEVECTOR: DummySimBackend()}
+
+        class Planner:
+            def plan(self, circuit, *, backend=None):
+                return PlanResult(
+                    table=[],
+                    final_backend=backend or Backend.STATEVECTOR,
+                    gates=circuit.gates,
+                    explicit_steps=[
+                        PlanStep(0, len(circuit.gates), backend or Backend.STATEVECTOR)
+                    ],
+                    explicit_conversions=[],
+                    step_costs=[],
+                )
+
+        self.planner = Planner()
+
+    def prepare_run(self, circuit, plan=None, *, backend=None):
+        return plan if plan is not None else self.planner.plan(circuit, backend=backend)
+
+    def run(self, circuit, plan, *, monitor=None, instrument=False):
+        if instrument:
+            from quasar.cost import Cost
+
+            return SSD([]), Cost(time=0.0, memory=0.0)
+        return SSD([])
+
+
+class WideCircuit:
+    def __init__(self, width):
+        self.num_qubits = width
+        self.gates = [SimpleNamespace(gate="x", qubits=(0,), params=())]
+        self.ssd = SSD([])
+
+    def simplify_classical_controls(self):
+        return self.gates
+
+
+def test_run_quasar_multiple_skips_when_over_cap():
+    runner = BenchmarkRunner()
+    circuit = WideCircuit(4)
+    scheduler = SimpleScheduler()
+    with pytest.warns(UserWarning, match="exceeds statevector limit"):
+        record = runner.run_quasar_multiple(
+            circuit,
+            scheduler,
+            repetitions=1,
+            memory_bytes=16 * (2**3),
+        )
+    assert record["unsupported"] is True
+    assert record["repetitions"] == 0
+    assert record["backend"] == Backend.STATEVECTOR.name
+
+
+def test_run_quasar_quick_skips_when_over_cap():
+    runner = BenchmarkRunner()
+    circuit = WideCircuit(4)
+
+    class QuickScheduler:
+        def __init__(self):
+            self.backends = {Backend.STATEVECTOR: DummySimBackend()}
+
+        def should_use_quick_path(self, circuit, backend=None, force=False):
+            return True
+
+        def select_backend(self, circuit, backend=None):
+            return backend or Backend.STATEVECTOR
+
+    scheduler = QuickScheduler()
+    with pytest.warns(UserWarning, match="exceeds statevector limit"):
+        record = runner.run_quasar(
+            circuit,
+            scheduler,
+            backend=Backend.STATEVECTOR,
+            quick=True,
+            memory_bytes=16 * (2**3),
+        )
+    assert record["unsupported"] is True
+    assert record["backend"] == Backend.STATEVECTOR.name
+    assert record["failed"] is False


### PR DESCRIPTION
## Summary
- add utility to compute statevector qubit limit from available memory
- skip statevector runs in `BenchmarkRunner` when circuit width exceeds the memory budget and expose override knobs
- document the default 64 GiB cap in benchmarks README

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68c043541b4c8321911a1639d66f1475