### PR TITLE
Make Circuit objects JSON serializable

### DIFF
--- a/quasar/circuit.py
+++ b/quasar/circuit.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass, field
-from typing import Any, Dict, Iterable, List
+from typing import Any, Dict, Iterable, List, Mapping
 import json
 import os
 import math
@@ -14,6 +14,30 @@ from qiskit_qasm3_import import api as qasm3_api
 from .ssd import SSD, SSDPartition
 from .cost import Cost, CostEstimator, Backend
 from .decompositions import decompose_mcx, decompose_ccz, decompose_cswap
+
+
+def _cost_to_dict(cost: Cost) -> Dict[str, float]:
+    """Return a plain dictionary representation for :class:`~quasar.cost.Cost`."""
+
+    return {
+        "time": cost.time,
+        "memory": cost.memory,
+        "log_depth": cost.log_depth,
+        "conversion": cost.conversion,
+        "replay": cost.replay,
+    }
+
+
+def _dict_to_cost(data: Mapping[str, Any]) -> Cost:
+    """Create a :class:`~quasar.cost.Cost` from a mapping of numeric values."""
+
+    return Cost(
+        time=float(data.get("time", 0.0)),
+        memory=float(data.get("memory", 0.0)),
+        log_depth=float(data.get("log_depth", 0.0)),
+        conversion=float(data.get("conversion", 0.0)),
+        replay=float(data.get("replay", 0.0)),
+    )
 
 
 def _is_multiple_of_pi(angle: float) -> bool:
@@ -48,6 +72,51 @@ class Gate:
             self.gate == other.gate
             and self.qubits == other.qubits
             and self.params == other.params
+        )
+
+    def to_dict(self, *, include_metadata: bool = False) -> Dict[str, Any]:
+        """Return a JSON-serialisable representation of the gate."""
+
+        data: Dict[str, Any] = {
+            "gate": self.gate,
+            "qubits": list(self.qubits),
+        }
+        if self.params:
+            data["params"] = dict(self.params)
+        if include_metadata:
+            data["entanglement"] = self.entanglement
+            if self.compatible_methods:
+                data["compatible_methods"] = list(self.compatible_methods)
+            if self.resource_estimates:
+                data["resource_estimates"] = {
+                    name: _cost_to_dict(cost)
+                    for name, cost in self.resource_estimates.items()
+                }
+        return data
+
+    def __json__(self) -> Dict[str, Any]:  # pragma: no cover - exercised indirectly
+        """Return the structure used by :mod:`json` during serialisation."""
+
+        return self.to_dict(include_metadata=True)
+
+    @classmethod
+    def from_dict(cls, data: Mapping[str, Any]) -> "Gate":
+        """Create a :class:`Gate` instance from a mapping."""
+
+        params = dict(data.get("params", {}))
+        resources: Dict[str, Cost] = {}
+        for name, cost in data.get("resource_estimates", {}).items():
+            if isinstance(cost, Cost):
+                resources[name] = cost
+            elif isinstance(cost, Mapping):
+                resources[name] = _dict_to_cost(cost)
+        return cls(
+            gate=str(data["gate"]),
+            qubits=list(data["qubits"]),
+            params=params,
+            entanglement=data.get("entanglement", "none"),
+            compatible_methods=list(data.get("compatible_methods", [])),
+            resource_estimates=resources,
         )
 
 
@@ -109,6 +178,60 @@ class Circuit:
             self.amplitude_rotation_diversity = amplitude_rotation_diversity(self)
             # Backward compatibility
             self.rotation_diversity = self.phase_rotation_diversity
+
+    # ------------------------------------------------------------------
+    # JSON serialisation helpers
+    # ------------------------------------------------------------------
+    def to_dict(self, *, include_metadata: bool = True) -> Dict[str, Any]:
+        """Return a JSON-serialisable representation of the circuit."""
+
+        data: Dict[str, Any] = {
+            "use_classical_simplification": self.use_classical_simplification,
+            "gates": [gate.to_dict(include_metadata=include_metadata) for gate in self.gates],
+        }
+        if include_metadata:
+            data["num_qubits"] = self._num_qubits
+            data["classical_state"] = list(self.classical_state)
+            if hasattr(self, "_num_gates"):
+                data["num_gates"] = self._num_gates
+            if hasattr(self, "_depth"):
+                data["depth"] = self._depth
+            for attr in (
+                "sparsity",
+                "symmetry",
+                "phase_rotation_diversity",
+                "amplitude_rotation_diversity",
+                "rotation_diversity",
+            ):
+                if hasattr(self, attr):
+                    data[attr] = getattr(self, attr)
+            if hasattr(self, "cost_estimates"):
+                data["cost_estimates"] = {
+                    name: _cost_to_dict(cost)
+                    for name, cost in self.cost_estimates.items()
+                }
+        return data
+
+    def to_json(
+        self,
+        path: str | os.PathLike[str] | None = None,
+        *,
+        include_metadata: bool = True,
+        **json_kwargs: Any,
+    ) -> str:
+        """Serialise the circuit to JSON and optionally write it to ``path``."""
+
+        payload = self.to_dict(include_metadata=include_metadata)
+        text = json.dumps(payload, **json_kwargs)
+        if path is not None:
+            with open(os.fspath(path), "w", encoding="utf8") as fh:
+                fh.write(text)
+        return text
+
+    def __json__(self) -> Dict[str, Any]:  # pragma: no cover - exercised indirectly
+        """Return the structure used by :mod:`json` during serialisation."""
+
+        return self.to_dict(include_metadata=True)
 
     def _expand_decompositions(self) -> None:
         """Replace higher-level gates by their basic equivalents."""
@@ -407,11 +530,31 @@ class Circuit:
     @classmethod
     def from_dict(
         cls,
-        gates: Iterable[Dict[str, Any]],
+        data: Iterable[Dict[str, Any]] | Mapping[str, Any],
         *,
         use_classical_simplification: bool = True,
-    ):
-        """Build a circuit from an iterable of gate dictionaries."""
+    ) -> "Circuit":
+        """Build a circuit from an iterable of gate dictionaries or a mapping."""
+
+        if isinstance(data, Mapping):
+            gates_data = data.get("gates")
+            if gates_data is None:
+                raise ValueError("Circuit dictionary must contain a 'gates' entry")
+            use_classical_simplification = bool(
+                data.get("use_classical_simplification", use_classical_simplification)
+            )
+            gates_iterable = gates_data
+        else:
+            gates_iterable = data
+
+        gates: List[Dict[str, Any] | Gate] = []
+        for gate in gates_iterable:
+            if isinstance(gate, Gate):
+                gates.append(gate)
+            elif isinstance(gate, Mapping):
+                gates.append(Gate.from_dict(gate))
+            else:
+                gates.append(gate)
         return cls(gates, use_classical_simplification=use_classical_simplification)
 
     @classmethod
@@ -427,7 +570,10 @@ class Circuit:
         """
         with open(path, "r", encoding="utf8") as f:
             data = json.load(f)
-        return cls(data, use_classical_simplification=use_classical_simplification)
+        return cls.from_dict(
+            data,
+            use_classical_simplification=use_classical_simplification,
+        )
 
     @classmethod
     def from_qiskit(
@@ -538,3 +684,28 @@ class Circuit:
     def num_qubits(self) -> int:
         """Number of qubits spanned by the circuit."""
         return self._num_qubits
+
+
+_JSON_SUPPORT_INSTALLED = False
+
+
+def _install_json_support() -> None:
+    """Extend :mod:`json` so that it recognises objects exposing ``__json__``."""
+
+    global _JSON_SUPPORT_INSTALLED
+    if _JSON_SUPPORT_INSTALLED:
+        return
+    _JSON_SUPPORT_INSTALLED = True
+
+    original_default = json.JSONEncoder.default
+
+    def _quasar_json_default(self: json.JSONEncoder, obj: Any) -> Any:
+        if hasattr(obj, "__json__"):
+            return obj.__json__()
+        return original_default(self, obj)
+
+    json.JSONEncoder.default = _quasar_json_default  # type: ignore[assignment]
+    json._default_encoder = json.JSONEncoder()
+
+
+_install_json_support()

--- a/tests/test_circuit_serialization.py
+++ b/tests/test_circuit_serialization.py
@@ -1,0 +1,39 @@
+"""Tests for serialising :class:`~quasar.circuit.Circuit` objects."""
+
+from __future__ import annotations
+
+import json
+
+from quasar.circuit import Circuit
+
+
+def _simple_circuit() -> Circuit:
+    return Circuit(
+        [
+            {"gate": "H", "qubits": [0]},
+            {"gate": "CX", "qubits": [0, 1]},
+            {"gate": "RZ", "qubits": [1], "params": {"theta": 1.57079632679}},
+        ]
+    )
+
+
+def test_circuit_is_json_serialisable() -> None:
+    circuit = _simple_circuit()
+
+    encoded = json.dumps(circuit)
+    payload = json.loads(encoded)
+
+    assert payload["use_classical_simplification"] is True
+    assert [gate["gate"] for gate in payload["gates"]] == ["H", "CX", "RZ"]
+
+
+def test_circuit_round_trip_via_json(tmp_path) -> None:
+    circuit = _simple_circuit()
+
+    json_path = tmp_path / "circuit.json"
+    text = circuit.to_json(json_path, indent=2)
+
+    assert json_path.read_text() == text
+
+    restored = Circuit.from_json(json_path)
+    assert restored.to_dict(include_metadata=False) == circuit.to_dict(include_metadata=False)


### PR DESCRIPTION
## Summary
- add `Circuit.to_dict`/`to_json` helpers plus JSON encoder hooks so `json.dumps` works on circuit and gate objects
- ensure gate metadata can be reconstructed from dictionaries when loading circuits
- add regression tests covering circuit JSON serialisation and round-tripping

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68cf9873fa4883218158b5a10b64dd7e