### PR TITLE
Add speedup bar chart notebook and tests

### DIFF
--- a/benchmarks/notebooks/relative_speedup_bar_chart.ipynb
+++ b/benchmarks/notebooks/relative_speedup_bar_chart.ipynb
@@ -1,0 +1,46 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "source": [
+    "import csv\n",
+    "from pathlib import Path\n",
+    "data_path = Path('..') / 'quick_analysis_results.csv'\n",
+    "rows = list(csv.DictReader(open(data_path)))\n",
+    "speedups = [float(r['full_time'])/float(r['quick_time']) for r in rows]\n",
+    "circuits = [f\"{r['qubits']}q\" for r in rows]\n"
+   ],
+   "outputs": [],
+   "execution_count": null
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "source": [
+    "import matplotlib.pyplot as plt\n",
+    "plt.figure(figsize=(8, 4))\n",
+    "plt.bar(circuits, speedups)\n",
+    "plt.ylabel('Speedup (\u00d7)')\n",
+    "plt.xlabel('Circuit')\n",
+    "plt.title('Relative Speedups')\n",
+    "plt.show()\n"
+   ],
+   "outputs": [],
+   "execution_count": null
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "version": "3"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/tests/test_relative_speedup_bar_chart.py
+++ b/tests/test_relative_speedup_bar_chart.py
@@ -1,0 +1,22 @@
+import csv
+from pathlib import Path
+
+import pytest
+
+
+def load_speedups():
+    path = Path(__file__).resolve().parents[1] / 'benchmarks' / 'quick_analysis_results.csv'
+    with path.open() as f:
+        reader = csv.DictReader(f)
+        rows = list(reader)
+    for row in rows:
+        quick = float(row['quick_time'])
+        full = float(row['full_time'])
+        expected = float(row['speedup'])
+        yield full / quick, expected
+
+
+def test_relative_speedup_bar_chart():
+    for computed, expected in load_speedups():
+        assert computed == pytest.approx(expected)
+        assert computed > 1.0


### PR DESCRIPTION
## Summary
- add notebook to compute relative speedups from benchmark results and plot bar chart
- add test to verify computed speedups exceed baseline and match table values

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c1b51f72ec83218b2e3e023a1881b0