### PR TITLE
Remove classical simplification flags from benchmark circuits

### DIFF
--- a/benchmarks/benchmark_cli.py
+++ b/benchmarks/benchmark_cli.py
@@ -64,20 +64,15 @@ def run_suite(
     engine = SimulationEngine()
     results = []
     for n in qubits:
-        try:
-            circuit = circuit_fn(
-                n, use_classical_simplification=use_classical_simplification
-            )
-        except TypeError:
-            circuit = circuit_fn(n)
-            if use_classical_simplification:
-                enable = getattr(circuit, "enable_classical_simplification", None)
-                if callable(enable):
-                    enable()
-                else:
-                    circuit.use_classical_simplification = True
+        circuit = circuit_fn(n)
+        if use_classical_simplification:
+            enable = getattr(circuit, "enable_classical_simplification", None)
+            if callable(enable):
+                enable()
             else:
-                circuit.use_classical_simplification = False
+                circuit.use_classical_simplification = True
+        else:
+            circuit.use_classical_simplification = False
         if is_clifford(circuit):
             continue
         runner = BenchmarkRunner()

--- a/benchmarks/circuits.py
+++ b/benchmarks/circuits.py
@@ -31,17 +31,15 @@ def is_clifford(circuit: Circuit) -> bool:
     return all(g.gate in CLIFFORD_GATES for g in circuit.gates)
 
 
-def ghz_circuit(
-    n_qubits: int, *, use_classical_simplification: bool = False
-) -> Circuit:
+def ghz_circuit(n_qubits: int) -> Circuit:
     """Create an ``n_qubits`` GHZ state preparation circuit."""
     gates: List[Gate] = []
     if n_qubits <= 0:
-        return Circuit(gates, use_classical_simplification=use_classical_simplification)
+        return Circuit(gates)
     gates.append(Gate("H", [0]))
     for i in range(1, n_qubits):
         gates.append(Gate("CX", [i - 1, i]))
-    return Circuit(gates, use_classical_simplification=use_classical_simplification)
+    return Circuit(gates)
 
 
 def _qft_spec(n: int) -> List[Gate]:
@@ -69,30 +67,16 @@ def _iqft_spec(n: int) -> List[Gate]:
     return gates
 
 
-def qft_circuit(
-    n_qubits: int, *, use_classical_simplification: bool = False
-) -> Circuit:
+def qft_circuit(n_qubits: int) -> Circuit:
     """Create an ``n_qubits`` quantum Fourier transform circuit."""
-    return Circuit(
-        _qft_spec(n_qubits),
-        use_classical_simplification=use_classical_simplification,
-    )
+    return Circuit(_qft_spec(n_qubits))
 
 
-def qft_on_ghz_circuit(
-    n_qubits: int, *, use_classical_simplification: bool = False
-) -> Circuit:
+def qft_on_ghz_circuit(n_qubits: int) -> Circuit:
     """Apply the QFT to a GHZ state."""
-    ghz = ghz_circuit(
-        n_qubits, use_classical_simplification=use_classical_simplification
-    )
-    qft = qft_circuit(
-        n_qubits, use_classical_simplification=use_classical_simplification
-    )
-    return Circuit(
-        list(ghz.gates) + list(qft.gates),
-        use_classical_simplification=use_classical_simplification,
-    )
+    ghz = ghz_circuit(n_qubits)
+    qft = qft_circuit(n_qubits)
+    return Circuit(list(ghz.gates) + list(qft.gates))
 
 
 def _w_state_spec(n: int) -> List[Gate]:
@@ -115,12 +99,10 @@ def _w_state_spec(n: int) -> List[Gate]:
     return gates
 
 
-def w_state_circuit(
-    n_qubits: int, *, use_classical_simplification: bool = False
-) -> Circuit:
+def w_state_circuit(n_qubits: int) -> Circuit:
     """Create an ``n_qubits`` W state preparation circuit."""
     gates = _w_state_spec(n_qubits)
-    return Circuit(gates, use_classical_simplification=use_classical_simplification)
+    return Circuit(gates)
 
 
 def grover_circuit(n_qubits: int, n_iterations: int = 1) -> Circuit:
@@ -169,12 +151,7 @@ def grover_circuit(n_qubits: int, n_iterations: int = 1) -> Circuit:
     return Circuit(gates)
 
 
-def bernstein_vazirani_circuit(
-    n_qubits: int,
-    secret: int = 0,
-    *,
-    use_classical_simplification: bool = False,
-) -> Circuit:
+def bernstein_vazirani_circuit(n_qubits: int, secret: int = 0) -> Circuit:
     """Create a Bernstein-Vazirani circuit for a given secret string.
 
     Args:
@@ -187,7 +164,7 @@ def bernstein_vazirani_circuit(
 
     gates: List[Gate] = []
     if n_qubits <= 0:
-        return Circuit(gates, use_classical_simplification=use_classical_simplification)
+        return Circuit(gates)
 
     anc = n_qubits
 
@@ -208,7 +185,7 @@ def bernstein_vazirani_circuit(
     for q in range(n_qubits):
         gates.append(Gate("H", [q]))
 
-    return Circuit(gates, use_classical_simplification=use_classical_simplification)
+    return Circuit(gates)
 
 
 def amplitude_estimation_circuit(num_qubits: int, probability: float) -> Circuit:
@@ -424,7 +401,7 @@ def adder_circuit(num_qubits: int, kind: str = "cdkm") -> Circuit:
         gates = _vbe_adder_gates(num_qubits)
     else:
         raise ValueError("Unknown adder kind")
-    return Circuit(gates, use_classical_simplification=False)
+    return Circuit(gates)
 
 
 def deutsch_jozsa_circuit(num_qubits: int, balanced: bool = True) -> Circuit:
@@ -578,12 +555,7 @@ def quantum_walk_circuit(num_qubits: int, depth: int) -> Circuit:
     return Circuit(gates)
 
 
-def random_circuit(
-    num_qubits: int,
-    seed: int | None = None,
-    *,
-    use_classical_simplification: bool = False,
-) -> Circuit:
+def random_circuit(num_qubits: int, seed: int | None = None) -> Circuit:
     """Generate a random circuit of depth ``2*num_qubits``."""
 
     rng = np.random.default_rng(seed)
@@ -613,7 +585,7 @@ def random_circuit(
                     gates.append(Gate("RZZ", [int(a), int(b)], {"theta": angle}))
                 else:
                     gates.append(Gate(gate, [int(a), int(b)]))
-    return Circuit(gates, use_classical_simplification=use_classical_simplification)
+    return Circuit(gates)
 
 
 def shor_circuit(circuit_size: int) -> Circuit:
@@ -734,7 +706,7 @@ def vqe_chain_circuit(num_qubits: int = 6, depth: int = 2) -> Circuit:
     """Parameterized VQE ansatz with linear entanglement chain."""
 
     gates = _two_local_gates(num_qubits, depth, "linear", ["RY", "RZ"])
-    return Circuit(gates, use_classical_simplification=False)
+    return Circuit(gates)
 
 
 def random_hybrid_circuit(num_qubits: int = 6, depth: int = 10, seed: int | None = None) -> Circuit:

--- a/benchmarks/extensive_circuits.py
+++ b/benchmarks/extensive_circuits.py
@@ -39,13 +39,13 @@ def dual_ghz_qft_circuit(width: int) -> Circuit:
     if width <= 0:
         return Circuit([])
 
-    ghz_a = ghz_circuit(width, use_classical_simplification=False)
-    ghz_b = ghz_circuit(width, use_classical_simplification=False)
+    ghz_a = ghz_circuit(width)
+    ghz_b = ghz_circuit(width)
     gates = list(ghz_a.gates)
     gates.extend(_shift_gates(ghz_b.gates, width))
-    qft = qft_circuit(2 * width, use_classical_simplification=False)
+    qft = qft_circuit(2 * width)
     gates.extend(qft.gates)
-    return Circuit(gates, use_classical_simplification=False)
+    return Circuit(gates)
 
 
 def adder_ghz_qaoa_circuit(
@@ -80,14 +80,14 @@ def adder_ghz_qaoa_circuit(
 
     adder = adder_circuit(bit_width, kind=adder_kind)
     adder_qubits = 2 * bit_width + 2
-    ghz = ghz_circuit(bit_width, use_classical_simplification=False)
+    ghz = ghz_circuit(bit_width)
 
     gates = list(adder.gates)
     gates.extend(_shift_gates(ghz.gates, adder_qubits))
     total_qubits = adder_qubits + bit_width
     qaoa = qaoa_circuit(total_qubits, repetitions=qaoa_layers)
     gates.extend(qaoa.gates)
-    return Circuit(gates, use_classical_simplification=False)
+    return Circuit(gates)
 
 
 __all__ = ["dual_ghz_qft_circuit", "adder_ghz_qaoa_circuit"]

--- a/benchmarks/large_scale_circuits.py
+++ b/benchmarks/large_scale_circuits.py
@@ -75,7 +75,7 @@ def ripple_carry_modular_circuit(
     if modulus is None:
         gates = list(adder_gates)
         gates.append(Gate("T", [0]))
-        return Circuit(gates, use_classical_simplification=False)
+        return Circuit(gates)
 
     n = bit_width
     gates: List[Gate] = []
@@ -114,7 +114,7 @@ def ripple_carry_modular_circuit(
         if bit == "1":
             gates.append(Gate("X", [prod[idx]]))
 
-    return Circuit(gates, use_classical_simplification=False)
+    return Circuit(gates)
 
 
 def surface_code_cycle(distance: int, rounds: int = 1, scheme: str = "surface") -> Circuit:
@@ -179,7 +179,7 @@ def surface_code_cycle(distance: int, rounds: int = 1, scheme: str = "surface") 
                     gates.append(Gate("CZ", [anc, q2]))
                     gates.append(Gate("H", [anc]))
 
-    return Circuit(gates, use_classical_simplification=False)
+    return Circuit(gates)
 
 
 def grover_with_oracle_circuit(
@@ -239,7 +239,7 @@ def grover_with_oracle_circuit(
         for q in range(n_qubits):
             gates.append(Gate("H", [q]))
 
-    return Circuit(gates, use_classical_simplification=False)
+    return Circuit(gates)
 
 
 def deep_qaoa_circuit(graph: nx.Graph, p_layers: int) -> Circuit:

--- a/benchmarks/run_benchmarks.py
+++ b/benchmarks/run_benchmarks.py
@@ -49,20 +49,15 @@ def run_all(
     records: list[dict[str, object]] = []
 
     for n in qubits:
-        try:
-            circuit = circuit_fn(
-                n, use_classical_simplification=use_classical_simplification
-            )
-        except TypeError:
-            circuit = circuit_fn(n)
-            if use_classical_simplification:
-                enable = getattr(circuit, "enable_classical_simplification", None)
-                if callable(enable):
-                    enable()
-                else:
-                    circuit.use_classical_simplification = True
+        circuit = circuit_fn(n)
+        if use_classical_simplification:
+            enable = getattr(circuit, "enable_classical_simplification", None)
+            if callable(enable):
+                enable()
             else:
-                circuit.use_classical_simplification = False
+                circuit.use_classical_simplification = True
+        else:
+            circuit.use_classical_simplification = False
 
         if is_clifford(circuit):
             continue

--- a/docs/backend_selection.md
+++ b/docs/backend_selection.md
@@ -82,8 +82,7 @@ pure Clifford circuit and selects the ``STIM`` backend:
 from benchmarks.circuits import qft_circuit
 from quasar import Backend, SimulationEngine
 
-circ = qft_circuit(5, use_classical_simplification=True)
-circ.simplify_classical_controls()  # must run before planning
+circ = qft_circuit(5)
 plan = SimulationEngine().planner.plan(circ)
 assert plan.final_backend == Backend.STIM
 ```

--- a/tests/test_large_partitioned_circuit.py
+++ b/tests/test_large_partitioned_circuit.py
@@ -1,13 +1,13 @@
 from quasar import Circuit, Gate, Backend, Partitioner
-from benchmarks.circuits import ghz_circuit, qft_circuit
+from benchmarks.circuits import ghz_circuit, _qft_spec
 
 
 def large_partitioned_circuit(n: int) -> Circuit:
     half = n // 2
-    ghz = ghz_circuit(half, use_classical_simplification=False)
-    qft = qft_circuit(half, use_classical_simplification=False)
+    ghz = ghz_circuit(half)
+    qft_gates = _qft_spec(half)
     gates = list(ghz.gates)
-    gates += [Gate(g.gate, [q + half for q in g.qubits], g.params) for g in qft.gates]
+    gates += [Gate(g.gate, [q + half for q in g.qubits], g.params) for g in qft_gates]
     gates += [
         Gate("CX", [0, half]),
         Gate("CX", [half - 1, n - 1]),

--- a/tests/test_memory_summary.py
+++ b/tests/test_memory_summary.py
@@ -52,7 +52,7 @@ def measure_memory(circuit: Circuit) -> Dict[str, float]:
 
 def circuits() -> Dict[str, Circuit]:
     return {
-        "ghz3": ghz_circuit(3, use_classical_simplification=False),
+        "ghz3": ghz_circuit(3),
         "clifford_ec": clifford_ec_circuit(),
     }
 

--- a/tests/test_planner_cost_gap_cdf.py
+++ b/tests/test_planner_cost_gap_cdf.py
@@ -6,18 +6,20 @@ from quasar.circuit import Circuit
 from quasar.planner import Planner, _simulation_cost, _supported_backends
 from benchmarks.circuits import (
     ghz_circuit,
-    qft_circuit,
-    qft_on_ghz_circuit,
+    _qft_spec,
     w_state_circuit,
     grover_circuit,
 )
 
 
 def circuits() -> dict[str, Circuit]:
+    ghz = ghz_circuit(4)
+    qft = Circuit(_qft_spec(4), use_classical_simplification=False)
+    qft_on_ghz = Circuit(list(ghz.gates) + _qft_spec(4), use_classical_simplification=False)
     return {
-        "ghz4": ghz_circuit(4),
-        "qft4": qft_circuit(4),
-        "qft_on_ghz4": qft_on_ghz_circuit(4),
+        "ghz4": ghz,
+        "qft4": qft,
+        "qft_on_ghz4": qft_on_ghz,
         "w4": w_state_circuit(4),
         "grover4": grover_circuit(4, 1),
     }

--- a/tests/test_recovery_backends.py
+++ b/tests/test_recovery_backends.py
@@ -3,7 +3,7 @@ import pytest
 from quasar.planner import Planner
 from quasar.circuit import Circuit, Gate
 from quasar.cost import Backend
-from benchmarks.circuits import ghz_circuit, qft_circuit
+from benchmarks.circuits import ghz_circuit, _qft_spec
 
 
 def compute_backends() -> dict[str, tuple[Backend, Backend, Backend]]:
@@ -15,7 +15,7 @@ def compute_backends() -> dict[str, tuple[Backend, Backend, Backend]]:
     minor = Circuit(
         list(baseline.gates) + [Gate("H", [0])], use_classical_simplification=False
     )
-    major = qft_circuit(5)
+    major = Circuit(_qft_spec(5), use_classical_simplification=False)
     perturbations = {"minor": minor, "major": major}
 
     metrics: dict[str, tuple[Backend, Backend, Backend]] = {}

--- a/tests/test_reoptimization_timeline.py
+++ b/tests/test_reoptimization_timeline.py
@@ -1,6 +1,7 @@
 
 from quasar.planner import Planner
-from benchmarks.circuits import ghz_circuit, qft_circuit
+from quasar.circuit import Circuit
+from benchmarks.circuits import ghz_circuit, _qft_spec
 
 
 def test_reoptimization_timeline() -> None:
@@ -10,7 +11,7 @@ def test_reoptimization_timeline() -> None:
     baseline = ghz_circuit(4)
     base_plan = planner.plan(baseline)
 
-    perturbed = qft_circuit(4)
+    perturbed = Circuit(_qft_spec(4), use_classical_simplification=False)
     pert_plan = planner.plan(perturbed)
 
     # Planner should detect change in circuit and adjust backend.


### PR DESCRIPTION
## Summary
- remove `use_classical_simplification` parameter from benchmark circuit generators
- update benchmarking scripts, docs, and tests to construct circuits without manual flags

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c7ca9a86f48321850d3c1c9dd039bb