### PR TITLE
Add stabiliser-to-DD benchmark and tests

### DIFF
--- a/docs/stim_to_dd_conversion.md
+++ b/docs/stim_to_dd_conversion.md
@@ -1,0 +1,46 @@
+# Tableau to Decision Diagram Conversion Benchmark
+
+The `benchmarks.partition_circuits.stim_to_dd_circuit` helper prepares a
+collection of identical GHZ subsystems that start on the stabiliser (Stim
+Tableau) backend and then transition to the decision-diagram simulator.
+It is designed to exercise QuASAr's conversion pipeline by keeping the
+subsystems independent until the exact moment non-Clifford gates are
+introduced.
+
+## Circuit structure
+
+* **Stabiliser preparation** – each group of `group_size` qubits is
+  initialised into a GHZ state using only Clifford gates. The method
+  selector therefore assigns the Tableau backend and compresses the
+  identical groups into a single partition with multiple subsystems.
+* **T layer** – a uniform layer of `T` rotations is applied to every
+  qubit. This breaks the Clifford structure and forces a conversion to
+  the decision-diagram backend. Because the groups remain disjoint, the
+  conversion happens independently for each subsystem.
+* **Optional entangling layer** – when `entangling_layer=True` a final
+  chain of `CX` gates links neighbouring subsystems *after* the `T`
+  layer. This demonstrates that cross-group entanglement can be added
+  without interfering with the earlier Tableau→DD conversion.
+
+## Inspecting the conversion
+
+```python
+from benchmarks.partition_circuits import stim_to_dd_circuit
+from quasar.cost import Backend
+from quasar.partitioner import Partitioner
+
+circuit = stim_to_dd_circuit(num_groups=3, group_size=3)
+ssd = Partitioner().partition(circuit, debug=True)
+
+print([part.backend for part in ssd.partitions])
+# → [Backend.TABLEAU, Backend.DECISION_DIAGRAM, ...]
+
+print([(conv.source, conv.target, conv.boundary) for conv in ssd.conversions])
+# → [(Backend.TABLEAU, Backend.DECISION_DIAGRAM, (0, 1, 2)), ...]
+```
+
+Each conversion record captures the boundary qubits for one GHZ group.
+The accompanying unit test `tests/test_stim_to_dd_conversion.py`
+verifies that the planner emits the Tableau partition, switches to the
+decision-diagram backend after the `T` layer, and records the conversion
+layer diagnostics.

--- a/tests/test_stim_to_dd_conversion.py
+++ b/tests/test_stim_to_dd_conversion.py
@@ -1,0 +1,56 @@
+"""Tests for the stabiliser-to-decision-diagram conversion benchmark."""
+
+from __future__ import annotations
+
+from benchmarks.partition_circuits import stim_to_dd_circuit
+from quasar.cost import Backend
+from quasar.partitioner import Partitioner
+
+
+def test_stim_to_dd_partition_and_conversion() -> None:
+    """GHZ subsystems should trigger a tableau→DD backend switch."""
+
+    num_groups = 3
+    group_size = 3
+    circuit = stim_to_dd_circuit(
+        num_groups=num_groups,
+        group_size=group_size,
+        entangling_layer=False,
+    )
+
+    partitioner = Partitioner()
+    ssd = partitioner.partition(circuit, debug=True)
+
+    assert len(ssd.partitions) >= 2
+    first_partition = ssd.partitions[0]
+    assert first_partition.backend == Backend.TABLEAU
+
+    # The tableau fragment should expose one subsystem per GHZ group.
+    ghz_groups = {tuple(group) for group in first_partition.subsystems}
+    assert len(ghz_groups) == num_groups
+    assert all(len(group) == group_size for group in ghz_groups)
+
+    dd_partitions = [
+        part for part in ssd.partitions[1:] if part.backend == Backend.DECISION_DIAGRAM
+    ]
+    assert dd_partitions
+
+    # The DD partition should inherit the independent group structure so the
+    # conversion happens per subsystem.
+    dd_groups = {tuple(group) for group in dd_partitions[0].subsystems}
+    assert dd_groups == ghz_groups
+
+    # Check that the partitioner recorded the backend transition and
+    # conversion layer diagnostics.
+    assert any(
+        conv.source == Backend.TABLEAU and conv.target == Backend.DECISION_DIAGRAM
+        for conv in ssd.conversions
+    )
+    applied_switches = [
+        entry
+        for entry in ssd.trace
+        if entry.applied
+        and entry.from_backend == Backend.TABLEAU
+        and entry.to_backend == Backend.DECISION_DIAGRAM
+    ]
+    assert applied_switches


### PR DESCRIPTION
## Summary
- add `stim_to_dd_circuit` that builds independent GHZ subsystems, applies T layers, and optionally entangles them to force Tableau→DD conversion
- cover the new benchmark with `tests/test_stim_to_dd_conversion.py`
- document the conversion scenario in `docs/stim_to_dd_conversion.md`

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68ca1b078bac8321a4d3adb1d06cf163