### PR TITLE
Add decision diagram frontier extraction benchmark

### DIFF
--- a/benchmarks/notebooks/dd_frontier_extraction_time.ipynb
+++ b/benchmarks/notebooks/dd_frontier_extraction_time.ipynb
@@ -1,0 +1,56 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Decision diagram frontier extraction time\n",
+    "\n",
+    "Measure how the time to convert a decision diagram boundary to a dense statevector scales with frontier size."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import time\n",
+    "import quasar_convert as qc\n",
+    "import matplotlib.pyplot as plt\n",
+    "\n",
+    "def measure_time(frontier: int, repeats: int = 5) -> float:\n",
+    "    eng = qc.ConversionEngine()\n",
+    "    ssd = qc.SSD()\n",
+    "    ssd.boundary_qubits = list(range(frontier))\n",
+    "    start = time.perf_counter()\n",
+    "    for _ in range(repeats):\n",
+    "        eng.convert_boundary_to_statevector(ssd)\n",
+    "    return time.perf_counter() - start\n",
+    "\n",
+    "frontiers = [4, 6, 8, 10, 12]\n",
+    "times = [measure_time(f) for f in frontiers]\n",
+    "\n",
+    "plt.plot(frontiers, times, marker='o')\n",
+    "plt.xlabel('Frontier size (qubits)')\n",
+    "plt.ylabel('Extraction time (s)')\n",
+    "plt.title('Decision diagram frontier extraction time')\n",
+    "plt.show()\n",
+    "times\n"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "version": "3.12"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/tests/test_dd_frontier_extraction_time.py
+++ b/tests/test_dd_frontier_extraction_time.py
@@ -1,0 +1,26 @@
+"""Test decision-diagram frontier extraction runtime scaling."""
+
+from __future__ import annotations
+
+import time
+
+import quasar_convert as qc
+
+
+def _measure_time(frontier: int, repeats: int = 5) -> float:
+    """Return total time to extract a boundary of ``frontier`` qubits."""
+    eng = qc.ConversionEngine()
+    ssd = qc.SSD()
+    ssd.boundary_qubits = list(range(frontier))
+    start = time.perf_counter()
+    for _ in range(repeats):
+        eng.convert_boundary_to_statevector(ssd)
+    return time.perf_counter() - start
+
+
+def test_frontier_extraction_time_scales_with_size() -> None:
+    """Extraction time should grow with the frontier size."""
+    frontiers = [4, 6, 8, 10]
+    times = [_measure_time(f) for f in frontiers]
+    for prev, curr in zip(times, times[1:]):
+        assert curr > prev * 2


### PR DESCRIPTION
## Summary
- benchmark decision diagram frontier extraction across frontier sizes
- test that extraction time increases with frontier size

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c177c42bf48321a7a8cf102bcbd7ad