### PR TITLE
Handle NaN baselines in compute_baseline_best

### DIFF
--- a/tests/test_plot_utils.py
+++ b/tests/test_plot_utils.py
@@ -66,3 +66,27 @@ def test_plot_quasar_vs_baseline_best_returns_speedup_table():
         assert "speedup" in summary.columns
     finally:
         plt.close(ax.figure)
+
+
+def test_compute_baseline_best_handles_all_nan_metrics():
+    df = pd.DataFrame(
+        [
+            {
+                "framework": "STATEVECTOR",
+                "backend": "STATEVECTOR",
+                "circuit": "qft",
+                "qubits": 3,
+                "run_time_mean": float("nan"),
+                "run_time_std": float("nan"),
+            }
+        ]
+    )
+
+    result = compute_baseline_best(df, metrics=["run_time_mean"])
+
+    assert isinstance(result, pd.DataFrame)
+    assert result.empty
+    assert isinstance(result.index, pd.RangeIndex)
+    assert "run_time_mean" in result.columns
+    assert "framework" in result.columns
+    assert "backend" in result.columns


### PR DESCRIPTION
## Summary
- filter baseline benchmark rows lacking finite values for the requested metrics before aggregating
- keep standard deviation columns and backend metadata for valid minima while returning stable empty frames when no baseline data remains
- add a regression test covering all-NaN baseline inputs

## Testing
- pytest


------
https://chatgpt.com/codex/tasks/task_e_68d01681692c83218e132f8b2c5af201