### PR TITLE
Respect memory ceilings during planning

### DIFF
--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -60,10 +60,17 @@ phases as well as their sum:
   baseline entries, the backend that achieved the minimum runtime.
 
 Statevector simulations are skipped when the circuit width exceeds the
-available memory. A default budget of 64 GiB (about 32 qubits) is assumed but
-can be adjusted via the ``QUASAR_STATEVECTOR_MAX_MEMORY_BYTES`` environment
-variable, the global ``--memory-bytes`` flag on `run_benchmarks.py`, or by
-passing ``memory_bytes`` to ``BenchmarkRunner.run_quasar``/``run_quasar_multiple``.
+available memory. QuASAr now derives this ceiling from the
+``QUASAR_STATEVECTOR_MAX_MEMORY_BYTES`` environment variable and, when
+``psutil`` is installed, the system's currently available memory, falling back
+to 64 GiB (about 32 qubits). The resulting budget is cached by both the
+benchmark runner and the :class:`~quasar.simulation_engine.SimulationEngine`,
+ensuring the planner enforces the limit even when the quick path is bypassed.
+You can override the ceiling via the environment variable, the global
+``--memory-bytes`` flag on `run_benchmarks.py`, the ``memory_bytes`` keyword on
+``BenchmarkRunner.run_quasar``/``run_quasar_multiple``, or the
+``SimulationEngine(memory_threshold=...)`` and ``simulate(memory_threshold=...)``
+APIs. Supplying a non-positive threshold disables the guard for that call.
 
 ### Reproducing paper figures
 

--- a/benchmarks/runner.py
+++ b/benchmarks/runner.py
@@ -480,13 +480,26 @@ class BenchmarkRunner:
                 tracemalloc.start()
                 if planner is not None:
                     start_prepare = time.perf_counter()
-                    plan = planner.plan(circuit, backend=backend)
-                    plan = scheduler.prepare_run(circuit, plan, backend=backend)
+                    plan = planner.plan(
+                        circuit,
+                        backend=backend,
+                        max_memory=memory_bytes,
+                    )
+                    plan = scheduler.prepare_run(
+                        circuit,
+                        plan,
+                        backend=backend,
+                        max_memory=memory_bytes,
+                    )
                     prepare_time = time.perf_counter() - start_prepare
                     _, prepare_peak_memory = tracemalloc.get_traced_memory()
                 else:
                     start_prepare = time.perf_counter()
-                    plan = scheduler.prepare_run(circuit, backend=backend)
+                    plan = scheduler.prepare_run(
+                        circuit,
+                        backend=backend,
+                        max_memory=memory_bytes,
+                    )
                     prepare_time = time.perf_counter() - start_prepare
                     _, prepare_peak_memory = tracemalloc.get_traced_memory()
                 tracemalloc.stop()
@@ -698,10 +711,23 @@ class BenchmarkRunner:
             original_ssd = None
         else:
             if planner is not None:
-                plan = planner.plan(circuit, backend=backend)
-                plan = scheduler.prepare_run(circuit, plan, backend=backend)
+                plan = planner.plan(
+                    circuit,
+                    backend=backend,
+                    max_memory=memory_bytes,
+                )
+                plan = scheduler.prepare_run(
+                    circuit,
+                    plan,
+                    backend=backend,
+                    max_memory=memory_bytes,
+                )
             else:
-                plan = scheduler.prepare_run(circuit, backend=backend)
+                plan = scheduler.prepare_run(
+                    circuit,
+                    backend=backend,
+                    max_memory=memory_bytes,
+                )
             original_ssd = (
                 copy.deepcopy(getattr(circuit, "ssd", None)) if circuit is not None else None
             )

--- a/quasar/scheduler.py
+++ b/quasar/scheduler.py
@@ -473,6 +473,7 @@ class Scheduler:
         target_accuracy: float | None = None,
         max_time: float | None = None,
         optimization_level: int | None = None,
+        max_memory: float | None = None,
         explain: bool = False,
     ) -> PlanResult:
         """Prepare an execution plan for ``circuit``.
@@ -494,6 +495,10 @@ class Scheduler:
             Desired lower bound on simulation fidelity.
         max_time:
             Upper bound on estimated runtime in seconds.
+        max_memory:
+            Optional memory ceiling in bytes. Forwarded to the planner when a
+            cached plan is not available so that backend selection respects the
+            configured limit.
         optimization_level:
             Heuristic tuning knob influencing planner behaviour.
         explain:
@@ -567,6 +572,7 @@ class Scheduler:
                     backend=backend,
                     target_accuracy=target_accuracy,
                     max_time=max_time,
+                    max_memory=max_memory,
                     optimization_level=optimization_level,
                     explain=explain,
                 )

--- a/tests/test_no_feasible_backend.py
+++ b/tests/test_no_feasible_backend.py
@@ -1,6 +1,13 @@
 import pytest
 
-from quasar import Planner, Circuit, Gate, Backend, NoFeasibleBackendError
+from quasar import (
+    Planner,
+    Circuit,
+    Gate,
+    Backend,
+    NoFeasibleBackendError,
+    SimulationEngine,
+)
 
 
 def _t_gate_circuit():
@@ -25,3 +32,35 @@ def test_planner_selects_backend_when_memory_sufficient():
     circuit = _t_gate_circuit()
     result = planner.plan(circuit, max_memory=10**8)
     assert result.steps[0].backend == Backend.STATEVECTOR
+
+
+def test_simulation_engine_respects_detected_memory_limit(monkeypatch):
+    monkeypatch.setenv("QUASAR_STATEVECTOR_MAX_MEMORY_BYTES", "64")
+    engine = SimulationEngine()
+    assert engine.memory_threshold == pytest.approx(64.0)
+
+    # Three-qubit circuit exceeds the 64-byte budget required for dense
+    # statevectors (128 bytes for amplitudes).
+    circuit = Circuit(
+        [
+            Gate("H", [0]),
+            Gate("H", [1]),
+            Gate("H", [2]),
+            Gate("CX", [0, 1]),
+            Gate("T", [2]),
+        ],
+        use_classical_simplification=False,
+    )
+
+    called = {"run": False}
+
+    def _fail_run(*args, **kwargs):  # pragma: no cover - should not execute
+        called["run"] = True
+        raise AssertionError("scheduler.run should not be invoked when planning fails")
+
+    monkeypatch.setattr(engine.scheduler, "run", _fail_run)
+
+    with pytest.raises(NoFeasibleBackendError):
+        engine.simulate(circuit, backend=Backend.STATEVECTOR)
+
+    assert called["run"] is False


### PR DESCRIPTION
## Summary
- forward benchmark memory budgets into planner and scheduler preparation so full planning respects statevector limits
- have the simulation engine derive a default memory ceiling, pass it through planning, and document the new behaviour
- cover the regression with a simulation-engine test that ensures oversize circuits are rejected before backend execution

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68cf6f622e688321a920b9cc116473b9