### PR TITLE
Add planner re-optimization timeline demo and tests

### DIFF
--- a/benchmarks/notebooks/reoptimization_timeline.ipynb
+++ b/benchmarks/notebooks/reoptimization_timeline.ipynb
@@ -1,0 +1,79 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "intro",
+   "metadata": {},
+   "source": [
+    "# Re-optimization Timeline\n",
+    "This notebook injects perturbations into a simple circuit, records the planner's execution progress, and plots the timeline of re-optimization and recovery."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "imports",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import time\n",
+    "import pandas as pd\n",
+    "import matplotlib.pyplot as plt\n",
+    "from quasar.planner import Planner\n",
+    "from benchmarks.circuits import ghz_circuit, qft_circuit"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "timeline",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "planner = Planner()\n",
+    "baseline = ghz_circuit(4)\n",
+    "perturbed = qft_circuit(4)\n",
+    "events = []\n",
+    "start = time.perf_counter()\n",
+    "planner.plan(baseline)\n",
+    "events.append({'event': 'baseline', 'time': time.perf_counter() - start})\n",
+    "planner.plan(perturbed)\n",
+    "events.append({'event': 'reoptimized', 'time': time.perf_counter() - start})\n",
+    "planner.plan(baseline)\n",
+    "events.append({'event': 'recovered', 'time': time.perf_counter() - start})\n",
+    "timeline = pd.DataFrame(events)\n",
+    "timeline"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "plot",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "fig, ax = plt.subplots()\n",
+    "ax.hlines(range(len(timeline)), 0, timeline['time'], color='C0')\n",
+    "ax.plot(timeline['time'], range(len(timeline)), 'o')\n",
+    "ax.set_yticks(range(len(timeline)))\n",
+    "ax.set_yticklabels(timeline['event'])\n",
+    "ax.set_xlabel('time (s)')\n",
+    "ax.set_title('Re-optimization timeline')\n",
+    "plt.show()"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "version": "3"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/tests/test_reoptimization_timeline.py
+++ b/tests/test_reoptimization_timeline.py
@@ -1,0 +1,31 @@
+import time
+
+from quasar.planner import Planner
+from benchmarks.circuits import ghz_circuit, qft_circuit
+
+
+def test_reoptimization_timeline() -> None:
+    """Planner should react to circuit perturbations and recover quickly."""
+    planner = Planner()
+
+    baseline = ghz_circuit(4)
+    start = time.perf_counter()
+    base_plan = planner.plan(baseline)
+    baseline_time = time.perf_counter() - start
+    assert baseline_time < 1.0
+
+    perturbed = qft_circuit(4)
+    start = time.perf_counter()
+    pert_plan = planner.plan(perturbed)
+    perturb_time = time.perf_counter() - start
+    assert perturb_time < 1.0
+
+    # Planner should detect change in circuit and adjust backend.
+    assert pert_plan.final_backend != base_plan.final_backend
+
+    # Recovery: planning the original circuit again should match initial backend.
+    start = time.perf_counter()
+    recovered = planner.plan(baseline)
+    recovery_time = time.perf_counter() - start
+    assert recovery_time < 1.0
+    assert recovered.final_backend == base_plan.final_backend


### PR DESCRIPTION
## Summary
- Add re-optimization timeline notebook showing perturbation, re-planning, and recovery with a plotted timeline
- Introduce test verifying planner detects circuit perturbations and recovers within time bounds

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c19a34c9dc83218473339d6994ea3c