### PR TITLE
Visualize partitioning thresholds via cost model

### DIFF
--- a/docs/partitioning_thresholds.ipynb
+++ b/docs/partitioning_thresholds.ipynb
@@ -1,0 +1,191 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "851e15e9",
+   "metadata": {},
+   "source": [
+    "# Partitioning Thresholds in QuASAr\n",
+    "\n",
+    "This notebook derives theoretical thresholds for when QuASAr's planner switches simulation methods and introduces circuit partitions.  The estimates are based solely on the calibrated cost model and therefore provide insight into the planner's decisions independent of empirical runtime measurements."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "f8497664",
+   "metadata": {},
+   "source": [
+    "## Methodology\n",
+    "\n",
+    "QuASAr incrementally grows a fragment of the input circuit and uses a `MethodSelector` to estimate the cost of running that fragment on the available simulation backends.  Whenever the cheapest backend changes for the extended fragment, the planner finalises the current partition and starts a new one.  The `CostEstimator` exposes analytic runtime and memory models for:\n",
+    "\n",
+    "* Dense statevector simulation (`Backend.STATEVECTOR`)\n",
+    "* Stabilizer tableau methods (`Backend.TABLEAU`)\n",
+    "* Matrix product states (`Backend.MPS`)\n",
+    "* Decision diagrams (`Backend.DECISION_DIAGRAM`)\n",
+    "\n",
+    "The following sections compare these cost models to highlight cross-over points where a different backend becomes cheaper.  These cross-overs act as theoretical thresholds for partitioning.  Conversion costs between backends are estimated using primitives such as boundary-to-boundary (B2B) extraction and local windows (LW)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "594861b2",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from quasar.cost import CostEstimator, Backend\n",
+    "import numpy as np\n",
+    "import matplotlib.pyplot as plt\n",
+    "\n",
+    "estimator = CostEstimator()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "cf200ec8",
+   "metadata": {},
+   "source": [
+    "### Tableau vs. Statevector\n",
+    "The tableau simulator handles Clifford-only circuits in \\(O(n^2)\\) time, whereas dense statevector simulation scales with \\(2^n\\).  The plot below assumes ten Clifford gates per qubit and shows where the tableau model becomes cheaper."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "05e44c29",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "n_range = np.arange(1, 15)\n",
+    "sv_times = []\n",
+    "tab_times = []\n",
+    "for n in n_range:\n",
+    "    g = 10 * n\n",
+    "    sv_times.append(estimator.statevector(n, g, 0, 0).time)\n",
+    "    tab_times.append(estimator.tableau(n, g).time)\n",
+    "sv_times = np.array(sv_times)\n",
+    "tab_times = np.array(tab_times)\n",
+    "# first qubit count where tableau is cheaper\n",
+    "crossover = n_range[np.argmax(tab_times < sv_times)]\n",
+    "plt.plot(n_range, sv_times, label=\"Statevector\")\n",
+    "plt.plot(n_range, tab_times, label=\"Tableau\")\n",
+    "plt.axvline(crossover, color=\"k\", linestyle=\"--\", label=f\"threshold={crossover}\")\n",
+    "plt.xlabel(\"qubits\")\n",
+    "plt.ylabel(\"estimated runtime\")\n",
+    "plt.title(\"Clifford fragment cost\")\n",
+    "plt.legend()\n",
+    "plt.show()\n",
+    "print(f\"Tableau becomes cheaper from {crossover} qubits onwards\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "49a3b162",
+   "metadata": {},
+   "source": [
+    "### MPS vs. Statevector\n",
+    "For local circuits the matrix-product-state (MPS) backend scales with the bond dimension \\(\\chi\\) instead of \\(2^n\\).  We assume a linear nearest-neighbour circuit with five single- and two-qubit gates per qubit and \\(\\chi=4\\)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "8eca5174",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "n_range = np.arange(2, 15)\n",
+    "sv_times = []\n",
+    "mps_times = []\n",
+    "for n in n_range:\n",
+    "    num_1q = 5 * n\n",
+    "    num_2q = 5 * (n - 1)\n",
+    "    sv_times.append(estimator.statevector(n, num_1q, num_2q, 0).time)\n",
+    "    mps_times.append(estimator.mps(n, num_1q, num_2q, chi=4, svd=True).time)\n",
+    "sv_times = np.array(sv_times)\n",
+    "mps_times = np.array(mps_times)\n",
+    "crossover = n_range[np.argmax(mps_times < sv_times)]\n",
+    "plt.plot(n_range, sv_times, label=\"Statevector\")\n",
+    "plt.plot(n_range, mps_times, label=\"MPS\")\n",
+    "plt.axvline(crossover, color=\"k\", linestyle=\"--\", label=f\"threshold={crossover}\")\n",
+    "plt.xlabel(\"qubits\")\n",
+    "plt.ylabel(\"estimated runtime\")\n",
+    "plt.title(\"Local circuit cost\")\n",
+    "plt.legend()\n",
+    "plt.show()\n",
+    "print(f\"MPS becomes cheaper from {crossover} qubits onwards\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "4096f094",
+   "metadata": {},
+   "source": [
+    "### Decision Diagram vs. Statevector\n",
+    "Decision diagrams excel on sparse states.  Here we ignore sparsity heuristics and simply compare the cost models for a circuit with ten gates per qubit."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "966f4a6f",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "n_range = np.arange(1, 20)\n",
+    "sv_times = []\n",
+    "dd_times = []\n",
+    "for n in n_range:\n",
+    "    g = 10 * n\n",
+    "    sv_times.append(estimator.statevector(n, g, 0, 0).time)\n",
+    "    dd_times.append(estimator.decision_diagram(num_gates=g, frontier=n).time)\n",
+    "sv_times = np.array(sv_times)\n",
+    "dd_times = np.array(dd_times)\n",
+    "plt.plot(n_range, sv_times, label=\"Statevector\")\n",
+    "plt.plot(n_range, dd_times, label=\"Decision diagram\")\n",
+    "plt.xlabel(\"qubits\")\n",
+    "plt.ylabel(\"estimated runtime\")\n",
+    "plt.title(\"Sparse circuit cost\")\n",
+    "plt.legend()\n",
+    "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "471d7260",
+   "metadata": {},
+   "source": [
+    "### Conversion Primitive Selection\n",
+    "When switching between backends, the planner chooses the cheapest conversion primitive.  The example below converts a boundary of size \\(q\\) from a statevector to a decision diagram and shows which primitive minimises the cost."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "d12804ec",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "qs = np.arange(1, 10)\n",
+    "primitives = []\n",
+    "costs = []\n",
+    "for q in qs:\n",
+    "    conv = estimator.conversion(Backend.STATEVECTOR, Backend.DECISION_DIAGRAM,\n",
+    "                                num_qubits=q, rank=2**q, frontier=q)\n",
+    "    primitives.append(conv.primitive)\n",
+    "    costs.append(conv.cost.time)\n",
+    "plt.plot(qs, costs, marker='o')\n",
+    "for q, p, c in zip(qs, primitives, costs):\n",
+    "    plt.text(q, c, p, ha='center', va='bottom')\n",
+    "plt.xlabel('boundary size q')\n",
+    "plt.ylabel('conversion time')\n",
+    "plt.title('Conversion primitive by boundary size')\n",
+    "plt.show()"
+   ]
+  }
+ ],
+ "metadata": {},
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
## Summary
- add notebook exploring cost-model crossovers for backend selection
- illustrate conversion primitive costs as function of boundary size

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68c2c768af908321b62d6a8f62be5b34