### PR TITLE
Remove deprecated extensive circuits

### DIFF
--- a/benchmarks/extensive_circuits.py
+++ b/benchmarks/extensive_circuits.py
@@ -11,7 +11,7 @@ substantial entanglement across distant qubit groups.
 from typing import List
 
 from quasar.circuit import Circuit, Gate
-from .circuits import ghz_circuit, qaoa_circuit, adder_circuit, grover_circuit
+from .circuits import ghz_circuit, qaoa_circuit, grover_circuit
 from .large_scale_circuits import surface_corrected_qaoa
 
 
@@ -54,49 +54,6 @@ def surface_code_qaoa_circuit(
     """
 
     return surface_corrected_qaoa(bit_width, distance, rounds)
-
-
-def adder_ghz_qaoa_circuit(
-    bit_width: int, qaoa_layers: int = 1, adder_kind: str = "vbe"
-) -> Circuit:
-    """Combine a ripple-carry adder, GHZ state and global QAOA layers.
-
-    The circuit constructs a ``bit_width``-bit ripple-carry adder acting on two
-    registers.  An independent GHZ state of the same size is prepared on a
-    disjoint set of qubits.  All qubits then undergo ``qaoa_layers`` rounds of a
-    ring-graph QAOA circuit.  The total qubit count is ``3 * bit_width + 2``.
-
-    Parameters
-    ----------
-    bit_width:
-        Number of bits in the adder operands and in the GHZ register.
-    qaoa_layers:
-        Number of QAOA problem/mixing layer pairs to apply across the full
-        system.
-    adder_kind:
-        Variant of the ripple-carry adder.  Passed directly to
-        :func:`adder_circuit`.
-
-    Returns
-    -------
-    Circuit
-        Complete circuit combining arithmetic, entangling and QAOA layers.
-    """
-
-    if bit_width <= 0 or qaoa_layers <= 0:
-        return Circuit([])
-
-    adder = adder_circuit(bit_width, kind=adder_kind)
-    adder_qubits = 2 * bit_width + 2
-    ghz = ghz_circuit(bit_width)
-
-    gates = list(adder.gates)
-    gates.extend(_shift_gates(ghz.gates, adder_qubits))
-    total_qubits = adder_qubits + bit_width
-    qaoa = qaoa_circuit(total_qubits, repetitions=qaoa_layers)
-    gates.extend(qaoa.gates)
-    return Circuit(gates)
-
 
 def ghz_grover_fusion_circuit(
     ghz_qubits: int, grover_qubits: int, iterations: int = 1
@@ -201,7 +158,6 @@ def qaoa_toffoli_gadget_circuit(
 
 __all__ = [
     "surface_code_qaoa_circuit",
-    "adder_ghz_qaoa_circuit",
     "ghz_grover_fusion_circuit",
     "qaoa_toffoli_gadget_circuit",
 ]

--- a/benchmarks/notebooks/large_circuit_partitioning.ipynb
+++ b/benchmarks/notebooks/large_circuit_partitioning.ipynb
@@ -26,12 +26,12 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from benchmarks.extensive_circuits import dual_ghz_qft_circuit, adder_ghz_qaoa_circuit\n",
+    "from benchmarks.extensive_circuits import surface_code_qaoa_circuit, ghz_grover_fusion_circuit\n",
     "from quasar.analyzer import CircuitAnalyzer\n",
     "from quasar.simulation_engine import SimulationEngine\n",
     "\n",
-    "ghz_qft = dual_ghz_qft_circuit(width=64)\n",
-    "hybrid = adder_ghz_qaoa_circuit(bit_width=32, qaoa_layers=3)\n"
+    "surface_qaoa = surface_code_qaoa_circuit(bit_width=8, distance=3, rounds=2)\n",
+    "fusion = ghz_grover_fusion_circuit(ghz_qubits=8, grover_qubits=6, iterations=2)\n"
    ]
   },
   {
@@ -88,8 +88,8 @@
     "    describe_conversions(name, list(circuit.ssd.conversions))\n",
     "    return analysis, plan\n",
     "\n",
-    "ghz_qft_analysis, ghz_qft_plan = prepare_circuit(ghz_qft, 'GHZ-QFT')\n",
-    "hybrid_analysis, hybrid_plan = prepare_circuit(hybrid, 'Adder-GHZ-QAOA')\n"
+    "surface_qaoa_analysis, surface_qaoa_plan = prepare_circuit(surface_qaoa, 'Surface-QAOA')\n",
+    "fusion_analysis, fusion_plan = prepare_circuit(fusion, 'GHZ-Grover')\n"
    ]
   },
   {
@@ -134,8 +134,8 @@
     "    print(f\"[{name}] Final SSD partitions: {len(ssd.partitions)}\")\n",
     "    return ssd, metrics\n",
     "\n",
-    "ghz_qft_ssd, ghz_qft_metrics = simulate_prepared(ghz_qft, ghz_qft_plan, ghz_qft_analysis, 'GHZ-QFT')\n",
-    "hybrid_ssd, hybrid_metrics = simulate_prepared(hybrid, hybrid_plan, hybrid_analysis, 'Adder-GHZ-QAOA')\n"
+    "surface_qaoa_ssd, surface_qaoa_metrics = simulate_prepared(surface_qaoa, surface_qaoa_plan, surface_qaoa_analysis, 'Surface-QAOA')\n",
+    "fusion_ssd, fusion_metrics = simulate_prepared(fusion, fusion_plan, fusion_analysis, 'GHZ-Grover')\n"
    ]
   }
  ],


### PR DESCRIPTION
## Summary
- remove the obsolete adder/GHZ/QAOA benchmark generator from `benchmarks.extensive_circuits`
- update the large circuit partitioning notebook to showcase the remaining hybrid circuits

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68c96050e8988321af0d50185061c7a4