### PR TITLE
Decompose CSWAP into two-qubit gates

### DIFF
--- a/quasar/backends/stim_backend.py
+++ b/quasar/backends/stim_backend.py
@@ -91,20 +91,11 @@ class StimBackend(Backend):
         if self.simulator is None:
             raise RuntimeError("Backend not initialised; call 'load' first")
         lname = self._ALIASES.get(name.upper(), name.lower())
-        if lname in {"ccx", "ccz", "mcx"}:
+        if lname in {"ccx", "ccz", "mcx", "cswap"}:
             raise NotImplementedError(
-                "CCX, CCZ and MCX gates must be decomposed before execution"
+                "CCX, CCZ, MCX and CSWAP gates must be decomposed before execution"
             )
         if lname == "i" or lname == "id":
-            self.history.append(name.upper())
-            return
-        if lname == "cswap":
-            c, a, b = qubits
-            self.simulator.cx(c, b)
-            self.simulator.cx(a, b)
-            self.simulator.cx(c, a)
-            self.simulator.cx(a, b)
-            self.simulator.cx(c, b)
             self.history.append(name.upper())
             return
         func = getattr(self.simulator, lname, None)

--- a/quasar/circuit.py
+++ b/quasar/circuit.py
@@ -13,7 +13,7 @@ from qiskit_qasm3_import import api as qasm3_api
 
 from .ssd import SSD, SSDPartition
 from .cost import Cost, CostEstimator, Backend
-from .decompositions import decompose_mcx, decompose_ccz
+from .decompositions import decompose_mcx, decompose_ccz, decompose_cswap
 
 
 def _is_multiple_of_pi(angle: float) -> bool:
@@ -122,6 +122,9 @@ class Circuit:
             elif name == "CCZ":
                 c1, c2, t = gate.qubits
                 expanded.extend(decompose_ccz(c1, c2, t))
+            elif name == "CSWAP":
+                c, a, b = gate.qubits
+                expanded.extend(decompose_cswap(c, a, b))
             else:
                 expanded.append(gate)
         self.gates = expanded

--- a/quasar/decompositions.py
+++ b/quasar/decompositions.py
@@ -2,7 +2,8 @@
 
 This module provides helpers for expanding multi-controlled gates into
 sequences of supported elementary operations. Currently the Toffoli
-(``CCX``) and controlled-controlled-Z (``CCZ``) gates are implemented.
+(``CCX``), controlled-controlled-Z (``CCZ``) and controlled-SWAP (``CSWAP``)
+gates are implemented.
 """
 
 from __future__ import annotations
@@ -119,4 +120,27 @@ def decompose_ccz(control1: int, control2: int, target: int) -> List["Gate"]:
     return [Gate("H", [target]), *ccx_sequence, Gate("H", [target])]
 
 
-__all__ = ["decompose_ccx", "decompose_mcx", "decompose_ccz"]
+def decompose_cswap(control: int, qubit_a: int, qubit_b: int) -> List["Gate"]:
+    """Return a decomposition of a controlled-SWAP (``CSWAP``) gate.
+
+    The Fredkin gate can be realised using three Toffoli operations sharing
+    the same control qubit.  Each ``CCX`` is further decomposed into
+    single- and two-qubit gates, yielding a sequence that contains no
+    multi-qubit primitives beyond ``CX``.
+
+    Parameters
+    ----------
+    control:
+        Index of the control qubit.
+    qubit_a, qubit_b:
+        Indices of the qubits to be swapped when the control is set.
+    """
+
+    return (
+        decompose_ccx(control, qubit_b, qubit_a)
+        + decompose_ccx(control, qubit_a, qubit_b)
+        + decompose_ccx(control, qubit_b, qubit_a)
+    )
+
+
+__all__ = ["decompose_ccx", "decompose_mcx", "decompose_ccz", "decompose_cswap"]

--- a/quasar/method_selector.py
+++ b/quasar/method_selector.py
@@ -23,7 +23,6 @@ CLIFFORD_GATES = {
     "CY",
     "CZ",
     "SWAP",
-    "CSWAP",
 }
 
 

--- a/quasar/partitioner.py
+++ b/quasar/partitioner.py
@@ -23,7 +23,6 @@ CLIFFORD_GATES = {
     "CY",
     "CZ",
     "SWAP",
-    "CSWAP",
 }
 
 

--- a/tests/test_cswap_decomposition.py
+++ b/tests/test_cswap_decomposition.py
@@ -1,0 +1,34 @@
+import numpy as np
+from qiskit import QuantumCircuit
+from qiskit.quantum_info import Operator
+
+from quasar.circuit import Gate, Circuit
+
+
+def _matrix_from_gates(gates, num_qubits):
+    qc = QuantumCircuit(num_qubits)
+    for gate in gates:
+        name = gate.gate.upper()
+        if name == "H":
+            qc.h(gate.qubits[0])
+        elif name == "T":
+            qc.t(gate.qubits[0])
+        elif name == "TDG":
+            qc.tdg(gate.qubits[0])
+        elif name == "CX":
+            qc.cx(gate.qubits[0], gate.qubits[1])
+        else:  # pragma: no cover - not expected in this test
+            raise ValueError(f"Unsupported gate {name}")
+    return Operator(qc).data
+
+
+def test_cswap_decomposition_unitary() -> None:
+    """Decomposed CSWAP should match the native Fredkin unitary."""
+    for n in range(3, 6):
+        circ = Circuit([Gate("CSWAP", [0, 1, 2])], use_classical_simplification=False)
+        assert all(g.gate.upper() not in {"CSWAP", "CCX"} for g in circ.gates)
+        decomp = _matrix_from_gates(circ.gates, n)
+        native_circuit = QuantumCircuit(n)
+        native_circuit.cswap(0, 1, 2)
+        native = Operator(native_circuit).data
+        assert np.allclose(decomp, native)


### PR DESCRIPTION
## Summary
- add `decompose_cswap` based on a triple-Toffoli pattern
- decompose CSWAP during circuit preprocessing so only 1- and 2-qubit gates remain
- drop bespoke CSWAP handling from Stim backend and prune CSWAP from Clifford gate lists
- include tests that check CSWAP decomposition against the native gate

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c7d9c0f08483219be695e4cfc27b53