### PR TITLE
feat: support accuracy and runtime constraints

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,12 @@ simulators and default to the specialised TABLEAU backend, though a
 general-purpose backend like ``Backend.STATEVECTOR`` can be requested
 explicitly.
 
+The simulation API also accepts optional ``target_accuracy``, ``max_time`` and
+``optimization_level`` parameters.  ``target_accuracy`` specifies the minimum
+fidelity the planner should maintain, ``max_time`` bounds the estimated runtime
+and causes planning to abort when exceeded, while ``optimization_level``
+controls how aggressively the planner and scheduler pursue runtime optimisations.
+
 ```python
 from quasar import Backend, Circuit, SimulationEngine
 

--- a/tests/test_simulation_engine.py
+++ b/tests/test_simulation_engine.py
@@ -1,3 +1,5 @@
+import pytest
+
 from quasar import Circuit, SimulationEngine, SSD, Backend
 
 
@@ -64,3 +66,46 @@ def test_simulate_uses_supplied_plan(monkeypatch):
     monkeypatch.setattr(engine.planner, "plan", counting_plan)
     engine.simulate(circuit)
     assert calls["count"] == 1
+
+
+def test_simulate_forwards_constraints(monkeypatch):
+    circuit = Circuit([{"gate": "H", "qubits": [0]}])
+    engine = SimulationEngine()
+    received: dict[str, float | int | None] = {}
+
+    original_plan = engine.planner.plan
+
+    def plan_spy(*args, **kwargs):
+        received["target_accuracy"] = kwargs.get("target_accuracy")
+        received["max_time"] = kwargs.get("max_time")
+        received["optimization_level"] = kwargs.get("optimization_level")
+        return original_plan(*args, **kwargs)
+
+    monkeypatch.setattr(engine.planner, "plan", plan_spy)
+
+    original_run = engine.scheduler.run
+
+    def run_spy(*args, **kwargs):
+        received["run_max_time"] = kwargs.get("max_time")
+        return original_run(*args, **kwargs)
+
+    monkeypatch.setattr(engine.scheduler, "run", run_spy)
+
+    engine.simulate(
+        circuit,
+        target_accuracy=0.9,
+        max_time=1000.0,
+        optimization_level=2,
+    )
+
+    assert received["target_accuracy"] == 0.9
+    assert received["max_time"] == 1000.0
+    assert received["optimization_level"] == 2
+    assert received["run_max_time"] == 1000.0
+
+
+def test_simulation_enforces_max_time():
+    circuit = Circuit([{"gate": "H", "qubits": [0]}])
+    engine = SimulationEngine()
+    with pytest.raises(ValueError):
+        engine.simulate(circuit, max_time=1e-9)


### PR DESCRIPTION
## Summary
- extend `SimulationEngine.simulate` with `target_accuracy`, `max_time`, and `optimization_level`
- update planner and scheduler to enforce accuracy and runtime limits
- document new simulation parameters and add tests

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68c0d99d65b08321b80ff3f3b0f66336