### PR TITLE
Add temporal analysis metrics and propagate to planner

### DIFF
--- a/quasar/scheduler.py
+++ b/quasar/scheduler.py
@@ -9,6 +9,7 @@ import time
 import tracemalloc
 
 from .planner import Planner, PlanStep, PlanResult, _add_cost
+from .analyzer import AnalysisResult
 from .partitioner import CLIFFORD_GATES
 from .cost import Backend, Cost
 from . import config
@@ -272,6 +273,7 @@ class Scheduler:
         circuit: Circuit,
         plan: PlanResult | None = None,
         *,
+        analysis: AnalysisResult | None = None,
         backend: Backend | None = None,
         target_accuracy: float | None = None,
         max_time: float | None = None,
@@ -315,6 +317,7 @@ class Scheduler:
                 final_backend=backend_choice,
                 gates=gates,
                 explicit_steps=[PlanStep(0, len(gates), backend_choice)],
+                analysis=analysis,
             )
             plan.explicit_conversions = []
             if self.planner is not None:
@@ -351,6 +354,7 @@ class Scheduler:
             if plan is None:
                 plan = self.planner.plan(
                     circuit,
+                    analysis=analysis,
                     backend=backend,
                     target_accuracy=target_accuracy,
                     max_time=max_time,
@@ -503,6 +507,7 @@ class Scheduler:
         plan: PlanResult | None = None,
         monitor: CostHook | None = None,
         *,
+        analysis: AnalysisResult | None = None,
         instrument: bool = False,
         backend: Backend | None = None,
         target_accuracy: float | None = None,
@@ -553,6 +558,7 @@ class Scheduler:
             plan = self.prepare_run(
                 circuit,
                 plan,
+                analysis=analysis,
                 backend=backend,
                 target_accuracy=target_accuracy,
                 max_time=max_time,

--- a/quasar/simulation_engine.py
+++ b/quasar/simulation_engine.py
@@ -118,6 +118,7 @@ class SimulationEngine:
         ):
             plan = self.scheduler.prepare_run(
                 circuit,
+                analysis=analysis,
                 backend=backend,
                 target_accuracy=target_accuracy,
                 max_time=max_time,
@@ -126,6 +127,7 @@ class SimulationEngine:
         else:
             plan = self.planner.plan(
                 circuit,
+                analysis=analysis,
                 max_memory=threshold,
                 backend=backend,
                 target_accuracy=target_accuracy,
@@ -138,6 +140,7 @@ class SimulationEngine:
         ssd = self.scheduler.run(
             circuit,
             plan,
+            analysis=analysis,
             backend=backend,
             target_accuracy=target_accuracy,
             max_time=max_time,

--- a/tests/test_analyzer.py
+++ b/tests/test_analyzer.py
@@ -46,3 +46,16 @@ def test_resource_estimates(sample_circuit):
         assert isinstance(cost, Cost)
         assert cost.time >= 0
         assert cost.memory >= 0
+
+
+def test_temporal_metrics():
+    circ = Circuit.from_dict(
+        [
+            {"gate": "H", "qubits": [0]},
+            {"gate": "H", "qubits": [1]},
+            {"gate": "CX", "qubits": [0, 1]},
+        ]
+    )
+    analysis = CircuitAnalyzer(circ).analyze()
+    assert analysis.parallel_layers == [[0, 1], [2]]
+    assert analysis.critical_path_length == 2

--- a/tests/test_planner.py
+++ b/tests/test_planner.py
@@ -1,4 +1,4 @@
-from quasar import Circuit, Planner, Backend, CostEstimator
+from quasar import Circuit, Planner, Backend, CostEstimator, CircuitAnalyzer
 
 
 def test_tableau_for_clifford():
@@ -114,3 +114,16 @@ def test_conversion_cost_multiplier_discourages_switch():
     )
     steps2 = penalized.plan(circ).steps
     assert all(s.backend == Backend.STATEVECTOR for s in steps2)
+
+
+def test_planner_receives_analysis_metrics():
+    gates = [
+        {"gate": "H", "qubits": [0]},
+        {"gate": "H", "qubits": [1]},
+        {"gate": "CX", "qubits": [0, 1]},
+    ]
+    circ = Circuit.from_dict(gates)
+    analysis = CircuitAnalyzer(circ).analyze()
+    plan = Planner().plan(circ, analysis=analysis)
+    assert plan.analysis is analysis
+    assert plan.analysis.critical_path_length == 2


### PR DESCRIPTION
## Summary
- analyze gate dependencies to compute parallel layers and circuit depth
- expose temporal metrics via `AnalysisResult` and propagate through planner and scheduler
- test analyzer temporal metrics and planner access to analysis

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c0dbeed11483218f6996f7e7474cde