### PR TITLE
Add decision diagram clone path and regression test

### DIFF
--- a/quasar/backends/mqt_dd.py
+++ b/quasar/backends/mqt_dd.py
@@ -66,7 +66,10 @@ class DecisionDiagramBackend(Backend):
         if mapping != list(range(n)):
             raise NotImplementedError("Qubit mapping not supported for decision diagrams")
         self.num_qubits = num_qubits
-        self.package = dd.DDPackage(self.num_qubits)
+        if self.package is None:
+            self.package = dd.DDPackage(self.num_qubits)
+        elif isinstance(self.state, dd.VectorDD):
+            self.package.dec_ref_vec(self.state)
         if isinstance(vec, dd.VectorDD) and num_qubits == n:
             self.package.inc_ref_vec(vec)
             self.state = vec

--- a/quasar_convert/__init__.py
+++ b/quasar_convert/__init__.py
@@ -418,6 +418,23 @@ except Exception:  # pragma: no cover - exercised when extension missing
         def convert_boundary_to_dd(self, ssd: SSD):
             return (len(ssd.boundary_qubits or []), 0)
 
+        def clone_dd_edge(self, num_qubits: int, edge: object, package: object):
+            """Fallback clone helper using dense vectors when the extension is missing."""
+
+            try:
+                from mqt.core import dd as mqt_dd  # type: ignore
+            except Exception:  # pragma: no cover - optional dependency
+                mqt_dd = None
+            if mqt_dd is not None and isinstance(edge, mqt_dd.VectorDD):
+                try:
+                    amps = edge.get_vector()
+                    if hasattr(package, "from_vector"):
+                        clone = package.from_vector(amps)
+                        return (num_qubits, clone)
+                except Exception:
+                    pass
+            return (num_qubits, edge)
+
         def learn_stabilizer(self, state: List[complex]):
             if not state:
                 return None

--- a/quasar_convert/binding.cpp
+++ b/quasar_convert/binding.cpp
@@ -1,7 +1,6 @@
 #include <pybind11/pybind11.h>
 #include <pybind11/stl.h>
 #include <pybind11/complex.h>
-#include <pybind11/conduit/pybind11_conduit_v1.h>
 
 #include <cstdint>
 #include <string>
@@ -133,16 +132,24 @@ PYBIND11_MODULE(_conversion_engine, m) {
                 std::size_t n,
                 py::object edge_obj,
                 py::object package_obj) {
-                 auto* edge_ptr =
-                     pybind11_conduit_v1::get_type_pointer_ephemeral<dd::vEdge>(edge_obj.ptr());
+                 dd::vEdge* edge_ptr = nullptr;
+                 try {
+                     edge_ptr = edge_obj.cast<dd::vEdge*>();
+                 } catch (const py::cast_error&) {
+                     throw std::runtime_error("Unable to access VectorDD edge pointer");
+                 }
                  if (edge_ptr == nullptr) {
                      throw std::runtime_error("Unable to access VectorDD edge pointer");
                  }
                  std::string buffer;
                  (void)eng.clone_dd_edge(n, *edge_ptr, buffer);
 
-                 auto* package_ptr =
-                     pybind11_conduit_v1::get_type_pointer_ephemeral<dd::Package<>>(package_obj.ptr());
+                 dd::Package<>* package_ptr = nullptr;
+                 try {
+                     package_ptr = package_obj.cast<dd::Package<>*>();
+                 } catch (const py::cast_error&) {
+                     throw std::runtime_error("Unable to access DDPackage pointer");
+                 }
                  if (package_ptr == nullptr) {
                      throw std::runtime_error("Unable to access DDPackage pointer");
                  }

--- a/quasar_convert/binding.cpp
+++ b/quasar_convert/binding.cpp
@@ -1,9 +1,12 @@
 #include <pybind11/pybind11.h>
 #include <pybind11/stl.h>
 #include <pybind11/complex.h>
+#include <pybind11/conduit/pybind11_conduit_v1.h>
 
 #include <cstdint>
 #include <string>
+#include <sstream>
+#include <stdexcept>
 
 #include "conversion_engine.hpp"
 
@@ -125,6 +128,34 @@ PYBIND11_MODULE(_conversion_engine, m) {
             std::uintptr_t ptr = reinterpret_cast<std::uintptr_t>(edge.p);
             return py::make_tuple(ssd.boundary_qubits.size(), ptr);
         })
+        .def("clone_dd_edge",
+             [](quasar::ConversionEngine& eng,
+                std::size_t n,
+                py::object edge_obj,
+                py::object package_obj) {
+                 auto* edge_ptr =
+                     pybind11_conduit_v1::get_type_pointer_ephemeral<dd::vEdge>(edge_obj.ptr());
+                 if (edge_ptr == nullptr) {
+                     throw std::runtime_error("Unable to access VectorDD edge pointer");
+                 }
+                 std::string buffer;
+                 (void)eng.clone_dd_edge(n, *edge_ptr, buffer);
+
+                 auto* package_ptr =
+                     pybind11_conduit_v1::get_type_pointer_ephemeral<dd::Package<>>(package_obj.ptr());
+                 if (package_ptr == nullptr) {
+                     throw std::runtime_error("Unable to access DDPackage pointer");
+                 }
+                 if (package_ptr->qubits() < n) {
+                     package_ptr->resize(n);
+                 }
+                 std::stringstream stream(buffer, std::ios::in | std::ios::binary);
+                 auto clone = package_ptr->deserialize<dd::vNode>(stream, true);
+                 return py::make_tuple(n, py::cast(clone));
+             },
+             py::arg("num_qubits"),
+             py::arg("edge"),
+             py::arg("package"))
         .def("dd_to_statevector", [](quasar::ConversionEngine& eng, std::size_t n, std::uintptr_t ptr) {
             // Reconstruct the decision diagram edge from the opaque handle and
             // export its amplitudes as a statevector.

--- a/quasar_convert/conversion_engine.hpp
+++ b/quasar_convert/conversion_engine.hpp
@@ -7,6 +7,7 @@
 #include <memory>
 #include <cstddef>
 #include <cstdint>
+#include <string>
 
 #ifdef QUASAR_USE_STIM
 #include <stim.h>
@@ -134,6 +135,11 @@ class ConversionEngine {
     // The decision diagram package exposes `vEdge` at the namespace level,
     // so we use it directly instead of the previous `Package<>::vEdge` alias.
     dd::vEdge convert_boundary_to_dd(const SSD& ssd) const;
+
+    // Clone a decision diagram edge into the conversion engine's package by
+    // round-tripping through the DD serialization format.  The caller can
+    // reuse ``buffer`` to construct package-local copies elsewhere.
+    dd::vEdge clone_dd_edge(std::size_t n, const dd::vEdge& edge, std::string& buffer) const;
 
     // Export the amplitudes represented by a decision diagram edge as a
     // normalised statevector.  The returned vector has dimension ``2^n`` where

--- a/tests/backends/test_mqt_dd_backend.py
+++ b/tests/backends/test_mqt_dd_backend.py
@@ -1,0 +1,30 @@
+import numpy as np
+import pytest
+
+from quasar.backends import DecisionDiagramBackend
+from quasar.scheduler import Scheduler
+from quasar_convert import ConversionEngine
+
+mqt_core = pytest.importorskip("mqt.core")
+
+
+def test_clone_preserves_decision_diagram_state():
+    dd = mqt_core.dd
+    original = DecisionDiagramBackend()
+    original.load(1)
+    original.apply_gate("X", [0])
+    extracted = original.extract_ssd()
+
+    engine = ConversionEngine()
+    scheduler = Scheduler(conversion_engine=engine)
+
+    target = DecisionDiagramBackend()
+    target.load(1)
+
+    clone = scheduler._clone_decision_diagram_state(extracted, target)
+    assert clone is not None
+    assert isinstance(clone[1], dd.VectorDD)
+
+    target.ingest(clone, num_qubits=1)
+    state = target.statevector()
+    np.testing.assert_allclose(state, np.array([0.0, 1.0], dtype=complex))


### PR DESCRIPTION
## Summary
- add a clone helper in the conversion engine that re-serializes decision diagram edges and reproduces them inside the local dd package
- expose the helper to Python, extend the scheduler to reuse VectorDD states, and update the DD backend ingest logic to share its package
- cover the regression with a backend test that verifies switching into the decision diagram backend preserves a non-zero state

## Testing
- pytest tests/backends/test_mqt_dd_backend.py


------
https://chatgpt.com/codex/tasks/task_e_68ca6c0f9a288321abaab294420c161e