### PR TITLE
Add backend switch conversion time notebook and baseline test

### DIFF
--- a/benchmarks/notebooks/backend_switches_conversion_time.ipynb
+++ b/benchmarks/notebooks/backend_switches_conversion_time.ipynb
@@ -1,0 +1,59 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Backend switches and conversion time\n",
+    "\n",
+    "Measure backend switch counts and total conversion time for a circuit requiring backend changes."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import pandas as pd\n",
+    "from quasar.circuit import Circuit, Gate\n",
+    "from quasar.simulation_engine import SimulationEngine\n",
+    "from quasar.cost import Backend\n",
+    "from quasar.planner import PlanResult, PlanStep\n",
+    "\n",
+    "def measure_switches_conversion_time() -> pd.DataFrame:\n",
+    "    circuit = Circuit([Gate(\"H\", [0]), Gate(\"T\", [0]), Gate(\"H\", [0])])\n",
+    "    steps = [\n",
+    "        PlanStep(0, 1, Backend.TABLEAU),\n",
+    "        PlanStep(1, 2, Backend.MPS),\n",
+    "        PlanStep(2, 3, Backend.TABLEAU),\n",
+    "    ]\n",
+    "    plan = PlanResult(table=[], final_backend=None, gates=circuit.gates, explicit_steps=steps)\n",
+    "    plan.explicit_conversions = []\n",
+    "    engine = SimulationEngine()\n",
+    "    engine.scheduler.run(circuit, plan, instrument=True)\n",
+    "    _, metrics = engine.scheduler.run(circuit, plan, instrument=True)\n",
+    "    return pd.DataFrame([\n",
+    "        {\n",
+    "            \"backend_switches\": metrics.backend_switches,\n",
+    "            \"conversion_time\": sum(metrics.conversion_durations),\n",
+    "        }\n",
+    "    ])\n",
+    "\n",
+    "measure_switches_conversion_time()"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/tests/test_backend_switches_conversion_time.py
+++ b/tests/test_backend_switches_conversion_time.py
@@ -1,0 +1,37 @@
+"""Verify backend switches and conversion time baseline."""
+
+from __future__ import annotations
+
+import pytest
+
+from quasar.circuit import Circuit, Gate
+from quasar.simulation_engine import SimulationEngine
+from quasar.cost import Backend
+from quasar.planner import PlanResult, PlanStep
+
+BASELINE_SWITCHES = 2
+BASELINE_CONVERSION_TIME = 0.0020
+
+
+def measure() -> tuple[int, float]:
+    """Return backend switches and total conversion time."""
+    circuit = Circuit([Gate("H", [0]), Gate("T", [0]), Gate("H", [0])])
+    steps = [
+        PlanStep(0, 1, Backend.TABLEAU),
+        PlanStep(1, 2, Backend.MPS),
+        PlanStep(2, 3, Backend.TABLEAU),
+    ]
+    plan = PlanResult(table=[], final_backend=None, gates=circuit.gates, explicit_steps=steps)
+    plan.explicit_conversions = []
+    engine = SimulationEngine()
+    engine.scheduler.run(circuit, plan, instrument=True)
+    _, metrics = engine.scheduler.run(circuit, plan, instrument=True)
+    switches = metrics.backend_switches
+    conversion_time = sum(metrics.conversion_durations)
+    return switches, conversion_time
+
+
+def test_backend_switches_conversion_time() -> None:
+    switches, conv_time = measure()
+    assert switches == BASELINE_SWITCHES
+    assert conv_time == pytest.approx(BASELINE_CONVERSION_TIME, rel=0.5)


### PR DESCRIPTION
## Summary
- add benchmark notebook measuring backend switches and conversion time
- add regression test validating switch count and conversion timing

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68c23058fa28832189ca36b12eb21a05