### PR TITLE
Add planner cost table notebook and tests

### DIFF
--- a/benchmarks/notebooks/planner_cost_table.ipynb
+++ b/benchmarks/notebooks/planner_cost_table.ipynb
@@ -1,0 +1,159 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "9d267e45",
+   "metadata": {},
+   "source": [
+    "# Planner cost table\n",
+    "\n",
+    "Compute plan cost and planner runtime for oracle, DP, and greedy methods on small circuits."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "6ca6cf11",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import time\n",
+    "from functools import lru_cache\n",
+    "import pandas as pd\n",
+    "from quasar.circuit import Circuit\n",
+    "from quasar.planner import Planner, _simulation_cost, _supported_backends"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "a1b4ce77",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def compute_metrics(circuit: Circuit) -> dict[str, tuple[float, float]]:\n",
+    "    planner = Planner()\n",
+    "    gates = circuit.gates\n",
+    "\n",
+    "    # DP planner\n",
+    "    t0 = time.perf_counter()\n",
+    "    res = planner.plan(circuit)\n",
+    "    t1 = time.perf_counter()\n",
+    "    dp_cost = res.table[-1][res.final_backend].cost.time\n",
+    "    dp_time = t1 - t0\n",
+    "\n",
+    "    @lru_cache(None)\n",
+    "    def dfs(i: int) -> float:\n",
+    "        if i >= len(gates):\n",
+    "            return 0.0\n",
+    "        best = float('inf')\n",
+    "        for j in range(i + 1, len(gates) + 1):\n",
+    "            seg = gates[i:j]\n",
+    "            allowed = _supported_backends(\n",
+    "                seg,\n",
+    "                allow_tableau=True,\n",
+    "                estimator=planner.estimator,\n",
+    "                sparsity=circuit.sparsity,\n",
+    "                phase_rotation_diversity=circuit.phase_rotation_diversity,\n",
+    "                amplitude_rotation_diversity=circuit.amplitude_rotation_diversity,\n",
+    "            )\n",
+    "            nq = len({q for g in seg for q in g.qubits})\n",
+    "            ng = len(seg)\n",
+    "            nm = sum(1 for g in seg if g.gate.upper() in {\"MEASURE\", \"RESET\"})\n",
+    "            n1 = sum(1 for g in seg if len(g.qubits) == 1 and g.gate.upper() not in {\"MEASURE\", \"RESET\"})\n",
+    "            n2 = ng - n1 - nm\n",
+    "            for backend in allowed:\n",
+    "                cost = _simulation_cost(planner.estimator, backend, nq, n1, n2, nm).time\n",
+    "                best = min(best, cost + dfs(j))\n",
+    "        return best\n",
+    "\n",
+    "    t2 = time.perf_counter()\n",
+    "    oracle_cost = dfs(0)\n",
+    "    t3 = time.perf_counter()\n",
+    "    oracle_time = t3 - t2\n",
+    "\n",
+    "    t4 = time.perf_counter()\n",
+    "    greedy_cost = 0.0\n",
+    "    for gate in gates:\n",
+    "        seg = [gate]\n",
+    "        allowed = _supported_backends(\n",
+    "            seg,\n",
+    "            allow_tableau=True,\n",
+    "            estimator=planner.estimator,\n",
+    "            sparsity=circuit.sparsity,\n",
+    "            phase_rotation_diversity=circuit.phase_rotation_diversity,\n",
+    "            amplitude_rotation_diversity=circuit.amplitude_rotation_diversity,\n",
+    "        )\n",
+    "        nq = len({q for g in seg for q in g.qubits})\n",
+    "        nm = sum(1 for g in seg if g.gate.upper() in {\"MEASURE\", \"RESET\"})\n",
+    "        n1 = sum(1 for g in seg if len(g.qubits) == 1 and g.gate.upper() not in {\"MEASURE\", \"RESET\"})\n",
+    "        n2 = len(seg) - n1 - nm\n",
+    "        best = min(\n",
+    "            _simulation_cost(planner.estimator, b, nq, n1, n2, nm).time\n",
+    "            for b in allowed\n",
+    "        )\n",
+    "        greedy_cost += best\n",
+    "    t5 = time.perf_counter()\n",
+    "    greedy_time = t5 - t4\n",
+    "\n",
+    "    return {\n",
+    "        \"oracle\": (oracle_cost, oracle_time),\n",
+    "        \"dp\": (dp_cost, dp_time),\n",
+    "        \"greedy\": (greedy_cost, greedy_time),\n",
+    "    }"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "f6acce6a",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Define small circuits\n",
+    "circuits = {\n",
+    "    \"bell\": Circuit([\n",
+    "        {\"gate\": \"H\", \"qubits\": [0]},\n",
+    "        {\"gate\": \"CX\", \"qubits\": [0, 1]},\n",
+    "    ], use_classical_simplification=False),\n",
+    "    \"ghz3\": Circuit([\n",
+    "        {\"gate\": \"H\", \"qubits\": [0]},\n",
+    "        {\"gate\": \"CX\", \"qubits\": [0, 1]},\n",
+    "        {\"gate\": \"CX\", \"qubits\": [1, 2]},\n",
+    "    ], use_classical_simplification=False),\n",
+    "}\n",
+    "\n",
+    "records = []\n",
+    "for name, circuit in circuits.items():\n",
+    "    metrics = compute_metrics(circuit)\n",
+    "    for method, (cost, runtime) in metrics.items():\n",
+    "        records.append({\"circuit\": name, \"method\": method, \"cost\": cost, \"time\": runtime})\n",
+    "\n",
+    "df = pd.DataFrame(records)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "6255b249",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "df.pivot(index='method', columns='circuit')[['cost', 'time']]"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "version": "3.12"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/tests/test_planner_cost_table.py
+++ b/tests/test_planner_cost_table.py
@@ -1,0 +1,120 @@
+import time
+from functools import lru_cache
+
+import pytest
+
+from quasar.circuit import Circuit
+from quasar.planner import Planner, _simulation_cost, _supported_backends
+
+BASELINES = {
+    "bell": {
+        "oracle": (20.0, 5.76e-05),
+        "dp": (20.0, 9.72e-04),
+        "greedy": (20.0, 2.63e-05),
+    },
+    "ghz3": {
+        "oracle": (36.0, 9.62e-05),
+        "dp": (36.0, 1.10e-03),
+        "greedy": (36.0, 3.63e-05),
+    },
+}
+
+
+def compute_metrics(circuit: Circuit) -> dict[str, tuple[float, float]]:
+    planner = Planner()
+    gates = circuit.gates
+
+    t0 = time.perf_counter()
+    res = planner.plan(circuit)
+    t1 = time.perf_counter()
+    dp_cost = res.table[-1][res.final_backend].cost.time
+    dp_time = t1 - t0
+
+    @lru_cache(None)
+    def dfs(i: int) -> float:
+        if i >= len(gates):
+            return 0.0
+        best = float("inf")
+        for j in range(i + 1, len(gates) + 1):
+            seg = gates[i:j]
+            allowed = _supported_backends(
+                seg,
+                allow_tableau=True,
+                estimator=planner.estimator,
+                sparsity=circuit.sparsity,
+                phase_rotation_diversity=circuit.phase_rotation_diversity,
+                amplitude_rotation_diversity=circuit.amplitude_rotation_diversity,
+            )
+            nq = len({q for g in seg for q in g.qubits})
+            ng = len(seg)
+            nm = sum(1 for g in seg if g.gate.upper() in {"MEASURE", "RESET"})
+            n1 = sum(1 for g in seg if len(g.qubits) == 1 and g.gate.upper() not in {"MEASURE", "RESET"})
+            n2 = ng - n1 - nm
+            for backend in allowed:
+                cost = _simulation_cost(planner.estimator, backend, nq, n1, n2, nm).time
+                best = min(best, cost + dfs(j))
+        return best
+
+    t2 = time.perf_counter()
+    oracle_cost = dfs(0)
+    t3 = time.perf_counter()
+    oracle_time = t3 - t2
+
+    t4 = time.perf_counter()
+    greedy_cost = 0.0
+    for gate in gates:
+        seg = [gate]
+        allowed = _supported_backends(
+            seg,
+            allow_tableau=True,
+            estimator=planner.estimator,
+            sparsity=circuit.sparsity,
+            phase_rotation_diversity=circuit.phase_rotation_diversity,
+            amplitude_rotation_diversity=circuit.amplitude_rotation_diversity,
+        )
+        nq = len({q for g in seg for q in g.qubits})
+        nm = sum(1 for g in seg if g.gate.upper() in {"MEASURE", "RESET"})
+        n1 = sum(1 for g in seg if len(g.qubits) == 1 and g.gate.upper() not in {"MEASURE", "RESET"})
+        n2 = len(seg) - n1 - nm
+        best = min(
+            _simulation_cost(planner.estimator, b, nq, n1, n2, nm).time
+            for b in allowed
+        )
+        greedy_cost += best
+    t5 = time.perf_counter()
+    greedy_time = t5 - t4
+
+    return {
+        "oracle": (oracle_cost, oracle_time),
+        "dp": (dp_cost, dp_time),
+        "greedy": (greedy_cost, greedy_time),
+    }
+
+
+def circuits() -> dict[str, Circuit]:
+    return {
+        "bell": Circuit(
+            [
+                {"gate": "H", "qubits": [0]},
+                {"gate": "CX", "qubits": [0, 1]},
+            ],
+            use_classical_simplification=False,
+        ),
+        "ghz3": Circuit(
+            [
+                {"gate": "H", "qubits": [0]},
+                {"gate": "CX", "qubits": [0, 1]},
+                {"gate": "CX", "qubits": [1, 2]},
+            ],
+            use_classical_simplification=False,
+        ),
+    }
+
+
+@pytest.mark.parametrize("name,circuit", list(circuits().items()))
+def test_planner_cost_table(name: str, circuit: Circuit) -> None:
+    metrics = compute_metrics(circuit)
+    for method, (cost, runtime) in metrics.items():
+        expected_cost, expected_time = BASELINES[name][method]
+        assert cost == expected_cost
+        assert runtime == pytest.approx(expected_time, rel=0.5, abs=1e-4)


### PR DESCRIPTION
## Summary
- Add `benchmarks/notebooks/planner_cost_table.ipynb` to compute cost and runtime for oracle, DP and greedy planners on small circuits.
- Provide a test `tests/test_planner_cost_table.py` validating recorded costs and runtimes against baseline values.

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c171d61e408321b457bc201947faa7