### PR TITLE
feat: add method selector and constraint-aware planning

### DIFF
--- a/quasar/__init__.py
+++ b/quasar/__init__.py
@@ -4,6 +4,7 @@ from .circuit import Gate, Circuit
 from .cost import Backend, Cost, ConversionEstimate, CostEstimator
 from .partitioner import Partitioner
 from .planner import Planner, PlanResult, PlanStep, DPEntry
+from .method_selector import MethodSelector
 from .scheduler import Scheduler
 from .simulation_engine import SimulationEngine, SimulationResult
 from .ssd import SSD, SSDPartition, ConversionLayer
@@ -27,6 +28,7 @@ __all__ = [
     "ConversionEstimate",
     "CostEstimator",
     "Partitioner",
+    "MethodSelector",
     "Planner",
     "PlanResult",
     "PlanStep",

--- a/quasar/method_selector.py
+++ b/quasar/method_selector.py
@@ -1,0 +1,177 @@
+from __future__ import annotations
+
+"""Backend selection based on multi-criteria constraints."""
+
+from typing import List, Tuple, TYPE_CHECKING
+
+from .cost import Backend, Cost, CostEstimator
+from . import config
+
+if TYPE_CHECKING:  # pragma: no cover
+    from .circuit import Gate
+
+CLIFFORD_GATES = {
+    "I",
+    "ID",
+    "X",
+    "Y",
+    "Z",
+    "H",
+    "S",
+    "SDG",
+    "CX",
+    "CY",
+    "CZ",
+    "SWAP",
+    "CSWAP",
+}
+
+
+class MethodSelector:
+    """Select simulation backends for circuit fragments.
+
+    The selector combines heuristic circuit analysis with calibrated
+    performance models to pick a backend that satisfies resource limits and
+    optional accuracy/time targets.
+    """
+
+    def __init__(self, estimator: CostEstimator | None = None) -> None:
+        self.estimator = estimator or CostEstimator()
+
+    def select(
+        self,
+        gates: List['Gate'],
+        num_qubits: int,
+        *,
+        sparsity: float | None = None,
+        phase_rotation_diversity: int | None = None,
+        amplitude_rotation_diversity: int | None = None,
+        allow_tableau: bool = True,
+        max_memory: float | None = None,
+        max_time: float | None = None,
+        target_accuracy: float | None = None,
+    ) -> Tuple[Backend, Cost]:
+        """Return the preferred backend and its cost for ``gates``.
+
+        Parameters
+        ----------
+        gates:
+            Gate sequence representing a contiguous fragment.
+        num_qubits:
+            Number of qubits touched by the fragment.
+        sparsity, phase_rotation_diversity, amplitude_rotation_diversity:
+            Optional analysis metrics for the overall circuit.
+        allow_tableau:
+            Permit tableau simulation when the fragment is Clifford-only.
+        max_memory:
+            Upper bound on allowed memory consumption in bytes.
+        max_time:
+            Upper bound on allowed runtime in seconds.
+        target_accuracy:
+            Desired lower bound on simulation fidelity.
+        """
+
+        names = [g.gate.upper() for g in gates]
+        num_gates = len(gates)
+        num_meas = sum(1 for g in gates if g.gate.upper() in {"MEASURE", "RESET"})
+        num_1q = sum(
+            1 for g in gates if len(g.qubits) == 1 and g.gate.upper() not in {"MEASURE", "RESET"}
+        )
+        num_2q = num_gates - num_1q - num_meas
+
+        # Clifford fragments can run on the tableau simulator directly.
+        if allow_tableau and names and all(n in CLIFFORD_GATES for n in names):
+            cost = self.estimator.tableau(num_qubits, num_gates)
+            if (max_memory is None or cost.memory <= max_memory) and (
+                max_time is None or cost.time <= max_time
+            ):
+                return Backend.TABLEAU, cost
+
+        # ------------------------------------------------------------------
+        # Heuristics for decision diagram suitability
+        # ------------------------------------------------------------------
+        from .sparsity import adaptive_dd_sparsity_threshold
+
+        sparse = sparsity if sparsity is not None else 0.0
+        phase_rot = phase_rotation_diversity or 0
+        amp_rot = amplitude_rotation_diversity or 0
+        nnz = int((1 - sparse) * (2**num_qubits))
+        s_thresh = adaptive_dd_sparsity_threshold(num_qubits)
+        amp_thresh = config.adaptive_dd_amplitude_rotation_threshold(num_qubits, sparse)
+        passes = (
+            sparse >= s_thresh
+            and nnz <= config.DEFAULT.dd_nnz_threshold
+            and phase_rot <= config.DEFAULT.dd_phase_rotation_diversity_threshold
+            and amp_rot <= amp_thresh
+        )
+        dd_metric = False
+        if passes:
+            s_score = sparse / s_thresh if s_thresh > 0 else 0.0
+            nnz_score = 1 - nnz / config.DEFAULT.dd_nnz_threshold
+            phase_score = 1 - phase_rot / config.DEFAULT.dd_phase_rotation_diversity_threshold
+            amp_score = 1 - amp_rot / amp_thresh
+            weight_sum = (
+                config.DEFAULT.dd_sparsity_weight
+                + config.DEFAULT.dd_nnz_weight
+                + config.DEFAULT.dd_phase_rotation_weight
+                + config.DEFAULT.dd_amplitude_rotation_weight
+            )
+            weighted = (
+                config.DEFAULT.dd_sparsity_weight * s_score
+                + config.DEFAULT.dd_nnz_weight * nnz_score
+                + config.DEFAULT.dd_phase_rotation_weight * phase_score
+                + config.DEFAULT.dd_amplitude_rotation_weight * amp_score
+            )
+            metric = weighted / weight_sum if weight_sum else 0.0
+            dd_metric = metric >= config.DEFAULT.dd_metric_threshold
+
+        # Determine whether the fragment is local enough for MPS
+        multi = [g for g in gates if len(g.qubits) > 1]
+        local = bool(multi) and all(
+            len(g.qubits) == 2 and abs(g.qubits[0] - g.qubits[1]) == 1 for g in multi
+        )
+
+        candidates: dict[Backend, Cost] = {}
+        if dd_metric:
+            dd_cost = self.estimator.decision_diagram(num_gates=num_gates, frontier=num_qubits)
+            if (max_memory is None or dd_cost.memory <= max_memory) and (
+                max_time is None or dd_cost.time <= max_time
+            ):
+                candidates[Backend.DECISION_DIAGRAM] = dd_cost
+
+        if local:
+            chi = getattr(self.estimator, "chi_max", None) or 4
+            if target_accuracy is not None or max_memory is not None:
+                chi_cap = self.estimator.chi_for_constraints(
+                    num_qubits,
+                    gates,
+                    target_accuracy
+                    if target_accuracy is not None
+                    else config.DEFAULT.mps_target_fidelity,
+                    max_memory,
+                )
+                if chi_cap > 0:
+                    chi = chi_cap
+            mps_cost = self.estimator.mps(
+                num_qubits,
+                num_1q + num_meas,
+                num_2q,
+                chi=chi,
+                svd=True,
+            )
+            if (max_memory is None or mps_cost.memory <= max_memory) and (
+                max_time is None or mps_cost.time <= max_time
+            ):
+                candidates[Backend.MPS] = mps_cost
+
+        sv_cost = self.estimator.statevector(num_qubits, num_1q, num_2q, num_meas)
+        if (max_memory is None or sv_cost.memory <= max_memory) and (
+            max_time is None or sv_cost.time <= max_time
+        ):
+            candidates[Backend.STATEVECTOR] = sv_cost
+
+        if not candidates:
+            candidates[Backend.STATEVECTOR] = sv_cost
+
+        backend = min(candidates, key=lambda b: (candidates[b].memory, candidates[b].time))
+        return backend, candidates[backend]

--- a/tests/test_method_selector_constraints.py
+++ b/tests/test_method_selector_constraints.py
@@ -1,0 +1,42 @@
+import math
+from quasar.cost import CostEstimator, Backend
+from quasar.circuit import Circuit
+from quasar.method_selector import MethodSelector
+from quasar.planner import Planner
+
+
+def test_method_selector_memory_limit():
+    est = CostEstimator()
+    selector = MethodSelector(est)
+    gates = [{"gate": "T", "qubits": [0]}] + [
+        {"gate": "CX", "qubits": [i, i + 1]} for i in range(14)
+    ]
+    circ = Circuit.from_dict(gates, use_classical_simplification=False)
+    sv = est.statevector(15, 0, 14, 0)
+    mps = est.mps(15, 0, 14, chi=4, svd=True)
+    max_mem = (sv.memory + mps.memory) / 2
+    backend, _ = selector.select(
+        circ.gates, 15, max_memory=max_mem, target_accuracy=0.0
+    )
+    assert backend == Backend.MPS
+
+
+def test_planner_forwarding_constraints():
+    class DummySelector(MethodSelector):
+        def __init__(self, est):
+            super().__init__(est)
+            self.kwargs = None
+
+        def select(self, gates, num_qubits, **kwargs):
+            self.kwargs = kwargs
+            cost = self.estimator.statevector(num_qubits, 0, 0, 0)
+            return Backend.STATEVECTOR, cost
+
+    est = CostEstimator()
+    selector = DummySelector(est)
+    planner = Planner(estimator=est, selector=selector)
+    circ = Circuit.from_dict([{"gate": "H", "qubits": [0]}], use_classical_simplification=False)
+    planner.plan(circ, target_accuracy=0.91, max_time=100.0)
+    assert selector.kwargs is not None
+    assert math.isclose(selector.kwargs["target_accuracy"], 0.91)
+    assert math.isclose(selector.kwargs["max_time"], 100.0)


### PR DESCRIPTION
## Summary
- implement MethodSelector for multi-criteria backend selection
- delegate partitioner and planner decisions to MethodSelector
- allow Planner.plan to handle accuracy/time limits

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68c0e274a474832183be50e625d29b7d