### PR TITLE
Expose per-gate entanglement and backend metadata

### DIFF
--- a/docs/analyzer.md
+++ b/docs/analyzer.md
@@ -1,0 +1,16 @@
+# Circuit Analyzer
+
+QuASAr's `CircuitAnalyzer` inspects quantum circuits and derives statistics
+used by the planner and scheduler. The `AnalysisResult` returned by
+``CircuitAnalyzer.analyze()`` now includes two pieces of per-gate metadata:
+
+* **`gate_entanglement`** – how each gate affects entanglement. Entries are
+  `"none"`, `"creates"`, or `"modifies"` depending on whether a gate acts on a
+  single qubit, introduces new entanglement between qubits, or operates on an
+  already entangled set.
+* **`method_compatibility`** – a list of simulation methods that can execute
+  each gate. Method names correspond to the lower‑case backend identifiers
+  (``"statevector"``, ``"tableau"``, ``"mps"``, ``"decision_diagram"``).
+
+These annotations are aligned with the circuit's topological order and are also
+attached to the gate objects themselves for downstream consumers.

--- a/tests/test_analyzer.py
+++ b/tests/test_analyzer.py
@@ -32,6 +32,12 @@ def test_entanglement_metrics(sample_circuit):
     assert metrics["max_connected_size"] == 3
 
 
+def test_gate_annotations(sample_circuit):
+    analysis = CircuitAnalyzer(sample_circuit).analyze()
+    assert analysis.gate_entanglement == ["none", "creates", "creates", "none"]
+    assert analysis.method_compatibility == [["tableau"]] * 4
+
+
 def test_resource_estimates(sample_circuit):
     analyzer = CircuitAnalyzer(sample_circuit)
     estimates = analyzer.resource_estimates()
@@ -83,6 +89,14 @@ def test_rotation_and_clifford_metrics():
     assert depths["T"] == 1
     assert depths["RZ"] == 2
     assert depths["CX"] == 3
+
+
+def test_method_compatibility_non_clifford():
+    circ = Circuit.from_dict([{"gate": "T", "qubits": [0]}], use_classical_simplification=False)
+    analysis = CircuitAnalyzer(circ).analyze()
+    methods = analysis.method_compatibility[0]
+    assert "statevector" in methods
+    assert "tableau" not in methods
 
 
 def test_graph_clustering_metric():


### PR DESCRIPTION
## Summary
- track entanglement creation/modification and backend compatibility for every gate
- extend AnalysisResult with per-gate metadata
- document analyzer outputs and test new annotations

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68c15eddfef883218c38a25f47d06954