### PR TITLE
Add runtime vs alpha benchmark and test

### DIFF
--- a/benchmarks/notebooks/runtime_vs_alpha.ipynb
+++ b/benchmarks/notebooks/runtime_vs_alpha.ipynb
@@ -1,0 +1,47 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "runtime-vs-alpha",
+   "metadata": {},
+   "source": [
+    "# Runtime vs $\\alpha$\n",
+    "\n",
+    "Measure the runtime of a simple sleep-based workload for various\\n",
+    "conversion cost multipliers $\\alpha$ and plot the results."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "measure-runtime",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import time\n",
+    "import matplotlib.pyplot as plt\n",
+    "\n",
+    "alphas = [0.5, 1, 2, 5]\n",
+    "\n",
+    "def run(alpha: float) -> float:\n",
+    "    start = time.perf_counter()\n",
+    "    time.sleep(alpha * 0.01)\n",
+    "    return time.perf_counter() - start\n",
+    "\n",
+    "runtimes = [run(a) for a in alphas]\n",
+    "for a, rt in zip(alphas, runtimes):\n",
+    "    print(f\"alpha={a} runtime={rt:.3f} s\")\n",
+    "\n",
+    "plt.figure()\n",
+    "plt.plot(alphas, runtimes, marker='o')\n",
+    "plt.xlabel(r\"$\\alpha$\")\n",
+    "plt.ylabel(\"runtime (s)\")\n",
+    "plt.title(\"Runtime vs alpha\")\n",
+    "plt.show()\n"
+   ]
+  }
+ ],
+ "metadata": {},
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/tests/test_runtime_vs_alpha.py
+++ b/tests/test_runtime_vs_alpha.py
@@ -1,0 +1,30 @@
+"""Verify runtime scales linearly with alpha.
+
+The test uses ``time.sleep`` to simulate a workload whose runtime is
+proportional to the input ``alpha``.  Measured runtimes are compared
+against baseline values and required to increase with ``alpha``.
+"""
+
+from __future__ import annotations
+
+import time
+
+import pytest
+
+ALPHAS = [0.5, 1, 2, 5]
+BASELINE = {a: a * 0.01 for a in ALPHAS}
+
+
+def run(alpha: float) -> float:
+    """Return the runtime of a sleep-based workload for ``alpha``."""
+    start = time.perf_counter()
+    time.sleep(alpha * 0.01)
+    return time.perf_counter() - start
+
+
+def test_runtime_vs_alpha() -> None:
+    """Runtimes should match the baseline curve and grow with ``alpha``."""
+    runtimes = {a: run(a) for a in ALPHAS}
+    for alpha, runtime in runtimes.items():
+        assert runtime == pytest.approx(BASELINE[alpha], abs=0.005)
+    assert all(runtimes[a] < runtimes[b] for a, b in zip(ALPHAS, ALPHAS[1:]))


### PR DESCRIPTION
## Summary
- Add `runtime_vs_alpha` notebook demonstrating runtime scaling with conversion cost multiplier α
- Introduce `test_runtime_vs_alpha` to validate simulated runtime against baseline curve

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68c2675118748321b965a2508635e148