### PR TITLE
Add CCZ gate decomposition and preprocessing

### DIFF
--- a/quasar/backends/mps.py
+++ b/quasar/backends/mps.py
@@ -132,8 +132,10 @@ class MPSBackend(Backend):
         if self.circuit is None:
             raise RuntimeError("Backend not initialised; call 'load' first")
         lname = name.upper()
-        if lname == "CCX":
-            raise NotImplementedError("CCX gates must be decomposed before execution")
+        if lname in {"CCX", "CCZ"}:
+            raise NotImplementedError(
+                "CCX and CCZ gates must be decomposed before execution"
+            )
         self.history.append(lname)
         if lname == "RX":
             self.circuit.rx(self._param(params, 0), qubits[0])

--- a/quasar/backends/mqt_dd.py
+++ b/quasar/backends/mqt_dd.py
@@ -108,8 +108,10 @@ class DecisionDiagramBackend(Backend):
             raise TypeError("Backend state is not a VectorDD")
 
         lname = name.upper()
-        if lname == "CCX":
-            raise NotImplementedError("CCX gates must be decomposed before execution")
+        if lname in {"CCX", "CCZ"}:
+            raise NotImplementedError(
+                "CCX and CCZ gates must be decomposed before execution"
+            )
         if lname == "CP" and params and "k" in params:
             theta = 2 * np.pi / (2 ** float(params["k"]))
             param_list = [theta]

--- a/quasar/backends/statevector.py
+++ b/quasar/backends/statevector.py
@@ -111,8 +111,10 @@ class StatevectorBackend(Backend):
         if self.circuit is None:
             raise RuntimeError("Backend not initialised; call 'load' first")
         lname = name.upper()
-        if lname == "CCX":
-            raise NotImplementedError("CCX gates must be decomposed before execution")
+        if lname in {"CCX", "CCZ"}:
+            raise NotImplementedError(
+                "CCX and CCZ gates must be decomposed before execution"
+            )
         self.history.append(lname)
         if lname == "RX":
             self.circuit.rx(self._param(params, 0), qubits[0])

--- a/quasar/backends/stim_backend.py
+++ b/quasar/backends/stim_backend.py
@@ -91,8 +91,10 @@ class StimBackend(Backend):
         if self.simulator is None:
             raise RuntimeError("Backend not initialised; call 'load' first")
         lname = self._ALIASES.get(name.upper(), name.lower())
-        if lname == "ccx":
-            raise NotImplementedError("CCX gates must be decomposed before execution")
+        if lname in {"ccx", "ccz"}:
+            raise NotImplementedError(
+                "CCX and CCZ gates must be decomposed before execution"
+            )
         if lname == "i" or lname == "id":
             self.history.append(name.upper())
             return

--- a/quasar/circuit.py
+++ b/quasar/circuit.py
@@ -13,7 +13,7 @@ from qiskit_qasm3_import import api as qasm3_api
 
 from .ssd import SSD, SSDPartition
 from .cost import Cost, CostEstimator, Backend
-from .decompositions import decompose_ccx
+from .decompositions import decompose_ccx, decompose_ccz
 
 
 def _is_multiple_of_pi(angle: float) -> bool:
@@ -119,6 +119,9 @@ class Circuit:
             if name == "CCX":
                 c1, c2, t = gate.qubits
                 expanded.extend(decompose_ccx(c1, c2, t))
+            elif name == "CCZ":
+                c1, c2, t = gate.qubits
+                expanded.extend(decompose_ccz(c1, c2, t))
             else:
                 expanded.append(gate)
         self.gates = expanded

--- a/quasar/decompositions.py
+++ b/quasar/decompositions.py
@@ -1,8 +1,8 @@
 """Gate decomposition utilities for QuASAr.
 
 This module provides helpers for expanding multi-controlled gates into
-sequences of supported elementary operations. Currently only the Toffoli
-(``CCX``) gate is implemented.
+sequences of supported elementary operations. Currently the Toffoli
+(``CCX``) and controlled-controlled-Z (``CCZ``) gates are implemented.
 """
 
 from __future__ import annotations
@@ -47,4 +47,33 @@ def decompose_ccx(control1: int, control2: int, target: int) -> List["Gate"]:
     ]
 
 
-__all__ = ["decompose_ccx"]
+def decompose_ccz(control1: int, control2: int, target: int) -> List["Gate"]:
+    r"""Return a decomposition of a controlled-controlled-Z (``CCZ``) gate.
+
+    The implementation follows the standard relation
+
+    .. math:: CCZ = H_t \cdot CCX \cdot H_t,
+
+    where ``CCX`` is decomposed into a sequence of single- and two-qubit
+    gates.  The resulting gate list therefore contains only operations that
+    are natively supported by the various backends (``H``, ``T``, ``TDG`` and
+    ``CX``).
+
+    Parameters
+    ----------
+    control1, control2, target:
+        Indices of the first control, second control and target qubits.
+    """
+
+    from .circuit import Gate
+
+    # ``CCZ`` can be implemented as ``H`` on the target, followed by a
+    # ``CCX`` and another ``H``.  We purposely keep the full Toffoli
+    # decomposition including its leading Hadamard to preserve the correct
+    # phase relationships, even though this results in two consecutive ``H``
+    # gates at the start of the sequence.
+    ccx_sequence = decompose_ccx(control1, control2, target)
+    return [Gate("H", [target]), *ccx_sequence, Gate("H", [target])]
+
+
+__all__ = ["decompose_ccx", "decompose_ccz"]

--- a/tests/test_ccz_decomposition.py
+++ b/tests/test_ccz_decomposition.py
@@ -1,0 +1,35 @@
+import numpy as np
+from qiskit import QuantumCircuit
+from qiskit.quantum_info import Operator
+
+from quasar.circuit import Gate, Circuit
+
+
+def _matrix_from_gates(gates, num_qubits):
+    qc = QuantumCircuit(num_qubits)
+    for gate in gates:
+        name = gate.gate.upper()
+        if name == "H":
+            qc.h(gate.qubits[0])
+        elif name == "T":
+            qc.t(gate.qubits[0])
+        elif name == "TDG":
+            qc.tdg(gate.qubits[0])
+        elif name == "CX":
+            qc.cx(gate.qubits[0], gate.qubits[1])
+        else:  # pragma: no cover - not expected in this test
+            raise ValueError(f"Unsupported gate {name}")
+    return Operator(qc).data
+
+
+def test_ccz_decomposition_unitary() -> None:
+    """Decomposed CCZ should match the native controlled-controlled-Z."""
+    for n in range(3, 6):
+        circ = Circuit([Gate("CCZ", [0, 1, 2])], use_classical_simplification=False)
+        assert all(g.gate.upper() != "CCZ" for g in circ.gates)
+        decomp = _matrix_from_gates(circ.gates, n)
+        native_circuit = QuantumCircuit(n)
+        native_circuit.ccz(0, 1, 2)
+        native = Operator(native_circuit).data
+        assert np.allclose(decomp, native)
+


### PR DESCRIPTION
## Summary
- add `decompose_ccz` using H, T/TDG and CX gates
- expand circuit preprocessing to replace `CCZ` gates
- guard backends against undecomposed `CCZ` gates
- test CCZ decomposition against native unitary

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c7d3cbf0a08321bc31bb22fe268eee