### PR TITLE
Add backend selection diagnostics and expose via planner

### DIFF
--- a/docs/backend_selection.md
+++ b/docs/backend_selection.md
@@ -90,9 +90,9 @@ assert plan.final_backend == Backend.STIM
 ## Telemetry
 
 Backend decisions made on the quick path can be recorded for later analysis.
-Set ``QUASAR_VERBOSE_SELECTION=1`` to emit the evaluated metrics and candidate
-ranking to standard output; the planner prints similar information for each
-segment it analyses.  For persistent logs set the environment variable
+Set ``QUASAR_VERBOSE_SELECTION=1`` to emit the evaluated metrics together with
+per-backend cost estimates and rejection reasons; the planner prints the same
+diagnostics for each segment it analyses.  For persistent logs set the environment variable
 ``QUASAR_BACKEND_SELECTION_LOG`` or override
 ``config.DEFAULT.backend_selection_log`` with a filesystem path.  Each quick
 selection appends a CSV row with
@@ -106,3 +106,9 @@ Use the helper script to aggregate results across benchmark runs:
 ```bash
 python tools/analyze_backend_selection.py logs/*.csv
 ```
+
+When ``Planner.plan`` is invoked with ``explain=True`` the returned
+``PlanDiagnostics`` object exposes a ``backend_selection`` mapping with the
+same diagnostic payload.  Each entry captures the heuristics, estimated costs
+and the reasons why candidates were accepted or rejected, making it easier to
+trace planning decisions without relying solely on console output.

--- a/quasar/method_selector.py
+++ b/quasar/method_selector.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 """Backend selection based on multi-criteria constraints."""
 
-from typing import List, Tuple, TYPE_CHECKING
+from typing import Any, List, Tuple, TYPE_CHECKING
 
 from .cost import Backend, Cost, CostEstimator
 from . import config
@@ -53,6 +53,7 @@ class MethodSelector:
         max_memory: float | None = None,
         max_time: float | None = None,
         target_accuracy: float | None = None,
+        diagnostics: dict[str, Any] | None = None,
     ) -> Tuple[Backend, Cost]:
         """Return the preferred backend and its cost for ``gates``.
 
@@ -72,6 +73,13 @@ class MethodSelector:
             Upper bound on allowed runtime in seconds.
         target_accuracy:
             Desired lower bound on simulation fidelity.
+        diagnostics:
+            Optional dictionary populated with the evaluated metrics and
+            backend-specific feasibility checks.  The mapping contains a
+            ``"metrics"`` entry describing the fragment followed by a
+            ``"backends"`` mapping of :class:`Backend` values to diagnostic
+            details.  Callers may inspect the populated structure to explain
+            backend choices or rejection reasons.
 
         Raises
         ------
@@ -83,17 +91,71 @@ class MethodSelector:
         num_gates = len(gates)
         num_meas = sum(1 for g in gates if g.gate.upper() in {"MEASURE", "RESET"})
         num_1q = sum(
-            1 for g in gates if len(g.qubits) == 1 and g.gate.upper() not in {"MEASURE", "RESET"}
+            1
+            for g in gates
+            if len(g.qubits) == 1 and g.gate.upper() not in {"MEASURE", "RESET"}
         )
         num_2q = num_gates - num_1q - num_meas
 
+        diag_backends: dict[Backend, dict[str, Any]] | None = None
+        diag: dict[str, Any] | None = diagnostics
+
         # Clifford fragments can run on the tableau simulator directly.
+        if diag is not None:
+            diag_backends = {}
+            diag["backends"] = diag_backends
+            metrics = diag.setdefault("metrics", {})
+            metrics.update({
+                "num_qubits": num_qubits,
+                "num_gates": num_gates,
+            })
+        else:
+            diag_backends = None
+
         if allow_tableau and names and all(n in CLIFFORD_GATES for n in names):
             cost = self.estimator.tableau(num_qubits, num_gates)
-            if (max_memory is None or cost.memory <= max_memory) and (
-                max_time is None or cost.time <= max_time
-            ):
+            tableau_reasons: list[str] = []
+            feasible = True
+            if max_memory is not None and cost.memory > max_memory:
+                tableau_reasons.append("memory > threshold")
+                feasible = False
+            if max_time is not None and cost.time > max_time:
+                tableau_reasons.append("time > threshold")
+                feasible = False
+            if diag_backends is not None:
+                diag_backends[Backend.TABLEAU] = {
+                    "feasible": feasible,
+                    "reasons": tableau_reasons,
+                    "cost": cost,
+                }
+            if feasible:
+                if diag is not None and diag_backends is not None:
+                    diag["selected_backend"] = Backend.TABLEAU
+                    diag["selected_cost"] = cost
+                    diag_backends[Backend.TABLEAU]["selected"] = True
+                    for other in (
+                        Backend.DECISION_DIAGRAM,
+                        Backend.MPS,
+                        Backend.STATEVECTOR,
+                    ):
+                        diag_backends.setdefault(
+                            other,
+                            {
+                                "feasible": False,
+                                "reasons": [
+                                    "skipped: tableau preferred for Clifford fragment"
+                                ],
+                                "selected": False,
+                            },
+                        )
                 return Backend.TABLEAU, cost
+        else:
+            if diag_backends is not None:
+                reason = "tableau disabled" if not allow_tableau else "non-clifford gates"
+                diag_backends[Backend.TABLEAU] = {
+                    "feasible": False,
+                    "reasons": [reason] if names or not allow_tableau else ["no gates"],
+                }
 
         # ------------------------------------------------------------------
         # Heuristics for decision diagram suitability
@@ -113,6 +175,18 @@ class MethodSelector:
             and amp_rot <= amp_thresh
         )
         dd_metric = False
+        if diag is not None:
+            metrics = diag.setdefault("metrics", {})
+            metrics.update(
+                {
+                    "sparsity": sparse,
+                    "phase_rotation_diversity": phase_rot,
+                    "amplitude_rotation_diversity": amp_rot,
+                    "nnz": nnz,
+                    "local": False,
+                }
+            )
+
         if passes:
             s_score = sparse / s_thresh if s_thresh > 0 else 0.0
             nnz_score = 1 - nnz / config.DEFAULT.dd_nnz_threshold
@@ -132,6 +206,30 @@ class MethodSelector:
             )
             metric = weighted / weight_sum if weight_sum else 0.0
             dd_metric = metric >= config.DEFAULT.dd_metric_threshold
+            if diag is not None:
+                metrics = diag.setdefault("metrics", {})
+                metrics["decision_diagram_metric"] = metric
+                metrics["dd_metric_threshold"] = config.DEFAULT.dd_metric_threshold
+            if not dd_metric and diag_backends is not None:
+                diag_backends[Backend.DECISION_DIAGRAM] = {
+                    "feasible": False,
+                    "reasons": ["metric below threshold"],
+                    "metric": metric,
+                }
+        elif diag_backends is not None:
+            reasons = []
+            if sparse < s_thresh:
+                reasons.append("sparsity below threshold")
+            if nnz > config.DEFAULT.dd_nnz_threshold:
+                reasons.append("nnz above threshold")
+            if phase_rot > config.DEFAULT.dd_phase_rotation_diversity_threshold:
+                reasons.append("phase diversity above threshold")
+            if amp_rot > amp_thresh:
+                reasons.append("amplitude diversity above threshold")
+            diag_backends[Backend.DECISION_DIAGRAM] = {
+                "feasible": False,
+                "reasons": reasons,
+            }
 
         # Determine whether the fragment is local enough for MPS
         multi = [g for g in gates if len(g.qubits) > 1]
@@ -139,16 +237,36 @@ class MethodSelector:
             len(g.qubits) == 2 and abs(g.qubits[0] - g.qubits[1]) == 1 for g in multi
         )
 
+        if diag is not None:
+            diag.setdefault("metrics", {})["local"] = local
+
         candidates: dict[Backend, Cost] = {}
         if dd_metric:
             dd_cost = self.estimator.decision_diagram(num_gates=num_gates, frontier=num_qubits)
-            if (max_memory is None or dd_cost.memory <= max_memory) and (
-                max_time is None or dd_cost.time <= max_time
-            ):
+            dd_reasons: list[str] = []
+            feasible = True
+            if max_memory is not None and dd_cost.memory > max_memory:
+                dd_reasons.append("memory > threshold")
+                feasible = False
+            if max_time is not None and dd_cost.time > max_time:
+                dd_reasons.append("time > threshold")
+                feasible = False
+            if feasible:
                 candidates[Backend.DECISION_DIAGRAM] = dd_cost
+            if diag_backends is not None:
+                entry = {
+                    "feasible": feasible,
+                    "reasons": dd_reasons,
+                    "cost": dd_cost,
+                }
+                if diag is not None and "metrics" in diag and "decision_diagram_metric" in diag["metrics"]:
+                    entry["metric"] = diag["metrics"]["decision_diagram_metric"]
+                diag_backends[Backend.DECISION_DIAGRAM] = entry
 
         if local:
             chi = getattr(self.estimator, "chi_max", None) or 4
+            chi_cap: int | None = None
+            infeasible_chi = False
             if target_accuracy is not None or max_memory is not None:
                 chi_cap = self.estimator.chi_for_constraints(
                     num_qubits,
@@ -160,6 +278,8 @@ class MethodSelector:
                 )
                 if chi_cap > 0:
                     chi = chi_cap
+                else:
+                    infeasible_chi = True
             mps_cost = self.estimator.mps(
                 num_qubits,
                 num_1q + num_meas,
@@ -167,18 +287,58 @@ class MethodSelector:
                 chi=chi,
                 svd=True,
             )
-            if (max_memory is None or mps_cost.memory <= max_memory) and (
-                max_time is None or mps_cost.time <= max_time
-            ):
+            mps_reasons: list[str] = []
+            feasible = True
+            if infeasible_chi:
+                mps_reasons.append("bond dimension exceeds memory limit")
+                feasible = False
+            if max_memory is not None and mps_cost.memory > max_memory:
+                mps_reasons.append("memory > threshold")
+                feasible = False
+            if max_time is not None and mps_cost.time > max_time:
+                mps_reasons.append("time > threshold")
+                feasible = False
+            if diag_backends is not None:
+                entry = {
+                    "feasible": feasible,
+                    "reasons": mps_reasons,
+                    "cost": mps_cost,
+                    "chi": chi,
+                }
+                if chi_cap is not None:
+                    entry["chi_limit"] = chi_cap
+                diag_backends[Backend.MPS] = entry
+            if feasible:
                 candidates[Backend.MPS] = mps_cost
+        elif diag_backends is not None:
+            reason = "non-local gates" if multi else "no multi-qubit gates"
+            diag_backends[Backend.MPS] = {
+                "feasible": False,
+                "reasons": [reason],
+            }
 
         sv_cost = self.estimator.statevector(num_qubits, num_1q, num_2q, num_meas)
-        if (max_memory is None or sv_cost.memory <= max_memory) and (
-            max_time is None or sv_cost.time <= max_time
-        ):
+        sv_reasons: list[str] = []
+        sv_feasible = True
+        if max_memory is not None and sv_cost.memory > max_memory:
+            sv_reasons.append("memory > threshold")
+            sv_feasible = False
+        if max_time is not None and sv_cost.time > max_time:
+            sv_reasons.append("time > threshold")
+            sv_feasible = False
+        if sv_feasible:
             candidates[Backend.STATEVECTOR] = sv_cost
+        if diag_backends is not None:
+            diag_backends[Backend.STATEVECTOR] = {
+                "feasible": sv_feasible,
+                "reasons": sv_reasons,
+                "cost": sv_cost,
+            }
 
         if not candidates:
+            if diag is not None:
+                diag["selected_backend"] = None
+                diag["selected_cost"] = None
             raise NoFeasibleBackendError(
                 "No simulation backend satisfies the given constraints"
             )
@@ -186,4 +346,9 @@ class MethodSelector:
         backend = min(
             candidates, key=lambda b: (candidates[b].memory, candidates[b].time)
         )
+        if diag is not None:
+            diag["selected_backend"] = backend
+            diag["selected_cost"] = candidates[backend]
+            for candidate, entry in diag_backends.items():
+                entry["selected"] = candidate == backend
         return backend, candidates[backend]

--- a/tests/test_method_selector_diagnostics.py
+++ b/tests/test_method_selector_diagnostics.py
@@ -1,0 +1,74 @@
+"""Tests covering diagnostic output of the method selector and planner."""
+
+from __future__ import annotations
+
+from quasar.circuit import Circuit, Gate
+from quasar.cost import CostEstimator, Backend
+from quasar.method_selector import MethodSelector
+from quasar.planner import Planner
+
+
+def build_test_circuit() -> Circuit:
+    """Return a small circuit exercising multiple backend heuristics."""
+
+    gates = [
+        Gate("T", [0]),
+        Gate("H", [1]),
+        Gate("CX", [0, 2]),
+    ]
+    return Circuit(gates, use_classical_simplification=False)
+
+
+def test_method_selector_populates_diagnostics() -> None:
+    """``MethodSelector.select`` should annotate backend diagnostics."""
+
+    selector = MethodSelector()
+    circuit = build_test_circuit()
+    diag: dict[str, object] = {}
+
+    backend, cost = selector.select(
+        circuit.gates,
+        circuit.num_qubits,
+        sparsity=1.0,
+        phase_rotation_diversity=0,
+        amplitude_rotation_diversity=0,
+        diagnostics=diag,
+    )
+
+    assert diag["selected_backend"] == backend
+    assert diag["selected_cost"] == cost
+
+    backends = diag["backends"]
+    assert Backend.TABLEAU in backends
+    assert Backend.MPS in backends
+    assert Backend.STATEVECTOR in backends
+
+    # Tableau should be rejected because the fragment is non-Clifford.
+    assert backends[Backend.TABLEAU]["feasible"] is False
+    assert "non-clifford gates" in backends[Backend.TABLEAU]["reasons"]
+
+    # The non-local entangling gate prevents MPS from being considered.
+    assert backends[Backend.MPS]["feasible"] is False
+    assert "non-local gates" in backends[Backend.MPS]["reasons"]
+
+    # The selected backend is marked accordingly in the diagnostics.
+    assert backends[backend]["selected"] is True
+
+
+def test_planner_explain_surfaces_selection_diagnostics() -> None:
+    """Planner diagnostics should include selector information."""
+
+    estimator = CostEstimator()
+    planner = Planner(
+        estimator=estimator,
+        quick_max_qubits=32,
+        quick_max_gates=128,
+        quick_max_depth=128,
+    )
+    circuit = build_test_circuit()
+
+    plan = planner.plan(circuit, explain=True)
+    assert plan.diagnostics is not None
+    selector_diag = plan.diagnostics.backend_selection
+    assert "single" in selector_diag
+    assert selector_diag["single"]["selected_backend"] == plan.final_backend


### PR DESCRIPTION
## Summary
- extend `MethodSelector.select` to populate per-backend diagnostics with cost estimates and rejection reasons
- surface selector diagnostics through planner explain mode and verbose logging output, and record them in `PlanDiagnostics`
- document the new debug output and add tests covering method selector and planner diagnostics

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68c9555e88b08321bb2dbb28cff6cd34