### PR TITLE
Add parallel GHZ benchmark and regression test for parallel planning

### DIFF
--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -100,6 +100,25 @@ New circuit generators are added to
 CLI can discover it automatically.  The existing functions, such as
 [`ghz_circuit`](circuits.py), illustrate the expected structure.
 
+## Parallel subsystem templates
+
+[`parallel_circuits.py`](parallel_circuits.py) contains helpers for
+benchmarks that emphasise independent subsystems.  The
+``many_ghz_subsystems(num_groups, group_size)`` generator creates
+``num_groups`` disjoint GHZ chains with ``group_size`` qubits each.  No
+gates cross subsystem boundaries, allowing the planner and scheduler to
+identify parallel partitions immediately:
+
+```python
+from benchmarks.parallel_circuits import many_ghz_subsystems
+
+circuit = many_ghz_subsystems(num_groups=8, group_size=6)
+```
+
+This circuit family is useful when measuring the benefits of QuASAr's
+parallel execution heuristics or validating partitioning behaviour on
+larger disjoint systems.
+
 ## Running specific backends
 
 Benchmarks can force a particular simulator by selecting a QuASAr backend

--- a/benchmarks/notebooks/relative_speedup_bar_chart.ipynb
+++ b/benchmarks/notebooks/relative_speedup_bar_chart.ipynb
@@ -30,6 +30,76 @@
     "plt.title('Relative Speedups')\n",
     "plt.show()\n"
    ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Parallel GHZ subsystems\n",
+    "\n",
+    "Independent GHZ chains built with ``many_ghz_subsystems`` remain disjoint\n",
+    "throughout the circuit.  The planner therefore tags a single step with\n",
+    "parallel metadata that the scheduler can execute concurrently.  The cell\n",
+    "below compares the cost model's sequential and parallel estimates for\n",
+    "eight groups of six qubits.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "execution_count": 3,
+   "source": [
+    "from benchmarks.parallel_circuits import many_ghz_subsystems\n",
+    "from quasar.cost import Backend\n",
+    "from quasar.partitioner import Partitioner\n",
+    "from quasar.planner import Planner, _add_cost, _parallel_simulation_cost, _simulation_cost\n",
+    "\n",
+    "num_groups, group_size = 8, 6\n",
+    "circuit = many_ghz_subsystems(num_groups=num_groups, group_size=group_size)\n",
+    "\n",
+    "planner = Planner()\n",
+    "plan = planner.plan(circuit, backend=Backend.TABLEAU)\n",
+    "step = plan.steps[0]\n",
+    "groups = Partitioner().parallel_groups(circuit.gates)\n",
+    "\n",
+    "estimator = planner.estimator\n",
+    "sequential = None\n",
+    "for qubits, gates in groups:\n",
+    "    n = len(qubits)\n",
+    "    num_meas = sum(1 for gate in gates if gate.gate.upper() in {\"MEASURE\", \"RESET\"})\n",
+    "    num_1q = sum(\n",
+    "        1\n",
+    "        for gate in gates\n",
+    "        if len(gate.qubits) == 1 and gate.gate.upper() not in {\"MEASURE\", \"RESET\"}\n",
+    "    )\n",
+    "    num_2q = sum(\n",
+    "        1\n",
+    "        for gate in gates\n",
+    "        if len(gate.qubits) > 1 and gate.gate.upper() not in {\"MEASURE\", \"RESET\"}\n",
+    "    )\n",
+    "    cost = _simulation_cost(estimator, Backend.TABLEAU, n, num_1q, num_2q, num_meas)\n",
+    "    sequential = cost if sequential is None else _add_cost(sequential, cost)\n",
+    "\n",
+    "parallel_cost = _parallel_simulation_cost(estimator, Backend.TABLEAU, groups)\n",
+    "\n",
+    "print(f\"Plan step parallel groups: {step.parallel}\")\n",
+    "print(\n",
+    "    f\"Sequential estimate: {sequential.time:.6f}s, Parallel estimate: {parallel_cost.time:.6f}s\"\n",
+    ")\n",
+    "if parallel_cost.time > 0:\n",
+    "    print(f\"Estimated speed-up: {sequential.time / parallel_cost.time:.2f}x\")\n"
+   ],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Plan step parallel groups: ((0, 1, 2, 3, 4, 5), (6, 7, 8, 9, 10, 11), (12, 13, 14, 15, 16, 17), (18, 19, 20, 21, 22, 23), (24, 25, 26, 27, 28, 29), (30, 31, 32, 33, 34, 35), (36, 37, 38, 39, 40, 41), (42, 43, 44, 45, 46, 47))\n",
+      "Sequential estimate: 6912.000000s, Parallel estimate: 864.000000s\n",
+      "Estimated speed-up: 8.00x\n"
+     ]
+    }
+   ]
   }
  ],
  "metadata": {

--- a/benchmarks/parallel_circuits.py
+++ b/benchmarks/parallel_circuits.py
@@ -1,0 +1,43 @@
+"""Circuit families highlighting parallel subsystems for benchmarking."""
+from __future__ import annotations
+
+from typing import List
+
+from quasar.circuit import Circuit, Gate
+
+
+def many_ghz_subsystems(num_groups: int, group_size: int) -> Circuit:
+    """Return ``num_groups`` disjoint GHZ chains of ``group_size`` qubits each.
+
+    The generated circuit entangles qubits only within their respective
+    subsystem, making the groups independent.  This allows the planner and
+    scheduler to execute the resulting partitions concurrently.
+
+    Args:
+        num_groups: Number of independent GHZ subsystems to generate.
+        group_size: Number of qubits per subsystem.  Must be positive to
+            create entanglement; values less than one result in an empty
+            circuit.
+
+    Returns:
+        A :class:`~quasar.circuit.Circuit` containing the requested GHZ
+        subsystems laid out on contiguous qubit blocks.
+    """
+
+    if num_groups <= 0 or group_size <= 0:
+        return Circuit([])
+
+    gates: List[Gate] = []
+    for group in range(num_groups):
+        base = group * group_size
+        # Prepare the GHZ state on the group's first qubit.
+        gates.append(Gate("H", [base]))
+        # Chain CX gates within the group to distribute entanglement.
+        for offset in range(1, group_size):
+            control = base + offset - 1
+            target = base + offset
+            gates.append(Gate("CX", [control, target]))
+    return Circuit(gates)
+
+
+__all__ = ["many_ghz_subsystems"]

--- a/tests/test_parallel_subsystems.py
+++ b/tests/test_parallel_subsystems.py
@@ -1,0 +1,36 @@
+"""Tests for circuits composed of independent parallel subsystems."""
+
+from __future__ import annotations
+
+from benchmarks.parallel_circuits import many_ghz_subsystems
+from quasar.cost import Backend
+from quasar.planner import Planner
+
+
+def test_many_ghz_subsystems_parallel_groups() -> None:
+    """Planner should expose disjoint GHZ groups as parallel partitions."""
+
+    num_groups = 4
+    group_size = 5
+    circuit = many_ghz_subsystems(num_groups=num_groups, group_size=group_size)
+
+    # Verify that gates never span multiple qubit blocks.
+    for gate in circuit.gates:
+        group_index = gate.qubits[0] // group_size if gate.qubits else 0
+        assert all(q // group_size == group_index for q in gate.qubits)
+
+    planner = Planner()
+    plan = planner.plan(circuit, backend=Backend.TABLEAU)
+
+    # The forced Tableau backend should treat all groups as a single step with
+    # explicit parallel metadata describing each independent subsystem.
+    assert len(plan.steps) == 1
+    step = plan.steps[0]
+    assert len(step.parallel) == num_groups
+    expected_groups = tuple(
+        tuple(range(group * group_size, (group + 1) * group_size))
+        for group in range(num_groups)
+    )
+    assert step.parallel == expected_groups
+    assert step.start == 0
+    assert step.end == len(circuit.gates)


### PR DESCRIPTION
## Summary
- add a parallel GHZ subsystem generator that keeps groups independent so the planner can expose concurrent partitions
- add a regression test that forces Tableau planning and checks the parallel metadata per group
- document the new benchmark circuit in the README and notebook, including a cost-model example of the parallel speed-up

## Testing
- pytest
- pytest tests/test_parallel_subsystems.py

------
https://chatgpt.com/codex/tasks/task_e_68c97d46a260832199774d7c71fcdb12