### PR TITLE
Raise error when no backend satisfies constraints

### DIFF
--- a/quasar/__init__.py
+++ b/quasar/__init__.py
@@ -4,7 +4,7 @@ from .circuit import Gate, Circuit
 from .cost import Backend, Cost, ConversionEstimate, CostEstimator
 from .partitioner import Partitioner
 from .planner import Planner, PlanResult, PlanStep, DPEntry
-from .method_selector import MethodSelector
+from .method_selector import MethodSelector, NoFeasibleBackendError
 from .scheduler import Scheduler
 from .simulation_engine import SimulationEngine, SimulationResult
 from .ssd import SSD, SSDPartition, ConversionLayer
@@ -35,6 +35,7 @@ __all__ = [
     "CostEstimator",
     "Partitioner",
     "MethodSelector",
+    "NoFeasibleBackendError",
     "Planner",
     "PlanResult",
     "PlanStep",

--- a/quasar/method_selector.py
+++ b/quasar/method_selector.py
@@ -27,6 +27,10 @@ CLIFFORD_GATES = {
 }
 
 
+class NoFeasibleBackendError(RuntimeError):
+    """Raised when no backend satisfies the provided constraints."""
+
+
 class MethodSelector:
     """Select simulation backends for circuit fragments.
 
@@ -69,6 +73,11 @@ class MethodSelector:
             Upper bound on allowed runtime in seconds.
         target_accuracy:
             Desired lower bound on simulation fidelity.
+
+        Raises
+        ------
+        NoFeasibleBackendError
+            If no backend satisfies the resource constraints.
         """
 
         names = [g.gate.upper() for g in gates]
@@ -171,7 +180,11 @@ class MethodSelector:
             candidates[Backend.STATEVECTOR] = sv_cost
 
         if not candidates:
-            candidates[Backend.STATEVECTOR] = sv_cost
+            raise NoFeasibleBackendError(
+                "No simulation backend satisfies the given constraints"
+            )
 
-        backend = min(candidates, key=lambda b: (candidates[b].memory, candidates[b].time))
+        backend = min(
+            candidates, key=lambda b: (candidates[b].memory, candidates[b].time)
+        )
         return backend, candidates[backend]

--- a/quasar/partitioner.py
+++ b/quasar/partitioner.py
@@ -4,7 +4,7 @@ from typing import Dict, List, Tuple, TYPE_CHECKING, Set
 
 from .ssd import SSD, SSDPartition, ConversionLayer
 from .cost import Backend, CostEstimator, Cost
-from .method_selector import MethodSelector
+from .method_selector import MethodSelector, NoFeasibleBackendError
 
 if TYPE_CHECKING:  # pragma: no cover
     from .circuit import Circuit, Gate
@@ -57,6 +57,12 @@ class Partitioner:
             graph-based heuristic that balances load and minimises conversion
             boundaries.  The default ``False`` uses the original sequential
             heuristic.
+
+        Raises
+        ------
+        NoFeasibleBackendError
+            If no simulation backend satisfies the resource constraints for a
+            fragment.
         """
 
         if not circuit.gates:

--- a/quasar/planner.py
+++ b/quasar/planner.py
@@ -19,7 +19,7 @@ from .partitioner import CLIFFORD_GATES, Partitioner
 from .ssd import ConversionLayer, SSD
 from . import config
 from .analyzer import AnalysisResult
-from .method_selector import MethodSelector
+from .method_selector import MethodSelector, NoFeasibleBackendError
 
 if True:  # pragma: no cover - used for type checking when available
     try:
@@ -1005,7 +1005,13 @@ class Planner:
         target_accuracy: float | None = None,
         max_time: float | None = None,
     ) -> Tuple[Backend, Cost]:
-        """Return best single-backend estimate for the full gate list."""
+        """Return best single-backend estimate for the full gate list.
+
+        Raises
+        ------
+        NoFeasibleBackendError
+            If no backend satisfies the provided resource constraints.
+        """
 
         qubits = {q for g in gates for q in g.qubits}
         num_qubits = len(qubits)
@@ -1063,6 +1069,12 @@ class Planner:
             selection.
         optimization_level:
             Heuristic tuning knob influencing cost comparisons.
+
+        Raises
+        ------
+        NoFeasibleBackendError
+            If no backend satisfies the resource constraints implied by the
+            provided limits.
         """
 
         gates = circuit.simplify_classical_controls()

--- a/tests/test_no_feasible_backend.py
+++ b/tests/test_no_feasible_backend.py
@@ -1,0 +1,27 @@
+import pytest
+
+from quasar import Planner, Circuit, Gate, Backend, NoFeasibleBackendError
+
+
+def _t_gate_circuit():
+    # Single non-Clifford gate to avoid tableau fallback
+    c = Circuit([Gate("T", [0])], use_classical_simplification=False)
+    # Force metrics that make decision diagrams unattractive
+    c.sparsity = 0.0
+    c.phase_rotation_diversity = 100
+    c.amplitude_rotation_diversity = 100
+    return c
+
+
+def test_planner_raises_no_feasible_backend_for_tight_memory():
+    planner = Planner()
+    circuit = _t_gate_circuit()
+    with pytest.raises(NoFeasibleBackendError):
+        planner.plan(circuit, max_memory=1000)
+
+
+def test_planner_selects_backend_when_memory_sufficient():
+    planner = Planner()
+    circuit = _t_gate_circuit()
+    result = planner.plan(circuit, max_memory=10**8)
+    assert result.steps[0].backend == Backend.STATEVECTOR


### PR DESCRIPTION
## Summary
- add `NoFeasibleBackendError` and raise when no backend meets resource limits
- document and propagate the new exception in the partitioner and planner
- test that tight memory limits surface the error while looser limits choose a backend

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68c2b5b35fe483218eb16d73aac56e27