### PR TITLE
Inspect planned SSD and handle planner errors

### DIFF
--- a/benchmarks/notebooks/large_scale_partitioning.ipynb
+++ b/benchmarks/notebooks/large_scale_partitioning.ipynb
@@ -1,89 +1,112 @@
 {
- "cells": [
-  {
-   "cell_type": "markdown",
-   "id": "4615a608",
-   "metadata": {},
-   "source": [
-    "# Large-scale partitioned circuit\n",
-    "Simulate a large circuit that triggers partitioning in QuASAr and record execution metrics."
-   ]
+  "cells": [
+    {
+      "cell_type": "markdown",
+      "id": "4615a608",
+      "metadata": {},
+      "source": [
+        "# Large-scale partitioned circuit\n",
+        "Simulate a large circuit that triggers partitioning in QuASAr and record execution metrics."
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "## Expected backend transition\n",
+        "The circuit combines a stabilizer GHZ block with a non-Clifford QFT block. The planner should first use the `TABLEAU` backend and then transition to the `DECISION_DIAGRAM` backend."
+      ],
+      "id": "expected-transition"
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "id": "5008c224",
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "import json, pathlib\n",
+        "import pandas as pd\n",
+        "from quasar import Backend, NoFeasibleBackendError\n",
+        "from quasar.circuit import Circuit, Gate\n",
+        "from quasar.simulation_engine import SimulationEngine\n",
+        "from quasar.analyzer import CircuitAnalyzer\n",
+        "from benchmarks.circuits import ghz_circuit, qft_circuit\n",
+        "\n",
+        "def large_partitioned_circuit(n: int) -> Circuit:\n",
+        "    half = n // 2\n",
+        "    ghz = ghz_circuit(half, use_classical_simplification=False)\n",
+        "    qft = qft_circuit(half, use_classical_simplification=False)\n",
+        "    gates = list(ghz.gates)\n",
+        "    gates += [Gate(g.gate, [q + half for q in g.qubits], g.params) for g in qft.gates]\n",
+        "    gates += [\n",
+        "        Gate('CX', [0, half]),\n",
+        "        Gate('CX', [half - 1, n - 1]),\n",
+        "    ]\n",
+        "    return Circuit(gates, use_classical_simplification=False)\n",
+        "\n",
+        "n_qubits = 16\n",
+        "circuit = large_partitioned_circuit(n_qubits)\n",
+        "engine = SimulationEngine()\n",
+        "analyzer = CircuitAnalyzer(circuit, estimator=engine.planner.estimator)\n",
+        "analysis = analyzer.analyze()\n",
+        "results = None\n",
+        "try:\n",
+        "    plan = engine.scheduler.prepare_run(circuit, analysis=analysis)\n",
+        "    partitions = circuit.ssd.partitions\n",
+        "    assert len(partitions) == 2\n",
+        "    assert [p.backend for p in partitions] == [Backend.TABLEAU, Backend.DECISION_DIAGRAM]\n",
+        "    print([(p.backend.name, p.qubits) for p in partitions])\n",
+        "    _, metrics = engine.scheduler.run(circuit, plan, analysis=analysis, instrument=True)\n",
+        "    results = pd.DataFrame([\n",
+        "        {\n",
+        "            'runtime_s': metrics.cost.time,\n",
+        "            'peak_memory_bytes': metrics.cost.memory,\n",
+        "            'backend_switches': metrics.backend_switches,\n",
+        "            'conversions': len(metrics.conversion_durations),\n",
+        "        }\n",
+        "    ])\n",
+        "except NoFeasibleBackendError as exc:\n",
+        "    print(f'No feasible backend: {exc}')\n",
+        "results\n"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "id": "f61e3664",
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "import json, pathlib\n",
+        "try:\n",
+        "    import ipynbname\n",
+        "    nb_name = ipynbname.path().stem\n",
+        "except Exception:  # pragma: no cover\n",
+        "    nb_name = 'large_scale_partitioning'\n",
+        "params = {'qubits': n_qubits}\n",
+        "pathlib.Path('../results').mkdir(exist_ok=True)\n",
+        "with open(f'../results/{nb_name}_params.json', 'w') as f:\n",
+        "    json.dump(params, f, indent=2, default=str)\n",
+        "if results is not None:\n",
+        "    with open(f'../results/{nb_name}_results.json', 'w') as f:\n",
+        "        json.dump(results.to_dict(orient='records'), f, indent=2, default=str)\n",
+        "    print(json.dumps(params, indent=2, default=str))\n",
+        "else:\n",
+        "    print('Planning failed; no metrics recorded.')\n"
+      ]
+    }
+  ],
+  "metadata": {
+    "kernelspec": {
+      "display_name": "Python 3",
+      "language": "python",
+      "name": "python3"
+    },
+    "language_info": {
+      "name": "python"
+    }
   },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "5008c224",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "import json, pathlib\n",
-    "import pandas as pd\n",
-    "from quasar.circuit import Circuit, Gate\n",
-    "from quasar.simulation_engine import SimulationEngine\n",
-    "from quasar.analyzer import CircuitAnalyzer\n",
-    "from benchmarks.circuits import ghz_circuit, qft_circuit\n",
-    "\n",
-    "def large_partitioned_circuit(n: int) -> Circuit:\n",
-    "    half = n // 2\n",
-    "    ghz = ghz_circuit(half, use_classical_simplification=False)\n",
-    "    qft = qft_circuit(half, use_classical_simplification=False)\n",
-    "    gates = list(ghz.gates)\n",
-    "    gates += [Gate(g.gate, [q + half for q in g.qubits], g.params) for g in qft.gates]\n",
-    "    gates += [\n",
-    "        Gate('CX', [0, half]),\n",
-    "        Gate('CX', [half - 1, n - 1]),\n",
-    "    ]\n",
-    "    return Circuit(gates, use_classical_simplification=False)\n",
-    "\n",
-    "n_qubits = 16\n",
-    "circuit = large_partitioned_circuit(n_qubits)\n",
-    "engine = SimulationEngine()\n",
-    "analyzer = CircuitAnalyzer(circuit, estimator=engine.planner.estimator)\n",
-    "analysis = analyzer.analyze()\n",
-    "plan = engine.planner.plan(circuit, analysis=analysis)\n",
-    "_, metrics = engine.scheduler.run(circuit, plan, analysis=analysis, instrument=True)\n",
-    "results = pd.DataFrame([{\n",
-    "    'runtime_s': metrics.cost.time,\n",
-    "    'peak_memory_bytes': metrics.cost.memory,\n",
-    "    'backend_switches': metrics.backend_switches,\n",
-    "    'conversions': len(metrics.conversion_durations),\n",
-    "}])\n",
-    "results"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "f61e3664",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "import json, pathlib\n",
-    "try:\n",
-    "    import ipynbname\n",
-    "    nb_name = ipynbname.path().stem\n",
-    "except Exception:  # pragma: no cover\n",
-    "    nb_name = 'large_scale_partitioning'\n",
-    "params = {'qubits': n_qubits}\n",
-    "pathlib.Path('../results').mkdir(exist_ok=True)\n",
-    "with open(f\"../results/{nb_name}_params.json\", 'w') as f:\n",
-    "    json.dump(params, f, indent=2, default=str)\n",
-    "with open(f\"../results/{nb_name}_results.json\", 'w') as f:\n",
-    "    json.dump(results.to_dict(orient='records'), f, indent=2, default=str)\n",
-    "print(json.dumps(params, indent=2, default=str))\n"
-   ]
-  }
- ],
- "metadata": {
-  "kernelspec": {
-   "display_name": "Python 3",
-   "language": "python",
-   "name": "python3"
-  },
-  "language_info": {
-   "name": "python"
-  }
- },
- "nbformat": 4,
- "nbformat_minor": 5
+  "nbformat": 4,
+  "nbformat_minor": 5
 }


### PR DESCRIPTION
## Summary
- Add documentation about expected Tableau→Decision Diagram transition
- Inspect planned SSD partitions and assert backend types before simulation
- Catch and report `NoFeasibleBackendError` and write metrics only on successful runs

## Testing
- `pytest` (fails: assert 0.06419345199992676 == 0.05 ± 0.005)


------
https://chatgpt.com/codex/tasks/task_e_68c2bcbba30083219504d72b8188c918