### PR TITLE
Add generic MCX decomposition using ancillas

### DIFF
--- a/docs/mcx_decomposition.md
+++ b/docs/mcx_decomposition.md
@@ -1,0 +1,13 @@
+# Multi-controlled X Decomposition
+
+QuASAr provides a generic expansion for multi-controlled X (MCX) gates through
+``decompose_mcx``.  An MCX with ``n`` control qubits is reduced to a sequence of
+Toffoli gates and single-qubit rotations.  The algorithm introduces ``n-2``
+ancillary qubits that carry partial conjunctions of the controls.  These
+ancillas are allocated using new qubit indices larger than any existing control
+or target index and are uncomputed at the end of the sequence.
+
+The approach guarantees that all ancilla qubits are returned to ``|0⟩`` but
+increases the circuit width by ``n-2`` and does not attempt to minimise the
+number of elementary gates.  Circuits that cannot spare additional qubits must
+supply their own decomposition strategy.

--- a/quasar/backends/mps.py
+++ b/quasar/backends/mps.py
@@ -132,9 +132,9 @@ class MPSBackend(Backend):
         if self.circuit is None:
             raise RuntimeError("Backend not initialised; call 'load' first")
         lname = name.upper()
-        if lname in {"CCX", "CCZ"}:
+        if lname in {"CCX", "CCZ", "MCX"}:
             raise NotImplementedError(
-                "CCX and CCZ gates must be decomposed before execution"
+                "CCX, CCZ and MCX gates must be decomposed before execution"
             )
         self.history.append(lname)
         if lname == "RX":

--- a/quasar/backends/mqt_dd.py
+++ b/quasar/backends/mqt_dd.py
@@ -108,9 +108,9 @@ class DecisionDiagramBackend(Backend):
             raise TypeError("Backend state is not a VectorDD")
 
         lname = name.upper()
-        if lname in {"CCX", "CCZ"}:
+        if lname in {"CCX", "CCZ", "MCX"}:
             raise NotImplementedError(
-                "CCX and CCZ gates must be decomposed before execution"
+                "CCX, CCZ and MCX gates must be decomposed before execution"
             )
         if lname == "CP" and params and "k" in params:
             theta = 2 * np.pi / (2 ** float(params["k"]))

--- a/quasar/backends/statevector.py
+++ b/quasar/backends/statevector.py
@@ -111,9 +111,9 @@ class StatevectorBackend(Backend):
         if self.circuit is None:
             raise RuntimeError("Backend not initialised; call 'load' first")
         lname = name.upper()
-        if lname in {"CCX", "CCZ"}:
+        if lname in {"CCX", "CCZ", "MCX"}:
             raise NotImplementedError(
-                "CCX and CCZ gates must be decomposed before execution"
+                "CCX, CCZ and MCX gates must be decomposed before execution"
             )
         self.history.append(lname)
         if lname == "RX":

--- a/quasar/backends/stim_backend.py
+++ b/quasar/backends/stim_backend.py
@@ -91,9 +91,9 @@ class StimBackend(Backend):
         if self.simulator is None:
             raise RuntimeError("Backend not initialised; call 'load' first")
         lname = self._ALIASES.get(name.upper(), name.lower())
-        if lname in {"ccx", "ccz"}:
+        if lname in {"ccx", "ccz", "mcx"}:
             raise NotImplementedError(
-                "CCX and CCZ gates must be decomposed before execution"
+                "CCX, CCZ and MCX gates must be decomposed before execution"
             )
         if lname == "i" or lname == "id":
             self.history.append(name.upper())

--- a/quasar/circuit.py
+++ b/quasar/circuit.py
@@ -13,7 +13,7 @@ from qiskit_qasm3_import import api as qasm3_api
 
 from .ssd import SSD, SSDPartition
 from .cost import Cost, CostEstimator, Backend
-from .decompositions import decompose_ccx, decompose_ccz
+from .decompositions import decompose_mcx, decompose_ccz
 
 
 def _is_multiple_of_pi(angle: float) -> bool:
@@ -116,9 +116,9 @@ class Circuit:
         expanded: List[Gate] = []
         for gate in self.gates:
             name = gate.gate.upper()
-            if name == "CCX":
-                c1, c2, t = gate.qubits
-                expanded.extend(decompose_ccx(c1, c2, t))
+            if name in {"CCX", "MCX"}:
+                *controls, target = gate.qubits
+                expanded.extend(decompose_mcx(list(controls), target))
             elif name == "CCZ":
                 c1, c2, t = gate.qubits
                 expanded.extend(decompose_ccz(c1, c2, t))

--- a/tests/test_mcx_decomposition.py
+++ b/tests/test_mcx_decomposition.py
@@ -1,0 +1,56 @@
+import numpy as np
+from qiskit import QuantumCircuit
+from qiskit.quantum_info import Operator
+
+from quasar.circuit import Circuit, Gate
+
+
+def _matrix_from_gates(gates, num_qubits):
+    qc = QuantumCircuit(num_qubits)
+    for gate in gates:
+        name = gate.gate.upper()
+        if name == "H":
+            qc.h(gate.qubits[0])
+        elif name == "T":
+            qc.t(gate.qubits[0])
+        elif name == "TDG":
+            qc.tdg(gate.qubits[0])
+        elif name == "CX":
+            qc.cx(gate.qubits[0], gate.qubits[1])
+        else:  # pragma: no cover - unsupported gate in test
+            raise ValueError(f"Unsupported gate {name}")
+    return Operator(qc).data
+
+
+def _expected_mcx(controls, target, ancillas, num_qubits):
+    qc = QuantumCircuit(num_qubits)
+    qc.mcx(controls, target, ancillas, mode="v-chain")
+    return Operator(qc).data
+
+
+def _max_index(gates):
+    return max((q for g in gates for q in g.qubits), default=-1)
+
+
+def test_mcx_three_controls():
+    controls = [0, 1, 2]
+    target = 3
+    circ = Circuit([Gate("MCX", controls + [target])], use_classical_simplification=False)
+    assert all(g.gate.upper() not in {"MCX", "CCX"} for g in circ.gates)
+    n = _max_index(circ.gates) + 1
+    ancillas = list(range(target + 1, n))
+    decomp = _matrix_from_gates(circ.gates, n)
+    expected = _expected_mcx(controls, target, ancillas, n)
+    assert np.allclose(decomp, expected)
+
+
+def test_mcx_four_controls():
+    controls = [0, 1, 2, 3]
+    target = 4
+    circ = Circuit([Gate("MCX", controls + [target])], use_classical_simplification=False)
+    assert all(g.gate.upper() not in {"MCX", "CCX"} for g in circ.gates)
+    n = _max_index(circ.gates) + 1
+    ancillas = list(range(target + 1, n))
+    decomp = _matrix_from_gates(circ.gates, n)
+    expected = _expected_mcx(controls, target, ancillas, n)
+    assert np.allclose(decomp, expected)


### PR DESCRIPTION
## Summary
- implement `decompose_mcx` to expand multi-controlled X gates via ancillary-qubit Toffoli chains
- preprocess circuits to lower `MCX`/`CCX` gates into basic gates
- document ancillary qubit requirements for MCX decomposition
- add tests for MCX with three and four controls

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c7d649dcd4832194e0d6f62cdf481e