### PR TITLE
Aggregate baseline best in benchmarks

### DIFF
--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -15,8 +15,10 @@ pip install pandas jupyter
 
 ## Running `run_benchmarks.py`
 
-The `run_benchmarks.py` script executes parameterised circuit families and
-records average runtimes:
+The `run_benchmarks.py` script executes parameterised circuit families on
+QuASAr and all available single‑method simulators. For each configuration the
+fastest non‑QuASAr backend is determined and only this aggregate baseline is
+stored alongside the QuASAr result:
 
 ```bash
 python benchmarks/run_benchmarks.py --circuit ghz --qubits 4:12:2 --repetitions 5 --output results/ghz
@@ -38,8 +40,8 @@ phases as well as their sum:
   compilation that happens before execution.
 - **run_time** – execution of the prepared circuit on the backend.
 - **total_time** – combined runtime of both phases.
-- For QuASAr runs, **backend** – the simulator backend selected by the
-  scheduler.
+- **backend** – for QuASAr rows, the simulator chosen by the scheduler; for
+  baseline entries, the backend that achieved the minimum runtime.
 
 Statevector simulations are skipped when the circuit width exceeds the
 available memory. A default budget of 64 GiB (about 32 qubits) is assumed but
@@ -69,13 +71,10 @@ reflects only the backend's execution.
 
 ## Comparing with baseline backends
 
-When results for several baseline simulators have been collected alongside
-QuASAr timings, the helper functions in [`plot_utils.py`](plot_utils.py) can
-highlight how QuASAr compares to the fastest individual backend. The function
-`compute_baseline_best` determines the per‑circuit minimum of `run_time_mean`
-and `total_time_mean` across all non‑QuASAr frameworks. `plot_quasar_vs_baseline_best`
-then overlays this "baseline_best" curve with the QuASAr measurements and can
-annotate QuASAr points with the backend chosen by the scheduler:
+`run_benchmarks.py` already aggregates the baseline measurements into a single
+"baseline_best" curve. The helper functions in
+[`plot_utils.py`](plot_utils.py) can visualise these results and annotate both
+baseline and QuASAr points with the corresponding backend when requested:
 
 ```python
 from benchmarks.plot_utils import plot_quasar_vs_baseline_best

--- a/benchmarks/plot_utils.py
+++ b/benchmarks/plot_utils.py
@@ -20,14 +20,17 @@ def compute_baseline_best(
         Rows with ``framework == 'quasar'`` are ignored.
     metrics:
         Iterable of column names for which to compute the minimum. By default the
-        function considers ``run_time_mean`` and ``total_time_mean``.
+        function considers ``run_time_mean`` and ``total_time_mean``.  The backend
+        responsible for the minimum of the first metric is recorded under the
+        ``backend`` column.
 
     Returns
     -------
     pd.DataFrame
         DataFrame with the same grouping columns and the minimal metric values.
         The returned frame contains an additional ``framework`` column set to
-        ``"baseline_best"``.
+        ``"baseline_best"`` and a ``backend`` column identifying the baseline
+        backend that achieved the minimum for the primary metric.
     """
 
     if df.empty:
@@ -40,17 +43,22 @@ def compute_baseline_best(
         raise ValueError("no baseline entries in results")
 
     group_cols = [c for c in ("circuit", "qubits") if c in df.columns]
+    extra_cols = [c for c in ("repetitions",) if c in baselines.columns]
     rows: list[dict[str, object]] = []
     for keys, group in baselines.groupby(group_cols):
         if not isinstance(keys, tuple):
             keys = (keys,)
         row = dict(zip(group_cols, keys))
+        for col in extra_cols:
+            row[col] = group[col].iloc[0]
         for metric in metrics:
             idx = group[metric].idxmin()
             row[metric] = group.loc[idx, metric]
             std_col = metric.replace("_mean", "_std")
             if std_col in group.columns:
                 row[std_col] = group.loc[idx, std_col]
+            if metric == metrics[0]:
+                row["backend"] = group.loc[idx, "framework"]
         rows.append(row)
 
     mins = pd.DataFrame(rows)
@@ -74,8 +82,10 @@ def plot_quasar_vs_baseline_best(
     metric:
         Column to plot on the y-axis. Defaults to ``"run_time_mean"``.
     annotate_backend:
-        When ``True`` annotate QuASAr points with the backend chosen by the
-        scheduler. Requires a ``backend`` column in ``df``.
+        When ``True`` annotate points with the backend used for each
+        measurement.  Requires a ``backend`` column in ``df`` and leverages the
+        ``backend`` column returned by :func:`compute_baseline_best` for
+        baseline points.
     ax:
         Optional matplotlib axes to draw on. A new axes is created when omitted.
 
@@ -138,11 +148,14 @@ def plot_quasar_vs_baseline_best(
             color="red",
         )
 
-    if annotate_backend and "backend" in quasar.columns:
-        for _, row in quasar.iterrows():
-            backend = row.get("backend")
-            if backend:
-                ax.annotate(str(backend), (row[x_col], row[metric]))
+    if annotate_backend:
+        for source in (baseline_best, quasar):
+            if "backend" not in source.columns:
+                continue
+            for _, row in source.iterrows():
+                backend = row.get("backend")
+                if backend:
+                    ax.annotate(str(backend), (row[x_col], row[metric]))
 
     ax.set_xlabel(x_col)
     ax.set_ylabel(metric.replace("_", " "))

--- a/benchmarks/run_benchmarks.py
+++ b/benchmarks/run_benchmarks.py
@@ -1,17 +1,167 @@
-"""Convenience wrapper for the benchmark command line interface.
+from __future__ import annotations
 
-The CLI executes circuits through QuASAr's scheduler and can force
-individual backends via :mod:`quasar.cost.Backend`. Circuit families that
-consist solely of Clifford gates are skipped automatically by the CLI to
-avoid measuring trivial stabiliser workloads.
+"""Execute benchmark circuits and record baseline-best results.
+
+The script evaluates a parameterised circuit family across all single-method
+simulation backends provided by :class:`quasar.cost.Backend` and QuASAr's
+automatic scheduler.  For each configuration the fastest non-QuASAr backend is
+determined via :func:`compute_baseline_best` and only this aggregated
+"baseline_best" entry is stored alongside the QuASAr measurement.
 """
 
-from benchmark_cli import main
+import argparse
+from pathlib import Path
+from typing import Iterable
+
+import pandas as pd
+
+from benchmark_cli import parse_qubit_range, resolve_circuit
+from circuits import is_clifford
+from plot_utils import compute_baseline_best
+from runner import BenchmarkRunner
+from quasar import SimulationEngine
+from quasar.cost import Backend
+
+
+BASELINE_BACKENDS: tuple[Backend, ...] = (
+    Backend.STATEVECTOR,
+    Backend.TABLEAU,
+    Backend.MPS,
+    Backend.DECISION_DIAGRAM,
+)
+
+
+def run_all(
+    circuit_fn,
+    qubits: Iterable[int],
+    repetitions: int,
+    *,
+    use_classical_simplification: bool = True,
+) -> pd.DataFrame:
+    """Execute ``circuit_fn`` for each qubit count on all backends.
+
+    The function returns a :class:`pandas.DataFrame` containing one row per
+    configuration for QuASAr and the aggregated baseline best.
+    """
+
+    engine = SimulationEngine()
+    runner = BenchmarkRunner()
+    records: list[dict[str, object]] = []
+
+    for n in qubits:
+        try:
+            circuit = circuit_fn(
+                n, use_classical_simplification=use_classical_simplification
+            )
+        except TypeError:
+            circuit = circuit_fn(n)
+            if use_classical_simplification:
+                enable = getattr(circuit, "enable_classical_simplification", None)
+                if callable(enable):
+                    enable()
+                else:
+                    circuit.use_classical_simplification = True
+            else:
+                circuit.use_classical_simplification = False
+
+        if is_clifford(circuit):
+            continue
+
+        for backend in BASELINE_BACKENDS:
+            rec = runner.run_quasar_multiple(
+                circuit,
+                engine,
+                backend=backend,
+                repetitions=repetitions,
+                quick=True,
+            )
+            rec.pop("result", None)
+            rec.update(
+                {
+                    "circuit": circuit_fn.__name__,
+                    "qubits": n,
+                    "framework": backend.value,
+                    "backend": backend.value,
+                }
+            )
+            records.append(rec)
+
+        quasar_rec = runner.run_quasar_multiple(
+            circuit, engine, repetitions=repetitions, quick=True
+        )
+        quasar_rec.pop("result", None)
+        backend_name = quasar_rec.get("backend")
+        if isinstance(backend_name, str) and backend_name in Backend.__members__:
+            quasar_rec["backend"] = Backend[backend_name].value
+        quasar_rec.update(
+            {"circuit": circuit_fn.__name__, "qubits": n, "framework": "quasar"}
+        )
+        records.append(quasar_rec)
+
+    df = pd.DataFrame(records)
+    try:
+        baseline_best = compute_baseline_best(df)
+        quasar_df = df[df["framework"] == "quasar"]
+        return pd.concat([baseline_best, quasar_df], ignore_index=True)
+    except ValueError:
+        # All baselines failed or are unsupported; return QuASAr data only.
+        return df[df["framework"] == "quasar"].reset_index(drop=True)
+
+
+def save_results(df: pd.DataFrame, output: Path) -> None:
+    """Persist ``df`` as CSV and JSON using ``output`` as base path."""
+
+    base = output.with_suffix("")
+    csv_path = base.with_suffix(".csv")
+    json_path = base.with_suffix(".json")
+    csv_path.parent.mkdir(parents=True, exist_ok=True)
+    df.to_csv(csv_path, index=False)
+    df.to_json(json_path, orient="records", indent=2)
+
+
+def main() -> None:  # pragma: no cover - CLI entry point
+    parser = argparse.ArgumentParser(
+        description="Execute benchmark circuits and record baseline-best results"
+    )
+    parser.add_argument(
+        "--circuit", required=True, help="Circuit family name (e.g. ghz, qft)"
+    )
+    parser.add_argument(
+        "--qubits",
+        required=True,
+        type=parse_qubit_range,
+        help="Qubit range as start:end[:step]",
+    )
+    parser.add_argument(
+        "--repetitions",
+        type=int,
+        default=3,
+        help="Number of repetitions per configuration",
+    )
+    parser.add_argument(
+        "--output", required=True, type=Path, help="Output file path without extension"
+    )
+    parser.add_argument(
+        "--disable-classical-simplify",
+        action="store_true",
+        help="Disable classical control simplification",
+    )
+    args = parser.parse_args()
+
+    circuit_fn = resolve_circuit(args.circuit)
+    df = run_all(
+        circuit_fn,
+        args.qubits,
+        args.repetitions,
+        use_classical_simplification=not args.disable_classical_simplify,
+    )
+    save_results(df, args.output)
+
 
 # Import surface-code protected circuits so the CLI can discover them.
-from circuits import surface_corrected_qaoa_circuit  # noqa: F401
+from circuits import surface_corrected_qaoa_circuit  # noqa: E402,F401
 
 
-if __name__ == "__main__":  # pragma: no cover - script entry point
+if __name__ == "__main__":
     main()
 

--- a/tests/test_plot_utils.py
+++ b/tests/test_plot_utils.py
@@ -24,14 +24,16 @@ def test_compute_baseline_best():
     assert set(best["circuit"]) == {"c1", "c2"}
     assert best.loc[best["circuit"] == "c1", "run_time_mean"].iloc[0] == 0.5
     assert best.loc[best["circuit"] == "c2", "run_time_mean"].iloc[0] == 3.0
+    assert best.loc[best["circuit"] == "c1", "backend"].iloc[0] == "mps"
+    assert best.loc[best["circuit"] == "c2", "backend"].iloc[0] == "sv"
 
 
 def test_plot_quasar_vs_baseline_best_annotations():
     df = sample_df()
     ax = plot_quasar_vs_baseline_best(df, annotate_backend=True)
-    texts = {t.get_text() for t in ax.texts}
-    assert "mps" in texts
-    assert "sv" in texts
+    texts = [t.get_text() for t in ax.texts]
+    assert texts.count("mps") == 2
+    assert texts.count("sv") == 2
     assert len(ax.lines) == 2
 
 
@@ -40,6 +42,7 @@ def test_compute_baseline_best_handles_unsupported():
     df.loc[df["framework"] == "sv", "unsupported"] = True
     best = compute_baseline_best(df)
     assert set(best["circuit"]) == {"c1"}
+    assert best.loc[best["circuit"] == "c1", "backend"].iloc[0] == "mps"
 
 
 def test_plot_marks_unsupported():


### PR DESCRIPTION
## Summary
- compute per-circuit baseline best in plotting utilities and annotate both baseline and QuASAr points
- overhaul `run_benchmarks.py` to execute all single-method backends, aggregate the fastest baseline, and save alongside QuASAr results
- document new benchmarking workflow with baseline-best aggregation

## Testing
- `pytest`
- `python benchmarks/run_benchmarks.py --help`

------
https://chatgpt.com/codex/tasks/task_e_68c059be73a483218c0ed68c94e8b614