### PR TITLE
Add recovery overhead benchmark and tests

### DIFF
--- a/benchmarks/notebooks/recovery_overhead_table.ipynb
+++ b/benchmarks/notebooks/recovery_overhead_table.ipynb
@@ -1,0 +1,68 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "a29adccb",
+   "metadata": {},
+   "source": [
+    "# Recovery overhead table\n",
+    "\n",
+    "Measure recovery time and planning overhead after circuit perturbations."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "5a0e8cda",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import time\n",
+    "import pandas as pd\n",
+    "from quasar.planner import Planner\n",
+    "from quasar.circuit import Circuit, Gate\n",
+    "from benchmarks.circuits import ghz_circuit, qft_circuit\n",
+    "\n",
+    "planner = Planner()\n",
+    "baseline = ghz_circuit(3)\n",
+    "start = time.perf_counter();\n",
+    "planner.plan(baseline);\n",
+    "baseline_time = time.perf_counter() - start\n",
+    "\n",
+    "minor = Circuit(list(baseline.gates) + [Gate('H', [0])], use_classical_simplification=False)\n",
+    "major = qft_circuit(3)\n",
+    "perturbations = {'minor': minor, 'major': major}\n",
+    "\n",
+    "rows = []\n",
+    "for name, pert in perturbations.items():\n",
+    "    start = time.perf_counter(); planner.plan(pert); perturb_time = time.perf_counter() - start\n",
+    "    start = time.perf_counter(); planner.plan(baseline); recovery_time = time.perf_counter() - start\n",
+    "    overhead = (perturb_time + recovery_time) / baseline_time\n",
+    "    rows.append({'perturbation': name, 'recovery_time': recovery_time, 'overhead': overhead})\n",
+    "table = pd.DataFrame(rows)\n",
+    "table\n"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.10"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/tests/test_recovery_overhead_table.py
+++ b/tests/test_recovery_overhead_table.py
@@ -1,0 +1,41 @@
+import time
+
+import pytest
+
+from quasar.planner import Planner
+from quasar.circuit import Circuit, Gate
+from benchmarks.circuits import ghz_circuit, qft_circuit
+
+BASELINES = {
+    "minor": (1.5e-05, 1.16),
+    "major": (2.1e-05, 4.47),
+}
+
+
+def compute_metrics() -> dict[str, tuple[float, float]]:
+    planner = Planner()
+    baseline = ghz_circuit(3)
+    start = time.perf_counter()
+    planner.plan(baseline)
+    baseline_time = time.perf_counter() - start
+
+    minor = Circuit(list(baseline.gates) + [Gate("H", [0])], use_classical_simplification=False)
+    major = qft_circuit(3)
+    perturbations = {"minor": minor, "major": major}
+
+    metrics: dict[str, tuple[float, float]] = {}
+    for name, pert in perturbations.items():
+        start = time.perf_counter(); planner.plan(pert); perturb_time = time.perf_counter() - start
+        start = time.perf_counter(); planner.plan(baseline); recovery_time = time.perf_counter() - start
+        overhead = (perturb_time + recovery_time) / baseline_time
+        metrics[name] = (recovery_time, overhead)
+    return metrics
+
+
+@pytest.mark.parametrize("name", ["minor", "major"])
+def test_recovery_overhead_table(name: str) -> None:
+    metrics = compute_metrics()[name]
+    expected_recovery, expected_overhead = BASELINES[name]
+    recovery, overhead = metrics
+    assert recovery == pytest.approx(expected_recovery, rel=0.5, abs=1e-4)
+    assert overhead == pytest.approx(expected_overhead, rel=0.5)


### PR DESCRIPTION
## Summary
- Add recovery_overhead_table notebook to measure re-planning performance after circuit perturbations
- Add tests verifying recovery times and overhead ratios against baseline values

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68c19e61633c8321b5d860c98d13a3e1