### PR TITLE
Add partition trace diagnostics

### DIFF
--- a/quasar/__init__.py
+++ b/quasar/__init__.py
@@ -7,7 +7,7 @@ from .planner import Planner, PlanResult, PlanStep, DPEntry
 from .method_selector import MethodSelector, NoFeasibleBackendError
 from .scheduler import Scheduler
 from .simulation_engine import SimulationEngine, SimulationResult
-from .ssd import SSD, SSDPartition, ConversionLayer
+from .ssd import SSD, SSDPartition, ConversionLayer, PartitionTraceEntry
 from .calibration import (
     run_calibration,
     save_coefficients,
@@ -46,6 +46,7 @@ __all__ = [
     "SSD",
     "SSDPartition",
     "ConversionLayer",
+    "PartitionTraceEntry",
     "run_calibration",
     "save_coefficients",
     "load_coefficients",

--- a/quasar/ssd.py
+++ b/quasar/ssd.py
@@ -7,6 +7,42 @@ from .cost import Backend, Cost
 
 
 @dataclass
+class PartitionTraceEntry:
+    """Diagnostics describing partition boundary decisions.
+
+    Attributes
+    ----------
+    gate_index, gate_name:
+        Identify the gate that triggered the decision.
+    from_backend, to_backend:
+        Backends involved in the potential switch.
+    boundary, boundary_size:
+        Sorted qubit indices along the cut and their count.
+    rank, frontier:
+        Estimated Schmidt rank and decision diagram frontier across the cut.
+    primitive, cost:
+        Conversion primitive and estimated cost when a conversion is required.
+    applied:
+        ``True`` when the backend change was accepted.
+    reason:
+        Short textual explanation for the decision.
+    """
+
+    gate_index: int
+    gate_name: str
+    from_backend: Backend | None
+    to_backend: Backend
+    boundary: Tuple[int, ...] = ()
+    boundary_size: int = 0
+    rank: int | None = None
+    frontier: int | None = None
+    primitive: str | None = None
+    cost: Cost | None = None
+    applied: bool = False
+    reason: str = ""
+
+
+@dataclass
 class SSDPartition:
     """Represents a set of identical subsystems along with metadata.
 
@@ -66,6 +102,9 @@ class SSD:
     rank: int | None = None
     frontier: int | None = None
     fingerprint: Hashable | None = None
+    trace: List[PartitionTraceEntry] = field(
+        default_factory=list, repr=False, compare=False
+    )
 
     def __post_init__(self) -> None:  # pragma: no cover - trivial
         if self.fingerprint is None:

--- a/tests/test_partitioner_trace.py
+++ b/tests/test_partitioner_trace.py
@@ -1,0 +1,174 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Iterable, List, Tuple
+
+from quasar.circuit import Circuit, Gate
+from quasar.cost import Backend, Cost, ConversionEstimate
+from quasar.partitioner import Partitioner
+from quasar.ssd import PartitionTraceEntry
+
+
+class DummySelector:
+    """Return pre-programmed backend choices for each ``select`` call."""
+
+    def __init__(self, results: Iterable[Tuple[Backend, Cost]]):
+        self._results: List[Tuple[Backend, Cost]] = list(results)
+        self._index = 0
+
+    def select(self, *args, **kwargs):  # type: ignore[no-untyped-def]
+        if self._index < len(self._results):
+            backend, cost = self._results[self._index]
+        else:
+            backend, cost = self._results[-1]
+        self._index += 1
+        return backend, cost
+
+
+@dataclass
+class FakeEstimator:
+    """Minimal cost estimator returning deterministic values."""
+
+    conversion_time: float = 3.0
+    conversion_memory: float = 7.0
+
+    def conversion(  # type: ignore[no-untyped-def]
+        self,
+        source,
+        target,
+        num_qubits,
+        rank,
+        frontier,
+        **_kwargs,
+    ) -> ConversionEstimate:
+        return ConversionEstimate(
+            "FAKE",
+            Cost(
+                time=self.conversion_time * num_qubits,
+                memory=self.conversion_memory * rank,
+                log_depth=float(frontier),
+            ),
+        )
+
+    def tableau(self, *args, **kwargs):  # type: ignore[no-untyped-def]
+        return Cost(time=1.0, memory=2.0)
+
+    def mps(self, *args, **kwargs):  # type: ignore[no-untyped-def]
+        return Cost(time=1.0, memory=2.0)
+
+    def decision_diagram(self, *args, **kwargs):  # type: ignore[no-untyped-def]
+        return Cost(time=1.0, memory=2.0)
+
+    def statevector(self, *args, **kwargs):  # type: ignore[no-untyped-def]
+        return Cost(time=1.0, memory=2.0)
+
+
+def build_circuit(*gates: Gate) -> Circuit:
+    return Circuit(list(gates), use_classical_simplification=False)
+
+
+def assert_trace_entry(
+    entry: PartitionTraceEntry,
+    *,
+    reason: str,
+    applied: bool,
+    source: Backend | None,
+    target: Backend,
+    boundary_size: int,
+    primitive: str = "FAKE",
+):
+    assert entry.reason == reason
+    assert entry.applied is applied
+    assert entry.from_backend == source
+    assert entry.to_backend == target
+    assert entry.boundary_size == boundary_size
+    if boundary_size:
+        assert entry.rank == 2**boundary_size
+        assert entry.frontier == boundary_size
+        assert entry.primitive == primitive
+        assert entry.cost is not None
+        assert entry.cost.time > 0
+    else:
+        assert entry.rank == 1
+        assert entry.frontier == 0
+        assert entry.primitive in (None, primitive)
+
+
+def test_trace_records_statevector_lock() -> None:
+    estimator = FakeEstimator()
+    selector = DummySelector(
+        [
+            (Backend.STATEVECTOR, Cost(time=1.0, memory=1.0)),
+            (Backend.MPS, Cost(time=2.0, memory=2.0)),
+        ]
+    )
+    partitioner = Partitioner(estimator=estimator, selector=selector)
+    circuit = build_circuit(Gate("H", [0]), Gate("CX", [0, 1]))
+
+    ssd = partitioner.partition(circuit, debug=True)
+
+    assert len(ssd.trace) == 1
+    entry = ssd.trace[0]
+    assert_trace_entry(
+        entry,
+        reason="statevector_lock",
+        applied=False,
+        source=Backend.STATEVECTOR,
+        target=Backend.MPS,
+        boundary_size=1,
+    )
+
+
+def test_trace_marks_single_qubit_preamble_switch() -> None:
+    estimator = FakeEstimator()
+    selector = DummySelector(
+        [
+            (Backend.TABLEAU, Cost(time=1.0, memory=1.0)),
+            (Backend.MPS, Cost(time=2.0, memory=2.0)),
+        ]
+    )
+    partitioner = Partitioner(estimator=estimator, selector=selector)
+    circuit = build_circuit(Gate("H", [0]), Gate("T", [0]))
+
+    ssd = partitioner.partition(circuit, debug=True)
+
+    assert len(ssd.trace) == 1
+    entry = ssd.trace[0]
+    assert_trace_entry(
+        entry,
+        reason="single_qubit_preamble",
+        applied=True,
+        source=Backend.TABLEAU,
+        target=Backend.MPS,
+        boundary_size=1,
+    )
+
+
+def test_trace_callback_receives_applied_cut() -> None:
+    estimator = FakeEstimator()
+    selector = DummySelector(
+        [
+            (Backend.TABLEAU, Cost(time=1.0, memory=1.0)),
+            (Backend.MPS, Cost(time=2.0, memory=2.0)),
+        ]
+    )
+    partitioner = Partitioner(estimator=estimator, selector=selector)
+    circuit = build_circuit(Gate("CX", [0, 1]), Gate("T", [0]))
+
+    events: List[PartitionTraceEntry] = []
+    ssd = partitioner.partition(circuit, trace=events.append)
+
+    assert events
+    assert events == ssd.trace
+    entry = events[0]
+    assert_trace_entry(
+        entry,
+        reason="backend_switch",
+        applied=True,
+        source=Backend.TABLEAU,
+        target=Backend.MPS,
+        boundary_size=1,
+    )
+    assert entry.cost is not None
+    assert entry.cost.time == estimator.conversion_time * entry.boundary_size
+


### PR DESCRIPTION
## Summary
- add a `PartitionTraceEntry` structure and expose partition diagnostics on `SSD.trace`
- extend `Partitioner.partition` with optional `debug` and `trace` hooks that record conversion estimates for every candidate cut
- cover the new tracing behaviour with targeted unit tests

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68c95c4fee108321bc2ec402a6344d60