### PR TITLE
Use sparse DD conversions for MPS and tableau

### DIFF
--- a/quasar_convert/__init__.py
+++ b/quasar_convert/__init__.py
@@ -114,11 +114,23 @@ try:  # pragma: no cover - exercised when the extension is available
                 self._ensure_impl()
                 return self._impl.mps_to_statevector(*args, **kwargs)
 
+        if hasattr(_CEngine, "dense_statevector_queries"):
+
+            def dense_statevector_queries(self) -> int:  # type: ignore[override]
+                self._ensure_impl()
+                return int(self._impl.dense_statevector_queries())
+
         if hasattr(_CEngine, "convert_boundary_to_tableau"):
 
             def convert_boundary_to_tableau(self, *args, **kwargs):  # type: ignore[override]
                 self._ensure_impl()
                 return self._impl.convert_boundary_to_tableau(*args, **kwargs)
+
+        if hasattr(_CEngine, "dd_to_tableau"):
+
+            def dd_to_tableau(self, *args, **kwargs):  # type: ignore[override]
+                self._ensure_impl()
+                return self._impl.dd_to_tableau(*args, **kwargs)
 
         if hasattr(_CEngine, "tableau_to_statevector"):
 
@@ -421,6 +433,9 @@ except Exception:  # pragma: no cover - exercised when extension missing
 
             return Tableau(len(ssd.boundary_qubits or []))
 
+        def dd_to_tableau(self, *args, **kwargs):
+            return None
+
         def convert_boundary_to_dd(self, ssd: SSD):
             return (len(ssd.boundary_qubits or []), 0)
 
@@ -466,6 +481,9 @@ except Exception:  # pragma: no cover - exercised when extension missing
 
                 return Tableau(n)
             return None
+
+        def dense_statevector_queries(self) -> int:
+            return 0
 
     __all__ = [
         "SSD",

--- a/quasar_convert/binding.cpp
+++ b/quasar_convert/binding.cpp
@@ -98,6 +98,7 @@ PYBIND11_MODULE(_conversion_engine, m) {
         .def("convert_boundary_to_statevector", &quasar::ConversionEngine::convert_boundary_to_statevector)
         .def("convert_boundary_to_stn", &quasar::ConversionEngine::convert_boundary_to_stn)
         .def("mps_to_statevector", &quasar::ConversionEngine::mps_to_statevector)
+        .def("dense_statevector_queries", &quasar::ConversionEngine::dense_statevector_queries)
 #ifdef QUASAR_USE_STIM
         .def("convert_boundary_to_tableau", &quasar::ConversionEngine::convert_boundary_to_tableau)
         .def("tableau_to_statevector", &quasar::ConversionEngine::tableau_to_statevector)
@@ -198,6 +199,14 @@ PYBIND11_MODULE(_conversion_engine, m) {
              py::arg("n"),
              py::arg("ptr"),
              py::arg("chi") = 0)
+#if defined(QUASAR_USE_MQT) && defined(QUASAR_USE_STIM)
+        .def("dd_to_tableau",
+             [](quasar::ConversionEngine& eng, std::size_t n, std::uintptr_t ptr) {
+                 dd::vEdge edge{reinterpret_cast<dd::vNode*>(ptr), dd::Complex::one};
+                 (void)n;
+                 return eng.dd_to_tableau(edge);
+             })
+#endif
 #endif
         ;
 }

--- a/quasar_convert/conversion_engine.hpp
+++ b/quasar_convert/conversion_engine.hpp
@@ -168,6 +168,10 @@ class ConversionEngine {
     // first materialising the corresponding statevector and then ingesting it
     // into the DD package.
     dd::vEdge tableau_to_dd(const StimTableau& tableau) const;
+    // Attempt to infer a stabilizer tableau directly from a decision diagram
+    // representation without materialising a dense statevector.  Returns
+    // ``std::nullopt`` when the state does not match any recognised pattern.
+    std::optional<StimTableau> dd_to_tableau(const dd::vEdge& edge) const;
 #endif
 
 #ifdef QUASAR_USE_STIM
@@ -189,10 +193,14 @@ class ConversionEngine {
         const std::vector<std::complex<double>>& state) const;
 #endif
 
+    std::size_t dense_statevector_queries() const { return dense_statevector_calls; }
+
   private:
 #ifdef QUASAR_USE_MQT
     std::unique_ptr<dd::Package<>> dd_pkg;
 #endif
+
+    mutable std::size_t dense_statevector_calls = 0;
 
     std::vector<std::vector<std::complex<double>>>
     statevector_to_mps(const std::vector<std::complex<double>>& state,


### PR DESCRIPTION
## Summary
- implement an incremental DD→MPS decomposition, add a sparse DD→tableau extractor, and track dense statevector exports for diagnostics
- expose the new conversion helpers through the bindings and Python wrapper while keeping stub fallbacks for environments without MQT support
- extend the optional Stim/MQT tests to assert that DD conversions no longer trigger the dense helper on sizeable diagrams

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68ca7b8ca32c8321995940e67a5fe977