### PR TITLE
Add stabilizer learning time benchmark and tests

### DIFF
--- a/benchmarks/notebooks/stabilizer_learning_time.ipynb
+++ b/benchmarks/notebooks/stabilizer_learning_time.ipynb
@@ -1,0 +1,63 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "be7ce7af",
+   "metadata": {},
+   "source": [
+    "# Stabilizer learning time\n",
+    "\n",
+    "Measure mean ± standard deviation of stabilizer-learning times for several window sizes."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "b1b9367a",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import time\n",
+    "import numpy as np\n",
+    "import pandas as pd\n",
+    "from quasar_convert import ConversionEngine\n",
+    "\n",
+    "def plus_state(n: int) -> list[float]:\n",
+    "    \"\"\"Return amplitudes of the n-qubit |+...+> state.\"\"\"\n",
+    "    dim = 1 << n\n",
+    "    amp = 1 / np.sqrt(dim)\n",
+    "    return [amp] * dim\n",
+    "\n",
+    "def measure(engine: ConversionEngine, window_sizes: list[int], repeats: int = 8, inner: int = 5000) -> pd.DataFrame:\n",
+    "    \"\"\"Collect mean ± std stabilizer-learning times for ``window_sizes``.\"\"\"\n",
+    "    records = []\n",
+    "    for n in window_sizes:\n",
+    "        state = plus_state(n)\n",
+    "        times = []\n",
+    "        for _ in range(repeats):\n",
+    "            start = time.process_time()\n",
+    "            for _ in range(inner):\n",
+    "                engine.learn_stabilizer(state)\n",
+    "            times.append((time.process_time() - start) / inner)\n",
+    "        records.append({\"window\": n, \"mean\": np.mean(times), \"std\": np.std(times, ddof=1)})\n",
+    "    return pd.DataFrame(records)\n",
+    "\n",
+    "engine = ConversionEngine()\n",
+    "window_sizes = [1, 2, 3, 4]\n",
+    "measure(engine, window_sizes)"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/tests/test_stabilizer_learning_time.py
+++ b/tests/test_stabilizer_learning_time.py
@@ -1,0 +1,46 @@
+"""Test stabilizer-learning runtime statistics."""
+
+from __future__ import annotations
+
+import time
+from typing import Tuple
+
+import numpy as np
+import pytest
+from quasar_convert import ConversionEngine
+
+WINDOW_SIZES = [1, 2, 3, 4]
+BASELINE = {
+    1: {"mean": 2.7e-05, "std": 3.9e-06},
+    2: {"mean": 2.7e-05, "std": 3.4e-06},
+    3: {"mean": 3.9e-05, "std": 2.3e-06},
+    4: {"mean": 3.9e-05, "std": 2.6e-06},
+}
+
+
+def plus_state(n: int) -> list[float]:
+    """Return amplitudes of the n-qubit ``|+...+>`` state."""
+    dim = 1 << n
+    amp = 1 / np.sqrt(dim)
+    return [amp] * dim
+
+
+def measure(window: int, repeats: int = 8, inner: int = 5000) -> Tuple[float, float]:
+    """Return mean and std runtime for stabilizer learning on ``window`` qubits."""
+    eng = ConversionEngine()
+    state = plus_state(window)
+    times = []
+    for _ in range(repeats):
+        start = time.process_time()
+        for _ in range(inner):
+            eng.learn_stabilizer(state)
+        times.append((time.process_time() - start) / inner)
+    return float(np.mean(times)), float(np.std(times, ddof=1))
+
+
+def test_stabilizer_learning_time_matches_baseline() -> None:
+    """Measured statistics should roughly match stored expectations."""
+    for w in WINDOW_SIZES:
+        mean, std = measure(w)
+        assert mean == pytest.approx(BASELINE[w]["mean"], rel=1.0)
+        assert std == pytest.approx(BASELINE[w]["std"], rel=1.0)


### PR DESCRIPTION
## Summary
- add notebook measuring stabilizer learning times over several window sizes
- test stabilizer learning runtime statistics against expected baselines

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68c17a2522f88321a8bf159421c18ce2