### PR TITLE
Add plan choice heatmap notebook and tests

### DIFF
--- a/benchmarks/notebooks/plan_choice_heatmap.ipynb
+++ b/benchmarks/notebooks/plan_choice_heatmap.ipynb
@@ -1,0 +1,111 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import inspect, sys, time, pathlib\n",
+    "import pandas as pd\n",
+    "import seaborn as sns\n",
+    "import matplotlib.pyplot as plt\n",
+    "\n",
+    "# Make project root importable\n",
+    "root = pathlib.Path('..', '..').resolve()\n",
+    "sys.path.append(str(root))\n",
+    "\n",
+    "from quasar.planner import Planner\n",
+    "from quasar.simulation_engine import SimulationEngine\n",
+    "from benchmarks.circuits import ghz_circuit, grover_circuit\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "alphas = [0.5, 1, 2, 5]\n",
+    "circuits = {\n",
+    "    'GHZ_6': ghz_circuit(6),\n",
+    "    'Grover_3': grover_circuit(3, 1),\n",
+    "}\n",
+    "records = []\n",
+    "for name, circ in circuits.items():\n",
+    "    for alpha in alphas:\n",
+    "        kwargs = {'conversion_cost_multiplier': alpha}\n",
+    "        if 'compare_pre_pass_costs' in inspect.signature(Planner).parameters:\n",
+    "            kwargs['compare_pre_pass_costs'] = True\n",
+    "        planner = Planner(**kwargs)\n",
+    "        plan = planner.plan(circ)\n",
+    "        steps = [s.backend.name for s in plan.steps]\n",
+    "        records.append({'circuit': name, 'alpha': alpha, 'steps': steps})\n",
+    "records\n",
+    "results = records\n",
+    "circuits = list(circuits.keys())\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "for name in circuits:\n",
+    "    subset = [r for r in records if r['circuit'] == name]\n",
+    "    max_frag = max(len(r['steps']) for r in subset)\n",
+    "    heat = pd.DataFrame(index=alphas, columns=range(max_frag))\n",
+    "    for r in subset:\n",
+    "        heat.loc[r['alpha'], :len(r['steps'])-1] = r['steps']\n",
+    "    backends = sorted({b for row in heat.values for b in row if b is not None})\n",
+    "    mapping = {b: i for i, b in enumerate(backends)}\n",
+    "    heat_numeric = heat.replace(mapping).astype(float)\n",
+    "    plt.figure(figsize=(1.2*max_frag, 1.2*len(alphas)))\n",
+    "    sns.heatmap(heat_numeric, annot=heat, fmt='', cmap='tab10', cbar=False)\n",
+    "    plt.title(f'Backend per fragment for {name}')\n",
+    "    plt.xlabel('Fragment')\n",
+    "    plt.ylabel('\u03b1')\n",
+    "    plt.show()\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import json, pathlib\n",
+    "try:\n",
+    "    import ipynbname\n",
+    "    nb_name = ipynbname.path().stem\n",
+    "except Exception:  # pragma: no cover\n",
+    "    nb_name = 'notebook'\n",
+    "\n",
+    "_params = {k: v for k, v in globals().items() if not k.startswith('_') and isinstance(v, (int, float, str, bool, list, dict, tuple))}\n",
+    "pathlib.Path('../results').mkdir(exist_ok=True)\n",
+    "with open(f"../results/{nb_name}_params.json", 'w') as f:\n",
+    "    json.dump(_params, f, indent=2)\n",
+    "if 'results' in globals():\n",
+    "    try:\n",
+    "        with open(f"../results/{nb_name}_results.json", 'w') as f:\n",
+    "            json.dump(results, f, indent=2)\n",
+    "    except TypeError:\n",
+    "        pass\n",
+    "print(json.dumps(_params, indent=2))\n"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/benchmarks/results/plan_choice_heatmap_params.json
+++ b/benchmarks/results/plan_choice_heatmap_params.json
@@ -1,0 +1,4 @@
+{
+  "alphas": [0.5, 1, 2, 5],
+  "circuits": ["GHZ_6", "Grover_3"]
+}

--- a/benchmarks/results/plan_choice_heatmap_results.json
+++ b/benchmarks/results/plan_choice_heatmap_results.json
@@ -1,0 +1,150 @@
+[
+  {
+    "circuit": "GHZ_6",
+    "alpha": 0.5,
+    "steps": [
+      "TABLEAU",
+      "TABLEAU",
+      "TABLEAU",
+      "TABLEAU",
+      "TABLEAU",
+      "TABLEAU"
+    ]
+  },
+  {
+    "circuit": "GHZ_6",
+    "alpha": 1,
+    "steps": [
+      "TABLEAU",
+      "TABLEAU",
+      "TABLEAU",
+      "TABLEAU",
+      "TABLEAU",
+      "TABLEAU"
+    ]
+  },
+  {
+    "circuit": "GHZ_6",
+    "alpha": 2,
+    "steps": [
+      "TABLEAU",
+      "TABLEAU",
+      "TABLEAU",
+      "TABLEAU",
+      "TABLEAU",
+      "TABLEAU"
+    ]
+  },
+  {
+    "circuit": "GHZ_6",
+    "alpha": 5,
+    "steps": [
+      "TABLEAU",
+      "TABLEAU",
+      "TABLEAU",
+      "TABLEAU",
+      "TABLEAU",
+      "TABLEAU"
+    ]
+  },
+  {
+    "circuit": "Grover_3",
+    "alpha": 0.5,
+    "steps": [
+      "STATEVECTOR",
+      "STATEVECTOR",
+      "STATEVECTOR",
+      "STATEVECTOR",
+      "STATEVECTOR",
+      "STATEVECTOR",
+      "STATEVECTOR",
+      "STATEVECTOR",
+      "STATEVECTOR",
+      "STATEVECTOR",
+      "STATEVECTOR",
+      "STATEVECTOR",
+      "STATEVECTOR",
+      "STATEVECTOR",
+      "STATEVECTOR",
+      "STATEVECTOR",
+      "STATEVECTOR",
+      "STATEVECTOR",
+      "STATEVECTOR"
+    ]
+  },
+  {
+    "circuit": "Grover_3",
+    "alpha": 1,
+    "steps": [
+      "STATEVECTOR",
+      "STATEVECTOR",
+      "STATEVECTOR",
+      "STATEVECTOR",
+      "STATEVECTOR",
+      "STATEVECTOR",
+      "STATEVECTOR",
+      "STATEVECTOR",
+      "STATEVECTOR",
+      "STATEVECTOR",
+      "STATEVECTOR",
+      "STATEVECTOR",
+      "STATEVECTOR",
+      "STATEVECTOR",
+      "STATEVECTOR",
+      "STATEVECTOR",
+      "STATEVECTOR",
+      "STATEVECTOR",
+      "STATEVECTOR"
+    ]
+  },
+  {
+    "circuit": "Grover_3",
+    "alpha": 2,
+    "steps": [
+      "STATEVECTOR",
+      "STATEVECTOR",
+      "STATEVECTOR",
+      "STATEVECTOR",
+      "STATEVECTOR",
+      "STATEVECTOR",
+      "STATEVECTOR",
+      "STATEVECTOR",
+      "STATEVECTOR",
+      "STATEVECTOR",
+      "STATEVECTOR",
+      "STATEVECTOR",
+      "STATEVECTOR",
+      "STATEVECTOR",
+      "STATEVECTOR",
+      "STATEVECTOR",
+      "STATEVECTOR",
+      "STATEVECTOR",
+      "STATEVECTOR"
+    ]
+  },
+  {
+    "circuit": "Grover_3",
+    "alpha": 5,
+    "steps": [
+      "STATEVECTOR",
+      "STATEVECTOR",
+      "STATEVECTOR",
+      "STATEVECTOR",
+      "STATEVECTOR",
+      "STATEVECTOR",
+      "STATEVECTOR",
+      "STATEVECTOR",
+      "STATEVECTOR",
+      "STATEVECTOR",
+      "STATEVECTOR",
+      "STATEVECTOR",
+      "STATEVECTOR",
+      "STATEVECTOR",
+      "STATEVECTOR",
+      "STATEVECTOR",
+      "STATEVECTOR",
+      "STATEVECTOR",
+      "STATEVECTOR"
+    ]
+  }
+]

--- a/tests/test_plan_choice_heatmap.py
+++ b/tests/test_plan_choice_heatmap.py
@@ -1,0 +1,38 @@
+import inspect
+import json
+from pathlib import Path
+
+from benchmarks.circuits import ghz_circuit, grover_circuit
+from quasar.planner import Planner
+
+
+def circuits():
+    return {
+        "GHZ_6": ghz_circuit(6),
+        "Grover_3": grover_circuit(3, 1),
+    }
+
+
+def load_records():
+    path = (
+        Path(__file__).resolve().parents[1]
+        / "benchmarks"
+        / "results"
+        / "plan_choice_heatmap_results.json"
+    )
+    with path.open() as f:
+        records = json.load(f)
+    return {(r["circuit"], r["alpha"]): r["steps"] for r in records}
+
+
+def test_plan_choice_heatmap():
+    expected = load_records()
+    for (name, alpha), steps in expected.items():
+        circ = circuits()[name]
+        kwargs = {"conversion_cost_multiplier": alpha}
+        if "compare_pre_pass_costs" in inspect.signature(Planner).parameters:
+            kwargs["compare_pre_pass_costs"] = True
+        planner = Planner(**kwargs)
+        plan = planner.plan(circ)
+        observed = [s.backend.name for s in plan.steps]
+        assert observed == steps


### PR DESCRIPTION
## Summary
- add `plan_choice_heatmap` notebook to visualize backend selections for varying α
- store backend selections for reference
- test planner backend choices against stored selections

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c235cfbc1c8321a15d584536a43702