### PR TITLE
Avoid dense exports for DD local-window conversions

### DIFF
--- a/quasar_convert/__init__.py
+++ b/quasar_convert/__init__.py
@@ -80,6 +80,12 @@ try:  # pragma: no cover - exercised when the extension is available
             self._ensure_impl()
             return self._impl.extract_local_window(*args, **kwargs)
 
+        if hasattr(_CEngine, "extract_local_window_dd"):
+
+            def extract_local_window_dd(self, *args, **kwargs):  # type: ignore[override]
+                self._ensure_impl()
+                return self._impl.extract_local_window_dd(*args, **kwargs)
+
         def convert(self, *args, **kwargs):
             self._ensure_impl()
             return self._impl.convert(*args, **kwargs)

--- a/quasar_convert/binding.cpp
+++ b/quasar_convert/binding.cpp
@@ -127,6 +127,23 @@ PYBIND11_MODULE(_conversion_engine, m) {
             std::uintptr_t ptr = reinterpret_cast<std::uintptr_t>(edge.p);
             return py::make_tuple(ssd.boundary_qubits.size(), ptr);
         })
+        .def("extract_local_window_dd",
+             [](quasar::ConversionEngine& eng,
+                py::object edge_obj,
+                const std::vector<uint32_t>& boundary) {
+                 dd::vEdge* edge_ptr = nullptr;
+                 try {
+                     edge_ptr = edge_obj.cast<dd::vEdge*>();
+                 } catch (const py::cast_error&) {
+                     throw std::runtime_error("Unable to access VectorDD edge pointer");
+                 }
+                 if (edge_ptr == nullptr) {
+                     throw std::runtime_error("Unable to access VectorDD edge pointer");
+                 }
+                 return eng.extract_local_window_dd(*edge_ptr, boundary);
+             },
+             py::arg("edge"),
+             py::arg("boundary"))
         .def("clone_dd_edge",
              [](quasar::ConversionEngine& eng,
                 std::size_t n,

--- a/quasar_convert/conversion_engine.hpp
+++ b/quasar_convert/conversion_engine.hpp
@@ -136,6 +136,13 @@ class ConversionEngine {
     // so we use it directly instead of the previous `Package<>::vEdge` alias.
     dd::vEdge convert_boundary_to_dd(const SSD& ssd) const;
 
+    // Extract the amplitudes of a local window directly from a decision
+    // diagram edge without materialising the full statevector.  The returned
+    // vector has dimension ``2**len(boundary)`` ordered with qubit 0 as the
+    // least significant bit.
+    std::vector<std::complex<double>> extract_local_window_dd(
+        const dd::vEdge& edge, const std::vector<uint32_t>& boundary) const;
+
     // Clone a decision diagram edge into the conversion engine's package by
     // round-tripping through the DD serialization format.  The caller can
     // reuse ``buffer`` to construct package-local copies elsewhere.

--- a/tests/test_scheduler_local_window_dd.py
+++ b/tests/test_scheduler_local_window_dd.py
@@ -1,0 +1,135 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Sequence
+
+import numpy as np
+import pytest
+
+from quasar.circuit import Circuit, Gate
+from quasar.cost import Backend, Cost
+from quasar.planner import PlanResult, PlanStep
+from quasar.scheduler import Scheduler
+from quasar.ssd import ConversionLayer, SSD, SSDPartition
+from quasar.backends.mqt_dd import DecisionDiagramBackend
+from quasar_convert import ConversionEngine
+
+
+@dataclass
+class DummyStatevectorBackend:
+    """Minimal statevector backend used for scheduler integration tests."""
+
+    backend: Backend = Backend.STATEVECTOR
+    num_qubits: int = 0
+    history: list[str] = field(default_factory=list)
+    state: np.ndarray | None = None
+
+    def load(self, num_qubits: int, **_: dict) -> None:
+        self.num_qubits = num_qubits
+        self.state = np.zeros(1 << num_qubits, dtype=complex)
+        if num_qubits:
+            self.state[0] = 1.0 + 0j
+        self.history.clear()
+
+    def ingest(
+        self,
+        state: Sequence[complex],
+        *,
+        num_qubits: int | None = None,
+        mapping: Sequence[int] | None = None,
+    ) -> None:
+        data = np.asarray(state, dtype=complex)
+        k = int(np.log2(len(data))) if len(data) else 0
+        if mapping is None:
+            mapping = list(range(k))
+        if num_qubits is None:
+            num_qubits = max(mapping, default=-1) + 1 if mapping else k
+        full = np.zeros(1 << num_qubits, dtype=complex)
+        for local in range(len(data)):
+            idx = 0
+            for bit, qubit in enumerate(mapping):
+                if (local >> bit) & 1:
+                    idx |= 1 << qubit
+            full[idx] = data[local]
+        self.num_qubits = num_qubits
+        self.state = full
+
+    def apply_gate(self, name: str, qubits: Sequence[int], params: dict | None = None) -> None:
+        raise AssertionError(f"Unexpected gate application: {name} on {qubits}")
+
+    def extract_ssd(self) -> SSD:
+        state = None if self.state is None else np.array(self.state, copy=True)
+        part = SSDPartition(
+            subsystems=(tuple(range(self.num_qubits)),),
+            history=tuple(self.history),
+            backend=self.backend,
+            state=state,
+        )
+        return SSD([part])
+
+    def statevector(self) -> np.ndarray:
+        if self.state is None:
+            return np.array([], dtype=complex)
+        return np.array(self.state, copy=True)
+
+
+def test_local_window_conversion_avoids_dense_export(monkeypatch: pytest.MonkeyPatch) -> None:
+    mqt_core = pytest.importorskip("mqt.core")
+    dd = mqt_core.dd
+
+    engine = ConversionEngine()
+    if not hasattr(engine, "extract_local_window_dd"):
+        pytest.skip("Decision diagram helper not available")
+
+    scheduler = Scheduler(
+        conversion_engine=engine,
+        backends={
+            Backend.DECISION_DIAGRAM: DecisionDiagramBackend(),
+            Backend.STATEVECTOR: DummyStatevectorBackend(),
+        },
+    )
+
+    circuit = Circuit([Gate("H", [0])], use_classical_simplification=False)
+
+    plan = PlanResult(
+        table=[],
+        final_backend=Backend.STATEVECTOR,
+        gates=circuit.gates,
+        explicit_steps=[
+            PlanStep(start=0, end=1, backend=Backend.DECISION_DIAGRAM),
+            PlanStep(start=1, end=1, backend=Backend.STATEVECTOR),
+        ],
+        explicit_conversions=[
+            ConversionLayer(
+                boundary=(0,),
+                source=Backend.DECISION_DIAGRAM,
+                target=Backend.STATEVECTOR,
+                rank=2,
+                frontier=1,
+                primitive="LW",
+                cost=Cost(time=0.0, memory=0.0),
+            )
+        ],
+        step_costs=[Cost(time=0.0, memory=0.0), Cost(time=0.0, memory=0.0)],
+    )
+
+    def fail_get_vector(self: dd.VectorDD) -> None:
+        raise AssertionError("Dense decision diagram export was invoked")
+
+    monkeypatch.setattr(dd.VectorDD, "get_vector", fail_get_vector)
+
+    def fail_extract_local_window(*args, **kwargs):
+        raise AssertionError("Dense helper used")
+
+    monkeypatch.setattr(engine, "extract_local_window", fail_extract_local_window)
+
+    result = scheduler.run(circuit, plan=plan)
+    assert isinstance(result, SSD)
+
+    state = result.extract_state(0)
+    assert isinstance(state, np.ndarray)
+    np.testing.assert_allclose(
+        state,
+        np.array([1 / np.sqrt(2.0), 1 / np.sqrt(2.0)], dtype=complex),
+        atol=1e-12,
+    )


### PR DESCRIPTION
## Summary
- add `ConversionEngine::extract_local_window_dd` to sample decision diagram edges without exporting dense vectors and expose it via the Python bindings
- route scheduler local-window conversions away from `statevector()` when the source backend is MQT's decision diagram engine
- cover the behaviour with a scheduler test that fails if `VectorDD.get_vector` is invoked during the conversion

## Testing
- pytest


------
https://chatgpt.com/codex/tasks/task_e_68ca73be496c83219c9459e141791a77