### PR TITLE
Add mixed backend partition circuit and coverage

### DIFF
--- a/benchmarks/notebooks/large_circuit_partitioning.ipynb
+++ b/benchmarks/notebooks/large_circuit_partitioning.ipynb
@@ -11,6 +11,7 @@
     "* **Surface-code QAOA hybrid** via `surface_code_qaoa_circuit`, interleaving low-degree QAOA layers with surface-code stabiliser rounds.\n",
     "* **GHZ–Grover fusion** via `ghz_grover_fusion_circuit`, preparing disjoint GHZ and Grover prefixes before entangling them.\n",
     "* **QAOA with a Toffoli gadget** via `qaoa_toffoli_gadget_circuit`, inserting a non-Clifford three-qubit gate between MPS-friendly layers.\n",
+    "* **Mixed backend subsystems** via `mixed_backend_subsystems`, combining a Clifford GHZ prefix, an MPS-friendly QAOA mid-block, and a dense random suffix that forces conversions between tableau, MPS, and statevector simulations.\n",
     "\n",
     "We inspect the resulting partitions, conversion layers, and execution metrics produced by QuASAr."
    ]
@@ -56,19 +57,20 @@
    },
    "outputs": [],
    "source": [
-
     "from benchmarks.extensive_circuits import (\n",
     "    surface_code_qaoa_circuit,\n",
     "    ghz_grover_fusion_circuit,\n",
     "    qaoa_toffoli_gadget_circuit,\n",
     ")\n",
-
+    "from benchmarks.partition_circuits import mixed_backend_subsystems\n",
     "from quasar.analyzer import CircuitAnalyzer\n",
     "from quasar.simulation_engine import SimulationEngine\n",
     "\n",
     "surface_qaoa = surface_code_qaoa_circuit(bit_width=8, distance=3, rounds=2)\n",
     "fusion = ghz_grover_fusion_circuit(ghz_qubits=10, grover_qubits=3, iterations=2)\n",
-    "toffoli_gadget = qaoa_toffoli_gadget_circuit(width=18, rounds_before=2, rounds_after=2)\n"
+    "toffoli_gadget = qaoa_toffoli_gadget_circuit(width=18, rounds_before=2, rounds_after=2)\n",
+    "\n",
+    "mixed = mixed_backend_subsystems(ghz_width=5, qaoa_width=5, qaoa_layers=2, random_width=4, seed=13)\n"
    ]
   },
   {
@@ -172,7 +174,9 @@
     "\n",
     "surface_analysis, surface_plan = prepare_circuit(surface_qaoa, 'Surface-Code QAOA')\n",
     "fusion_analysis, fusion_plan = prepare_circuit(fusion, 'GHZ–Grover Fusion')\n",
-    "toffoli_analysis, toffoli_plan = prepare_circuit(toffoli_gadget, 'QAOA Toffoli Gadget')\n"
+    "toffoli_analysis, toffoli_plan = prepare_circuit(toffoli_gadget, 'QAOA Toffoli Gadget')\n",
+    "\n",
+    "mixed_analysis, mixed_plan = prepare_circuit(mixed, 'Mixed Backend Subsystems')"
    ]
   },
   {
@@ -252,7 +256,9 @@
     "\n",
     "surface_ssd, surface_metrics = simulate_prepared(surface_qaoa, surface_plan, surface_analysis, 'Surface-Code QAOA')\n",
     "fusion_ssd, fusion_metrics = simulate_prepared(fusion, fusion_plan, fusion_analysis, 'GHZ–Grover Fusion')\n",
-    "toffoli_ssd, toffoli_metrics = simulate_prepared(toffoli_gadget, toffoli_plan, toffoli_analysis, 'QAOA Toffoli Gadget')\n"
+    "toffoli_ssd, toffoli_metrics = simulate_prepared(toffoli_gadget, toffoli_plan, toffoli_analysis, 'QAOA Toffoli Gadget')\n",
+    "\n",
+    "mixed_ssd, mixed_metrics = simulate_prepared(mixed, mixed_plan, mixed_analysis, 'Mixed Backend Subsystems')"
    ]
   }
  ],

--- a/benchmarks/partition_circuits.py
+++ b/benchmarks/partition_circuits.py
@@ -1,0 +1,141 @@
+from __future__ import annotations
+
+"""Composite benchmark circuits targeting multiple simulation backends."""
+
+from random import Random
+from typing import Iterable, List
+
+from quasar.circuit import Circuit, Gate
+
+from .circuits import ghz_circuit, random_circuit
+
+
+def _shift_gates(gates: Iterable[Gate], offset: int) -> List[Gate]:
+    """Return a list of gates with qubit indices increased by ``offset``."""
+
+    return [Gate(g.gate, [q + offset for q in g.qubits], dict(g.params)) for g in gates]
+
+
+def mixed_backend_subsystems(
+    *,
+    ghz_width: int = 4,
+    qaoa_width: int = 4,
+    qaoa_layers: int = 2,
+    random_width: int = 4,
+    seed: int = 7,
+) -> Circuit:
+    """Combine GHZ, QAOA and dense random blocks to stress backend switching.
+
+    The circuit prepares three contiguous subsystems that naturally favour
+    different simulators:
+
+    ``ghz_width`` Clifford-only gates initialise a GHZ state suitable for the
+    tableau backend.  ``qaoa_width`` qubits then execute a low-entanglement linear-chain
+    QAOA routine which the method selector maps to the MPS backend.  Finally, a
+    dense non-local block on ``random_width`` qubits mixes random rotations with
+    a Toffoli gadget, forcing the selector towards the statevector (or
+    decision-diagram) backend.  Cross-partition entangling gates connect the
+    three regions to trigger explicit conversion layers during planning.
+
+    Parameters
+    ----------
+    ghz_width:
+        Number of qubits in the Clifford GHZ prefix.  Must be at least three so
+        that multiple entangling connectors can be placed.
+    qaoa_width:
+        Number of qubits evolved by the QAOA block.  Requires a minimum of
+        three qubits to form a non-trivial linear topology.
+    qaoa_layers:
+        Number of QAOA layers applied to the MPS-friendly block.  A positive
+        integer is required.
+    random_width:
+        Number of qubits used for the dense random suffix.  At least four
+        qubits are required to host the Toffoli gadget and non-local ZZ
+        rotations that promote dense backends.
+    seed:
+        Seed controlling the random parameters of the QAOA and dense random
+        blocks to keep the benchmark deterministic.
+
+    Returns
+    -------
+    Circuit
+        Combined circuit spanning all three subsystems with explicit conversion
+        boundaries.
+    """
+
+    if ghz_width < 3:
+        raise ValueError("ghz_width must be at least three to expose entanglement boundaries")
+    if qaoa_width < 3:
+        raise ValueError("qaoa_width must be at least three for a ring QAOA block")
+    if qaoa_layers <= 0:
+        raise ValueError("qaoa_layers must be positive")
+    if random_width < 4:
+        raise ValueError("random_width must be at least four to host dense gadgets")
+
+    rng = Random(seed)
+
+    gates: List[Gate] = []
+
+    ghz = ghz_circuit(ghz_width)
+    gates.extend(ghz.gates)
+
+    qaoa_offset = ghz_width
+    qaoa_first = qaoa_offset
+    qaoa_last = qaoa_offset + qaoa_width - 1
+
+    # Entangle the GHZ register with the upcoming QAOA block to force a
+    # conversion boundary once non-Clifford gates appear on the QAOA qubits.
+    gates.append(Gate("CX", [ghz_width - 1, qaoa_first]))
+
+    # Construct a linear-chain QAOA block so the selector favours the MPS backend.
+    for qubit in range(qaoa_width):
+        gates.append(Gate("H", [qaoa_offset + qubit]))
+    for _ in range(qaoa_layers):
+        for qubit in range(qaoa_width - 1):
+            zz_angle = rng.uniform(0.2, 2.8)
+            gates.append(
+                Gate("RZZ", [qaoa_offset + qubit, qaoa_offset + qubit + 1], {"theta": zz_angle})
+            )
+        bridge_theta = rng.uniform(0.25, 1.35)
+        gates.append(Gate("RZZ", [ghz_width - 1, qaoa_first], {"theta": bridge_theta}))
+        for qubit in range(qaoa_width):
+            rx_angle = rng.uniform(0.1, 2.6)
+            gates.append(Gate("RX", [qaoa_offset + qubit], {"theta": rx_angle}))
+
+    # Local single-qubit rotations increase amplitude diversity and keep the block firmly in the MPS regime.
+    for qubit in range(qaoa_width):
+        ry_angle = rng.uniform(0.15, 1.35)
+        gates.append(Gate("RY", [qaoa_offset + qubit], {"theta": ry_angle}))
+        rz_angle = rng.uniform(0.1, 1.25)
+        gates.append(Gate("RZ", [qaoa_offset + qubit], {"phi": rz_angle}))
+
+    final_theta = rng.uniform(0.2, 1.2)
+    gates.append(Gate("RZZ", [qaoa_last - 1, qaoa_last], {"theta": final_theta}))
+
+    random_offset = qaoa_offset + qaoa_width
+    random_first = random_offset
+    random_last = random_offset + random_width - 1
+
+    # Connect the QAOA block with the dense suffix using Clifford entanglers so
+    # the partitioner must convert the shared boundary when switching backends.
+    gates.append(Gate("CX", [qaoa_last, random_first]))
+    zz_bridge = rng.uniform(0.3, 1.4)
+    gates.append(Gate("RZZ", [qaoa_last, random_first], {"theta": zz_bridge}))
+
+    dense = random_circuit(random_width, seed=seed + 1)
+    gates.extend(_shift_gates(dense.gates, random_offset))
+
+    # Reinforce the dense nature of the suffix with explicit non-local
+    # interactions and a Toffoli gadget which decomposes into T gates and
+    # long-range CNOTs.  The angles are deterministic but non-Clifford.
+    zz_angle = rng.uniform(0.35, 1.45)
+    gates.append(Gate("RZZ", [random_first, random_last], {"theta": zz_angle}))
+    ccx_control_b = random_offset + random_width // 2
+    gates.append(Gate("CCX", [random_first, ccx_control_b, random_last]))
+    crz_angle = rng.uniform(0.2, 1.1)
+    gates.append(Gate("CRZ", [random_first + 1, random_last - 1], {"phi": crz_angle}))
+
+    return Circuit(gates, use_classical_simplification=False)
+
+
+__all__ = ["mixed_backend_subsystems"]

--- a/tests/test_mixed_method_partition.py
+++ b/tests/test_mixed_method_partition.py
@@ -1,0 +1,73 @@
+"""Tests for hybrid circuits requiring multiple simulation backends."""
+
+from __future__ import annotations
+
+from benchmarks.circuits import CLIFFORD_GATES
+from benchmarks.partition_circuits import mixed_backend_subsystems
+from quasar.cost import Backend
+from quasar.partitioner import Partitioner
+
+
+def test_mixed_backend_subsystems_partitioning() -> None:
+    """GHZ, QAOA and dense blocks should map to distinct backends."""
+
+    ghz_width = 4
+    qaoa_width = 4
+    dense_width = 4
+    circuit = mixed_backend_subsystems(
+        ghz_width=ghz_width,
+        qaoa_width=qaoa_width,
+        qaoa_layers=2,
+        random_width=dense_width,
+        seed=11,
+    )
+
+    partitioner = Partitioner()
+    ssd = partitioner.partition(circuit, debug=True)
+
+    assert len(ssd.partitions) >= 3
+
+    ghz_qubits = set(range(ghz_width))
+    qaoa_offset = ghz_width
+    dense_offset = qaoa_offset + qaoa_width
+    dense_qubits = set(range(dense_offset, dense_offset + dense_width))
+
+    tableau_partition = next(
+        (
+            part
+            for part in ssd.partitions
+            if part.backend == Backend.TABLEAU
+            and ghz_qubits.issubset(set(part.qubits))
+        ),
+        None,
+    )
+    assert tableau_partition is not None
+    assert set(tableau_partition.history).issubset(CLIFFORD_GATES)
+
+    dense_partitions = [
+        part
+        for part in ssd.partitions
+        if part.backend in {Backend.STATEVECTOR, Backend.DECISION_DIAGRAM}
+        and dense_qubits.issubset(set(part.qubits))
+    ]
+    assert dense_partitions
+    assert any(
+        any(name in {"T", "TDG"} for name in part.history)
+        for part in dense_partitions
+    )
+
+    applied_trace = [entry for entry in ssd.trace if entry.applied]
+    assert any(entry.to_backend == Backend.MPS for entry in applied_trace)
+    assert any(
+        entry.from_backend == Backend.MPS and entry.to_backend == Backend.STATEVECTOR
+        for entry in applied_trace
+    )
+
+    assert any(
+        conv.source == Backend.TABLEAU and conv.target in {Backend.DECISION_DIAGRAM, Backend.MPS}
+        for conv in ssd.conversions
+    )
+    assert any(
+        conv.source == Backend.DECISION_DIAGRAM and conv.target == Backend.MPS
+        for conv in ssd.conversions
+    )


### PR DESCRIPTION
## Summary
- introduce `mixed_backend_subsystems` combining GHZ, linear-chain QAOA, and dense random segments to exercise backend conversions
- validate the partitioning behaviour with a targeted pytest and conversion trace assertions
- extend the large circuit partitioning notebook to inspect the new hybrid circuit alongside existing examples

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68c992de879c8321af9dd263267ddda5