### PR TITLE
Add planner cost gap CDF notebook and tests

### DIFF
--- a/benchmarks/notebooks/planner_cost_gap_cdf.ipynb
+++ b/benchmarks/notebooks/planner_cost_gap_cdf.ipynb
@@ -1,0 +1,106 @@
+{
+  "cells": [
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "# Planner Cost Gap CDF\n",
+        "Compute the relative cost gap between the dynamic programming planner and an exhaustive oracle for a small set of circuits and plot the cumulative distribution function (CDF)."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "from functools import lru_cache\n",
+        "import numpy as np\n",
+        "import matplotlib.pyplot as plt\n",
+        "from benchmarks.circuits import ghz_circuit, qft_circuit, qft_on_ghz_circuit, w_state_circuit, grover_circuit\n",
+        "from quasar.circuit import Circuit\n",
+        "from quasar.planner import Planner, _simulation_cost, _supported_backends\n"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "def cost_gap(circuit: Circuit) -> float:\n",
+        "    planner = Planner()\n",
+        "    gates = circuit.gates\n",
+        "    res = planner.plan(circuit)\n",
+        "    dp_cost = res.table[-1][res.final_backend].cost.time\n",
+        "\n",
+        "    @lru_cache(None)\n",
+        "    def dfs(i: int) -> float:\n",
+        "        if i >= len(gates):\n",
+        "            return 0.0\n",
+        "        best = float(\"inf\")\n",
+        "        for j in range(i + 1, len(gates) + 1):\n",
+        "            seg = gates[i:j]\n",
+        "            allowed = _supported_backends(\n",
+        "                seg,\n",
+        "                allow_tableau=True,\n",
+        "                estimator=planner.estimator,\n",
+        "                sparsity=circuit.sparsity,\n",
+        "                phase_rotation_diversity=circuit.phase_rotation_diversity,\n",
+        "                amplitude_rotation_diversity=circuit.amplitude_rotation_diversity,\n",
+        "            )\n",
+        "            nq = len({q for g in seg for q in g.qubits})\n",
+        "            ng = len(seg)\n",
+        "            nm = sum(1 for g in seg if g.gate.upper() in {\"MEASURE\", \"RESET\"})\n",
+        "            n1 = sum(1 for g in seg if len(g.qubits) == 1 and g.gate.upper() not in {\"MEASURE\", \"RESET\"})\n",
+        "            n2 = ng - n1 - nm\n",
+        "            for backend in allowed:\n",
+        "                cost = _simulation_cost(planner.estimator, backend, nq, n1, n2, nm).time\n",
+        "                best = min(best, cost + dfs(j))\n",
+        "        return best\n",
+        "\n",
+        "    oracle_cost = dfs(0)\n",
+        "    return (dp_cost - oracle_cost) / oracle_cost\n"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "circuits = {\n",
+        "    \"ghz4\": ghz_circuit(4),\n",
+        "    \"qft4\": qft_circuit(4),\n",
+        "    \"qft_on_ghz4\": qft_on_ghz_circuit(4),\n",
+        "    \"w4\": w_state_circuit(4),\n",
+        "    \"grover4\": grover_circuit(4, 1),\n",
+        "}\n",
+        "\n",
+        "gaps = np.array([cost_gap(c) for c in circuits.values()])\n",
+        "cdf_x = np.sort(gaps)\n",
+        "cdf_y = np.linspace(0, 1, len(cdf_x), endpoint=True)\n",
+        "\n",
+        "plt.plot(cdf_x, cdf_y, marker=\"o\")\n",
+        "plt.xlabel(\"Relative cost gap (DP vs oracle)\")\n",
+        "plt.ylabel(\"CDF\")\n",
+        "plt.title(\"Planner Cost Gap CDF\")\n",
+        "plt.grid(True)\n",
+        "plt.show()\n"
+      ]
+    }
+  ],
+  "metadata": {
+    "kernelspec": {
+      "display_name": "Python 3",
+      "language": "python",
+      "name": "python3"
+    },
+    "language_info": {
+      "name": "python",
+      "version": "3.11"
+    }
+  },
+  "nbformat": 4,
+  "nbformat_minor": 5
+}

--- a/tests/test_planner_cost_gap_cdf.py
+++ b/tests/test_planner_cost_gap_cdf.py
@@ -1,0 +1,70 @@
+import numpy as np
+import pytest
+from functools import lru_cache
+
+from quasar.circuit import Circuit
+from quasar.planner import Planner, _simulation_cost, _supported_backends
+from benchmarks.circuits import (
+    ghz_circuit,
+    qft_circuit,
+    qft_on_ghz_circuit,
+    w_state_circuit,
+    grover_circuit,
+)
+
+
+def circuits() -> dict[str, Circuit]:
+    return {
+        "ghz4": ghz_circuit(4),
+        "qft4": qft_circuit(4),
+        "qft_on_ghz4": qft_on_ghz_circuit(4),
+        "w4": w_state_circuit(4),
+        "grover4": grover_circuit(4, 1),
+    }
+
+
+def cost_gap(circuit: Circuit) -> float:
+    planner = Planner()
+    gates = circuit.gates
+
+    res = planner.plan(circuit)
+    dp_cost = res.table[-1][res.final_backend].cost.time
+
+    @lru_cache(None)
+    def dfs(i: int) -> float:
+        if i >= len(gates):
+            return 0.0
+        best = float("inf")
+        for j in range(i + 1, len(gates) + 1):
+            seg = gates[i:j]
+            allowed = _supported_backends(
+                seg,
+                allow_tableau=True,
+                estimator=planner.estimator,
+                sparsity=circuit.sparsity,
+                phase_rotation_diversity=circuit.phase_rotation_diversity,
+                amplitude_rotation_diversity=circuit.amplitude_rotation_diversity,
+            )
+            nq = len({q for g in seg for q in g.qubits})
+            ng = len(seg)
+            nm = sum(1 for g in seg if g.gate.upper() in {"MEASURE", "RESET"})
+            n1 = sum(
+                1
+                for g in seg
+                if len(g.qubits) == 1 and g.gate.upper() not in {"MEASURE", "RESET"}
+            )
+            n2 = ng - n1 - nm
+            for backend in allowed:
+                cost = _simulation_cost(planner.estimator, backend, nq, n1, n2, nm).time
+                best = min(best, cost + dfs(j))
+        return best
+
+    oracle_cost = dfs(0)
+    return (dp_cost - oracle_cost) / oracle_cost
+
+
+def test_planner_cost_gap_cdf() -> None:
+    gaps = np.array([cost_gap(c) for c in circuits().values()])
+    quantiles = np.quantile(gaps, [0.25, 0.5, 0.75])
+    expected = np.array([-0.37340061553843984, 0.0, 17.05337647088215])
+    assert quantiles == pytest.approx(expected, rel=1e-6, abs=1e-6)


### PR DESCRIPTION
## Summary
- Add notebook computing relative cost gaps across circuits and plotting the planner gap CDF
- Test cost gap CDF quantiles for representative circuits

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c174b702448321a74085bcc0b0c663