### PR TITLE
Add execution metrics and fidelity tracking to simulations

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,12 @@ for part in result.ssd.partitions:
 Depending on the backend, ``state`` may be a dense NumPy vector, a list of MPS
 tensors, a ``stim.Tableau`` or a decision diagram node.
 
+Alongside the final :class:`~quasar.ssd.SSD`, the returned
+:class:`~quasar.simulation_engine.SimulationResult` records execution metrics
+such as the number of backend switches, individual conversion durations, plan
+cache hits and optional state fidelity when a reference statevector is
+supplied.
+
 The :func:`SimulationEngine.simulate` method accepts an optional ``backend``
 argument to explicitly choose the simulation backend (e.g.,
 ``Backend.TABLEAU`` for Clifford circuits).  When ``backend`` is ``None`` (the
@@ -54,11 +60,13 @@ simulators and default to the specialised TABLEAU backend, though a
 general-purpose backend like ``Backend.STATEVECTOR`` can be requested
 explicitly.
 
-The simulation API also accepts optional ``target_accuracy``, ``max_time`` and
-``optimization_level`` parameters.  ``target_accuracy`` specifies the minimum
-fidelity the planner should maintain, ``max_time`` bounds the estimated runtime
-and causes planning to abort when exceeded, while ``optimization_level``
-controls how aggressively the planner and scheduler pursue runtime optimisations.
+The simulation API also accepts optional ``target_accuracy``, ``max_time``,
+``optimization_level`` and ``reference_state`` parameters.  ``target_accuracy``
+specifies the minimum fidelity the planner should maintain, ``max_time`` bounds
+the estimated runtime and causes planning to abort when exceeded, while
+``optimization_level`` controls how aggressively the planner and scheduler
+pursue runtime optimisations.  Supplying ``reference_state`` computes the
+fidelity of the resulting statevector against the provided reference.
 
 ```python
 from quasar import Backend, Circuit, SimulationEngine

--- a/tests/test_scheduler_instrumentation.py
+++ b/tests/test_scheduler_instrumentation.py
@@ -75,5 +75,5 @@ def test_run_reports_instrumentation(monkeypatch):
     )
     monkeypatch.setattr("quasar.scheduler.tracemalloc.reset_peak", lambda: None)
 
-    _, run_cost = scheduler.run(circuit, plan, instrument=True)
-    assert run_cost.time > 0
+    _, metrics = scheduler.run(circuit, plan, instrument=True)
+    assert metrics.cost.time > 0

--- a/tests/test_scheduler_single_backend_parity.py
+++ b/tests/test_scheduler_single_backend_parity.py
@@ -24,7 +24,7 @@ def test_single_backend_auto_and_fixed_runtime_parity(monkeypatch):
         "quasar.scheduler.tracemalloc.get_traced_memory", lambda: (0, 0)
     )
 
-    _, auto_cost = scheduler.run(auto_circ, instrument=True)
-    _, fixed_cost = scheduler.run(fixed_circ, instrument=True, backend=backend)
+    _, auto_metrics = scheduler.run(auto_circ, instrument=True)
+    _, fixed_metrics = scheduler.run(fixed_circ, instrument=True, backend=backend)
 
-    assert auto_cost.time == fixed_cost.time
+    assert auto_metrics.cost.time == fixed_metrics.cost.time


### PR DESCRIPTION
## Summary
- extend Scheduler.run with RunMetrics to log backend switches, conversion durations, plan cache hits, and optional state fidelity
- surface metrics in SimulationEngine.SimulationResult and allow fidelity calculation against a reference state
- document and test the new execution statistics

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68c0e7d57ad48321b1a729b9faa0ce9a