### PR TITLE
Add planner diagnostics support and expose through scheduler

### DIFF
--- a/tests/test_planner_diagnostics.py
+++ b/tests/test_planner_diagnostics.py
@@ -1,0 +1,52 @@
+from __future__ import annotations
+
+from quasar.planner import Planner
+from quasar.scheduler import Scheduler
+from quasar.cost import Cost
+from benchmarks.circuits import adder_circuit
+
+
+def make_planner() -> Planner:
+    return Planner(
+        quick_max_qubits=None,
+        quick_max_gates=None,
+        quick_max_depth=None,
+    )
+
+
+def test_planner_collects_diagnostics() -> None:
+    circuit = adder_circuit(1)
+    planner = make_planner()
+
+    result = planner.plan(circuit, use_cache=False, explain=True)
+
+    diagnostics = result.diagnostics
+    assert diagnostics is not None
+    assert diagnostics.strategy is not None
+    assert isinstance(diagnostics.single_cost, Cost)
+    assert isinstance(diagnostics.pre_cost, Cost)
+    assert isinstance(diagnostics.dp_cost, Cost)
+    assert diagnostics.conversion_estimates, "expected conversion estimates to be recorded"
+
+    estimate = diagnostics.conversion_estimates[0]
+    assert estimate.stage in {"pre", "coarse", "refine"}
+    assert estimate.source is not None
+    assert estimate.boundary
+    assert isinstance(estimate.cost, Cost)
+    assert estimate.feasible in {True, False}
+
+
+def test_scheduler_prepares_diagnostics() -> None:
+    circuit = adder_circuit(1)
+    scheduler = Scheduler(
+        quick_max_qubits=None,
+        quick_max_gates=None,
+        quick_max_depth=None,
+    )
+
+    plan = scheduler.prepare_run(circuit, explain=True)
+
+    diagnostics = plan.diagnostics
+    assert diagnostics is not None
+    assert diagnostics.conversion_estimates
+    assert diagnostics.single_cost is not None


### PR DESCRIPTION
## Summary
- add planner diagnostics data structures and extend dynamic programming to record conversion cost estimates
- add an ``explain`` flag to ``Planner.plan`` and surface the diagnostics on ``Scheduler.prepare_run``
- cover the new behaviour with integration tests for planner and scheduler diagnostics

## Testing
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68c94eec8c3c8321bff4048d9db10f8a