### PR TITLE
Add SVD runtime microbenchmark

### DIFF
--- a/benchmarks/notebooks/svd_runtime_vs_chi.ipynb
+++ b/benchmarks/notebooks/svd_runtime_vs_chi.ipynb
@@ -1,0 +1,55 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "2cdd5c26",
+   "metadata": {},
+   "source": [
+    "# SVD Runtime vs $\\chi$\n",
+    "\n",
+    "This notebook benchmarks the runtime of NumPy's SVD for random square matrices of dimension $\\chi$ and plots the scaling on log–log axes."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "115eac04",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "\n",
+    "import numpy as np\n",
+    "import time\n",
+    "import matplotlib.pyplot as plt\n",
+    "\n",
+    "chis = [2, 4, 8, 16, 32]\n",
+    "repeats = 20\n",
+    "\n",
+    "np.random.seed(0)\n",
+    "\n",
+    "def svd_runtime(chi, repeats=20):\n",
+    "    m = np.random.rand(chi, chi)\n",
+    "    times = []\n",
+    "    for _ in range(repeats):\n",
+    "        start = time.perf_counter()\n",
+    "        np.linalg.svd(m, full_matrices=False)\n",
+    "        times.append(time.perf_counter() - start)\n",
+    "    return min(times)\n",
+    "\n",
+    "runtimes = [svd_runtime(chi, repeats) for chi in chis]\n",
+    "for chi, rt in zip(chis, runtimes):\n",
+    "    print(f\"chi={chi:2d} runtime={rt:.2e} s\")\n",
+    "\n",
+    "plt.figure()\n",
+    "plt.loglog(chis, runtimes, marker='o')\n",
+    "plt.xlabel(r\"$\\chi$\")\n",
+    "plt.ylabel(\"runtime (s)\")\n",
+    "plt.title(\"SVD runtime vs chi\")\n",
+    "plt.show()\n"
+   ]
+  }
+ ],
+ "metadata": {},
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/tests/test_svd_runtime_vs_chi.py
+++ b/tests/test_svd_runtime_vs_chi.py
@@ -1,0 +1,32 @@
+import numpy as np
+import pytest
+import time
+
+CHIS = [2, 4, 8, 16, 32]
+BASELINE = {
+    2: 9.99e-06,
+    4: 1.30e-05,
+    8: 2.00e-05,
+    16: 4.45e-05,
+    32: 1.69e-04,
+}
+
+
+def svd_runtime(chi: int, repeats: int = 20) -> float:
+    """Return the minimal runtime of an SVD on a random ``chi``×``chi`` matrix."""
+    m = np.random.rand(chi, chi)
+    times = []
+    for _ in range(repeats):
+        start = time.perf_counter()
+        np.linalg.svd(m, full_matrices=False)
+        times.append(time.perf_counter() - start)
+    return min(times)
+
+
+def test_svd_runtime_vs_chi() -> None:
+    """SVD runtimes grow with ``chi`` and match expected baselines."""
+    np.random.seed(0)
+    runtimes = [svd_runtime(c) for c in CHIS]
+    assert all(x < y for x, y in zip(runtimes, runtimes[1:]))
+    for chi, rt in zip(CHIS, runtimes):
+        assert rt == pytest.approx(BASELINE[chi], rel=1.0)


### PR DESCRIPTION
## Summary
- add notebook benchmarking NumPy SVD runtime scaling with bond dimension chi
- test SVD runtime growth vs chi against baseline timings

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c17648e278832194e0117e54e095ab