### PR TITLE
Estimate effects of planner parallel groups

### DIFF
--- a/quasar/cost.py
+++ b/quasar/cost.py
@@ -179,6 +179,11 @@ class CostEstimator:
             "ingest_dd_mem": 0.0,
             # Fixed overhead applied to every backend switch -----------------
             "conversion_base": 5.0,
+            # Parallel execution overhead ---------------------------------
+            # Fixed penalties applied when running multiple independent
+            # groups concurrently.
+            "parallel_time_overhead": 0.0,
+            "parallel_memory_overhead": 0.0,
         }
         if coeff:
             self.coeff.update(coeff)
@@ -299,6 +304,23 @@ class CostEstimator:
             if chi_mem < chi:
                 return 0
         return chi if chi >= 1 else 0
+
+    # ------------------------------------------------------------------
+    # Parallel execution helpers
+    # ------------------------------------------------------------------
+    def parallel_time_overhead(self, groups: int) -> float:
+        """Return runtime overhead for executing ``groups`` in parallel."""
+
+        if groups <= 1:
+            return 0.0
+        return self.coeff.get("parallel_time_overhead", 0.0) * (groups - 1)
+
+    def parallel_memory_overhead(self, groups: int) -> float:
+        """Return additional memory required for ``groups`` run in parallel."""
+
+        if groups <= 1:
+            return 0.0
+        return self.coeff.get("parallel_memory_overhead", 0.0) * (groups - 1)
 
     def statevector(
         self,

--- a/tests/test_planner_parallel_groups.py
+++ b/tests/test_planner_parallel_groups.py
@@ -1,0 +1,35 @@
+from quasar.circuit import Circuit
+from quasar.cost import CostEstimator
+from quasar.planner import Planner, _parallel_simulation_cost
+from quasar.partitioner import Partitioner
+from quasar.cost import Backend
+
+
+def test_parallel_group_cost(monkeypatch):
+    circuit = Circuit([
+        {"gate": "H", "qubits": [0]},
+        {"gate": "T", "qubits": [0]},
+        {"gate": "H", "qubits": [1]},
+        {"gate": "T", "qubits": [1]},
+    ])
+    planner = Planner(CostEstimator())
+
+    plan_parallel = planner.plan(circuit, backend=Backend.STATEVECTOR)
+    step_parallel = plan_parallel.steps[0]
+    groups = Partitioner().parallel_groups(circuit.gates)
+    cost_parallel = _parallel_simulation_cost(
+        planner.estimator, Backend.STATEVECTOR, groups
+    )
+
+    def serial_groups(self, gates):
+        qubits = tuple(sorted({q for g in gates for q in g.qubits}))
+        return [(qubits, list(gates))]
+
+    serial = serial_groups(None, circuit.gates)  # compute single group
+    cost_serial = _parallel_simulation_cost(
+        planner.estimator, Backend.STATEVECTOR, serial
+    )
+
+    assert step_parallel.parallel == ((0,), (1,))
+    assert cost_parallel.time < cost_serial.time
+    assert cost_parallel.memory > cost_serial.memory


### PR DESCRIPTION
## Summary
- model runtime/memory changes for parallel groups via new CostEstimator helpers
- extend planner to weigh parallel group costs and integrate them in dynamic programming
- add regression test for parallel-group planning

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c1435a943c8321a8806a5aa7d1f9e2