### PR TITLE
Add verbose logging to benchmark scripts

### DIFF
--- a/benchmarks/paper_figures.py
+++ b/benchmarks/paper_figures.py
@@ -1,8 +1,14 @@
-"""Generate reproducible benchmark figures for the QuASAr paper."""
+"""Generate reproducible benchmark figures for the QuASAr paper.
+
+Run the module as a script with ``--verbose`` to display progress logs while
+figures and result tables are generated.
+"""
 
 from __future__ import annotations
 
+import argparse
 import json
+import logging
 from dataclasses import dataclass
 from pathlib import Path
 import sys
@@ -51,6 +57,26 @@ FIGURES_DIR = Path(__file__).resolve().parent / "figures"
 RESULTS_DIR = Path(__file__).resolve().parent / "results"
 FIGURES_DIR.mkdir(parents=True, exist_ok=True)
 RESULTS_DIR.mkdir(parents=True, exist_ok=True)
+
+
+LOGGER = logging.getLogger(__name__)
+
+
+def _configure_logging(verbosity: int) -> None:
+    """Initialise logging for CLI usage."""
+
+    level = logging.WARNING
+    if verbosity >= 2:
+        level = logging.DEBUG
+    elif verbosity == 1:
+        level = logging.INFO
+    logging.basicConfig(level=level, format="%(levelname)s: %(message)s")
+
+
+def _log_written(path: Path) -> None:
+    """Emit a user-friendly message when ``path`` is written."""
+
+    LOGGER.info("Wrote %s", path)
 
 
 @dataclass
@@ -159,19 +185,40 @@ def collect_backend_data(
 ) -> tuple[pd.DataFrame, pd.DataFrame]:
     """Return forced and automatic scheduler results for ``specs``."""
 
+    spec_list = list(specs)
+    LOGGER.info(
+        "Collecting backend data for %d circuit family(ies)", len(spec_list)
+    )
+    if not spec_list:
+        LOGGER.warning("No circuit specifications provided; skipping collection")
+        return pd.DataFrame(), pd.DataFrame()
+
     engine = SimulationEngine()
     forced_records: list[dict[str, object]] = []
     auto_records: list[dict[str, object]] = []
 
-    for spec in specs:
+    for spec in spec_list:
+        LOGGER.info("Processing circuit family '%s'", spec.name)
         for n in spec.qubits:
+            LOGGER.info("Preparing circuits for %s with %s qubits", spec.name, n)
             circuit_forced = _build_circuit(spec, n, use_classical_simplification=False)
             circuit_auto = _build_circuit(spec, n, use_classical_simplification=True)
             if circuit_forced is None or circuit_auto is None:
+                LOGGER.warning(
+                    "Skipping circuit %s with %s qubits because construction failed",
+                    spec.name,
+                    n,
+                )
                 continue
 
             for backend in backends:
                 runner = BenchmarkRunner()
+                LOGGER.info(
+                    "Executing forced run: circuit=%s qubits=%s backend=%s",
+                    spec.name,
+                    n,
+                    backend.name,
+                )
                 try:
                     rec = runner.run_quasar_multiple(
                         circuit_forced,
@@ -191,6 +238,13 @@ def collect_backend_data(
                             "error": str(exc),
                         }
                     )
+                    LOGGER.warning(
+                        "Forced run failed for circuit=%s qubits=%s backend=%s: %s",
+                        spec.name,
+                        n,
+                        backend.name,
+                        exc,
+                    )
                     continue
 
                 rec.pop("result", None)
@@ -204,8 +258,19 @@ def collect_backend_data(
                     }
                 )
                 forced_records.append(rec)
+                LOGGER.info(
+                    "Completed forced run: circuit=%s qubits=%s backend=%s",
+                    spec.name,
+                    n,
+                    backend.name,
+                )
 
             runner = BenchmarkRunner()
+            LOGGER.info(
+                "Executing automatic run: circuit=%s qubits=%s backend=quasar",
+                spec.name,
+                n,
+            )
             try:
                 rec = runner.run_quasar_multiple(
                     circuit_auto,
@@ -213,7 +278,13 @@ def collect_backend_data(
                     repetitions=repetitions,
                     quick=False,
                 )
-            except Exception:  # pragma: no cover - skip unsupported mixes
+            except Exception as exc:  # pragma: no cover - skip unsupported mixes
+                LOGGER.warning(
+                    "Automatic scheduling failed for circuit=%s qubits=%s: %s",
+                    spec.name,
+                    n,
+                    exc,
+                )
                 continue
             rec.pop("result", None)
             rec.update(
@@ -225,14 +296,24 @@ def collect_backend_data(
                 }
             )
             auto_records.append(rec)
+            LOGGER.info(
+                "Completed automatic run: circuit=%s qubits=%s backend=quasar",
+                spec.name,
+                n,
+            )
 
     return pd.DataFrame(forced_records), pd.DataFrame(auto_records)
 
 
 def generate_backend_comparison() -> None:
+    LOGGER.info("Generating backend comparison figures")
     forced, auto = collect_backend_data(CIRCUITS, BACKENDS, repetitions=3)
-    forced.to_csv(RESULTS_DIR / "backend_forced.csv", index=False)
-    auto.to_csv(RESULTS_DIR / "backend_auto.csv", index=False)
+    forced_path = RESULTS_DIR / "backend_forced.csv"
+    auto_path = RESULTS_DIR / "backend_auto.csv"
+    forced.to_csv(forced_path, index=False)
+    auto.to_csv(auto_path, index=False)
+    _log_written(forced_path)
+    _log_written(auto_path)
 
     combined = pd.concat([forced, auto], ignore_index=True)
     ax, summary = plot_quasar_vs_baseline_best(
@@ -244,15 +325,25 @@ def generate_backend_comparison() -> None:
     )
     ax.set_title("Runtime comparison versus baseline best")
     ax.figure.tight_layout()
-    ax.figure.savefig(FIGURES_DIR / "backend_vs_baseline.png")
-    ax.figure.savefig(FIGURES_DIR / "backend_vs_baseline.pdf")
-    summary.to_csv(RESULTS_DIR / "backend_vs_baseline_speedups.csv", index=False)
+    png_path = FIGURES_DIR / "backend_vs_baseline.png"
+    pdf_path = FIGURES_DIR / "backend_vs_baseline.pdf"
+    csv_path = RESULTS_DIR / "backend_vs_baseline_speedups.csv"
+    ax.figure.savefig(png_path)
+    ax.figure.savefig(pdf_path)
+    _log_written(png_path)
+    _log_written(pdf_path)
+    summary.to_csv(csv_path, index=False)
+    _log_written(csv_path)
     plt.close(ax.figure)
 
     if not forced.empty and not auto.empty:
         grid = plot_backend_timeseries(forced, auto, metric="run_time_mean")
-        grid.savefig(FIGURES_DIR / "backend_timeseries_runtime.png")
-        grid.savefig(FIGURES_DIR / "backend_timeseries_runtime.pdf")
+        runtime_png = FIGURES_DIR / "backend_timeseries_runtime.png"
+        runtime_pdf = FIGURES_DIR / "backend_timeseries_runtime.pdf"
+        grid.savefig(runtime_png)
+        grid.savefig(runtime_pdf)
+        _log_written(runtime_png)
+        _log_written(runtime_pdf)
         plt.close(grid.fig)
 
         for frame in (forced, auto):
@@ -264,19 +355,36 @@ def generate_backend_comparison() -> None:
             metric="run_peak_memory_mean",
             annotate_auto=False,
         )
-        grid_mem.savefig(FIGURES_DIR / "backend_timeseries_memory.png")
-        grid_mem.savefig(FIGURES_DIR / "backend_timeseries_memory.pdf")
+        mem_png = FIGURES_DIR / "backend_timeseries_memory.png"
+        mem_pdf = FIGURES_DIR / "backend_timeseries_memory.pdf"
+        grid_mem.savefig(mem_png)
+        grid_mem.savefig(mem_pdf)
+        _log_written(mem_png)
+        _log_written(mem_pdf)
         plt.close(grid_mem.fig)
+    else:
+        LOGGER.info(
+            "Skipping backend timeseries plots because one of the result tables is empty"
+        )
 
 
 def generate_heatmap() -> None:
     results_path = RESULTS_DIR / "plan_choice_heatmap_results.json"
     if not results_path.exists():
+        LOGGER.info(
+            "Skipping plan-choice heatmap: results file %s is missing",
+            results_path,
+        )
         return
     data = json.loads(results_path.read_text())
     if not data:
+        LOGGER.info(
+            "Skipping plan-choice heatmap: results file %s is empty",
+            results_path,
+        )
         return
 
+    LOGGER.info("Generating plan-choice heatmap from %s", results_path)
     df = pd.DataFrame(data)
     df["selected_backend"] = df["steps"].apply(lambda steps: steps[-1] if steps else None)
     labels = backend_labels(df["selected_backend"].dropna().unique())
@@ -290,17 +398,28 @@ def generate_heatmap() -> None:
     )
 
     ax = plot_heatmap(pivot_numeric, annot=annot, fmt="")
-    ax.figure.savefig(FIGURES_DIR / "plan_choice_heatmap.png")
-    ax.figure.savefig(FIGURES_DIR / "plan_choice_heatmap.pdf")
-    annot.to_csv(RESULTS_DIR / "plan_choice_heatmap_table.csv")
+    heatmap_png = FIGURES_DIR / "plan_choice_heatmap.png"
+    heatmap_pdf = FIGURES_DIR / "plan_choice_heatmap.pdf"
+    table_csv = RESULTS_DIR / "plan_choice_heatmap_table.csv"
+    ax.figure.savefig(heatmap_png)
+    ax.figure.savefig(heatmap_pdf)
+    _log_written(heatmap_png)
+    _log_written(heatmap_pdf)
+    annot.to_csv(table_csv)
+    _log_written(table_csv)
     plt.close(ax.figure)
 
 
 def generate_speedup_bars() -> None:
     csv_path = Path(__file__).resolve().parent / "quick_analysis_results.csv"
     if not csv_path.exists():
+        LOGGER.info(
+            "Skipping speedup summary: quick-analysis results %s not found",
+            csv_path,
+        )
         return
     df = pd.read_csv(csv_path)
+    LOGGER.info("Generating speedup summary from %s", csv_path)
     df["label"] = df.apply(
         lambda row: f"{int(row['qubits'])}q d{int(row['depth'])}", axis=1
     )
@@ -308,15 +427,32 @@ def generate_speedup_bars() -> None:
     speedups = grouped["speedup"].mean().to_dict()
     ax = plot_speedup_bars(speedups)
     ax.figure.tight_layout()
-    ax.figure.savefig(FIGURES_DIR / "relative_speedups.png")
-    ax.figure.savefig(FIGURES_DIR / "relative_speedups.pdf")
-    grouped["speedup"].mean().reset_index().to_csv(
-        RESULTS_DIR / "relative_speedups.csv", index=False
-    )
+    speedup_png = FIGURES_DIR / "relative_speedups.png"
+    speedup_pdf = FIGURES_DIR / "relative_speedups.pdf"
+    speedup_csv = RESULTS_DIR / "relative_speedups.csv"
+    ax.figure.savefig(speedup_png)
+    ax.figure.savefig(speedup_pdf)
+    _log_written(speedup_png)
+    _log_written(speedup_pdf)
+    grouped["speedup"].mean().reset_index().to_csv(speedup_csv, index=False)
+    _log_written(speedup_csv)
     plt.close(ax.figure)
 
 
-def main() -> None:
+def main(argv: Sequence[str] | None = None) -> None:
+    parser = argparse.ArgumentParser(
+        description="Generate reproducible benchmark figures for the QuASAr paper",
+    )
+    parser.add_argument(
+        "-v",
+        "--verbose",
+        action="count",
+        default=0,
+        help="Increase logging verbosity (use -vv for debug output).",
+    )
+    args = parser.parse_args(argv)
+
+    _configure_logging(args.verbose)
     setup_benchmark_style()
     generate_backend_comparison()
     generate_heatmap()


### PR DESCRIPTION
## Summary
- add a shared --verbose flag to run_benchmarks so progress through circuit widths, backends, and scenarios is logged via the standard logging module
- instrument paper_figures with configurable logging, reporting circuit/backend combinations, file writes, and skipped optional plots
- extend quick_analysis_benchmark with a verbosity flag and progress/file logging before and after timing runs

## Testing
- python benchmarks/run_benchmarks.py --circuit qft --qubits 3:3 --repetitions 1 --output /tmp/qft_test --verbose
- python benchmarks/run_benchmarks.py --circuit grover --qubits 3:3 --repetitions 1 --output /tmp/grover_test --verbose
- python benchmarks/run_benchmarks.py --scenario staged_rank --repetitions 1 --output /tmp/scenario_test --verbose
- python - <<'PY'
from benchmarks import paper_figures as pf
from benchmarks.paper_figures import CircuitSpec
from quasar.cost import Backend
pf.CIRCUITS = (
    CircuitSpec('qft_small', pf.circuit_lib.qft_circuit, (3,), None),
)
pf.BACKENDS = (Backend.STATEVECTOR,)
pf.main(['--verbose'])
PY
- MPLBACKEND=Agg python benchmarks/quick_analysis_benchmark.py --verbose

------
https://chatgpt.com/codex/tasks/task_e_68cf6775e78c8321a7897f7069850ee4