### PR TITLE
Handle memory-bound planning fallback

### DIFF
--- a/tests/test_scheduler_memory_limit.py
+++ b/tests/test_scheduler_memory_limit.py
@@ -1,0 +1,62 @@
+import pytest
+
+from quasar.circuit import Circuit
+from quasar.cost import Backend
+from quasar import config
+from quasar.scheduler import Scheduler
+
+
+class ForceStatevectorScheduler(Scheduler):
+    """Scheduler that always selects the statevector quick path."""
+
+    def select_backend(
+        self,
+        circuit: Circuit,
+        *,
+        backend: Backend | None = None,
+        max_time: float | None = None,
+        optimization_level: int | None = None,
+    ) -> Backend | None:
+        return Backend.STATEVECTOR
+
+
+def _local_chain_circuit() -> Circuit:
+    return Circuit(
+        [
+            {"gate": "H", "qubits": [0]},
+            {"gate": "CX", "qubits": [0, 1]},
+            {"gate": "CX", "qubits": [1, 2]},
+            {"gate": "RZ", "qubits": [2], "params": {"theta": 0.5}},
+            {"gate": "CX", "qubits": [2, 3]},
+            {"gate": "CX", "qubits": [3, 4]},
+        ],
+        use_classical_simplification=False,
+    )
+
+
+def test_prepare_run_respects_memory_limit(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Quick-path execution must fall back when exceeding the memory budget."""
+
+    # Disable the decision diagram metric so that MPS becomes the preferred
+    # alternative backend once planning is triggered.
+    monkeypatch.setattr(config.DEFAULT, "dd_metric_threshold", 2.0)
+
+    circuit = _local_chain_circuit()
+    scheduler = ForceStatevectorScheduler(
+        backend_order=[
+            Backend.STATEVECTOR,
+            Backend.MPS,
+            Backend.DECISION_DIAGRAM,
+            Backend.TABLEAU,
+        ],
+        quick_max_qubits=10,
+        quick_max_gates=32,
+        quick_max_depth=32,
+    )
+
+    plan = scheduler.prepare_run(circuit, max_memory=60_000)
+
+    assert plan.final_backend != Backend.STATEVECTOR
+    assert all(step.backend != Backend.STATEVECTOR for step in plan.steps)
+    assert plan.step_costs
+    assert max(cost.memory for cost in plan.step_costs) <= 60_000


### PR DESCRIPTION
## Summary
- stop `_supported_backends` and the DP planner from re-adding statevector plans that exceed the configured memory budget and surface `NoFeasibleBackendError` with detailed context when no feasible backend remains
- make `Planner.plan` and `Scheduler.prepare_run` catch the new failure path, rerun planning instead of forcing the quick path, and report clear memory-limit violations
- add a regression test ensuring the scheduler falls back to an alternative backend when a forced statevector quick path would overrun the memory limit

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68cf751218248321854d4ce654b54875