### PR TITLE
Add abbreviated backend labels for heatmap annotations

### DIFF
--- a/benchmarks/paper_figures.py
+++ b/benchmarks/paper_figures.py
@@ -805,8 +805,12 @@ def generate_heatmap() -> None:
     LOGGER.info("Generating plan-choice heatmap from %s", results_path)
     df = pd.DataFrame(data)
     df["selected_backend"] = df["steps"].apply(lambda steps: steps[-1] if steps else None)
-    labels = backend_labels(df["selected_backend"].dropna().unique())
-    df["label"] = df["selected_backend"].map(lambda name: labels.get(name, name))
+    unique_backends = df["selected_backend"].dropna().unique()
+    labels = backend_labels(unique_backends)
+    short_labels = backend_labels(unique_backends, abbreviated=True)
+    df["label"] = df["selected_backend"].map(
+        lambda name: short_labels.get(name, labels.get(name, name))
+    )
 
     pivot = df.pivot(index="circuit", columns="alpha", values="selected_backend")
     annot = df.pivot(index="circuit", columns="alpha", values="label")

--- a/benchmarks/plot_utils.py
+++ b/benchmarks/plot_utils.py
@@ -29,17 +29,28 @@ class BackendStyle:
     marker: str
     label: str
     tag: str | None = None
+    short_label: str | None = None
 
 
 _DEFAULT_BACKEND_STYLES: Mapping[str, BackendStyle] = {
-    "quasar": BackendStyle("#1b9e77", "o", "QuASAr", "QA"),
-    "baseline_best": BackendStyle("#264653", "s", "Baseline best", "BB"),
-    "sv": BackendStyle("#1f77b4", "o", "Statevector", "SV"),
-    "tab": BackendStyle("#ff7f0e", "^", "Tableau", "TB"),
-    "mps": BackendStyle("#2ca02c", "D", "MPS", "MPS"),
-    "dd": BackendStyle("#d62728", "s", "DD", "DD"),
-    "stim": BackendStyle("#9467bd", "P", "Stim", "ST"),
-    "mqt_dd": BackendStyle("#8c564b", "s", "MQT-DD", "MQ"),
+    "quasar": BackendStyle(
+        "#1b9e77", "o", "QuASAr", tag="QA", short_label="QuASAr"
+    ),
+    "baseline_best": BackendStyle(
+        "#264653", "s", "Baseline best", tag="BB", short_label="Baseline"
+    ),
+    "sv": BackendStyle(
+        "#1f77b4", "o", "Statevector", tag="SV", short_label="SV"
+    ),
+    "tab": BackendStyle(
+        "#ff7f0e", "^", "Tableau", tag="Tab", short_label="Tab"
+    ),
+    "mps": BackendStyle("#2ca02c", "D", "MPS", tag="MPS", short_label="MPS"),
+    "dd": BackendStyle("#d62728", "s", "DD", tag="DD", short_label="DD"),
+    "stim": BackendStyle("#9467bd", "P", "Stim", tag="ST", short_label="Stim"),
+    "mqt_dd": BackendStyle(
+        "#8c564b", "s", "MQT-DD", tag="MQ", short_label="MQT-DD"
+    ),
 }
 
 
@@ -214,16 +225,34 @@ def backend_markers(order: Iterable[object] | None = None) -> Mapping[object, st
     return markers
 
 
-def backend_labels(order: Iterable[object] | None = None) -> Mapping[object, str]:
-    """Return short, publication friendly labels for backends."""
+def backend_labels(
+    order: Iterable[object] | None = None,
+    *,
+    abbreviated: bool = False,
+) -> Mapping[object, str]:
+    """Return publication friendly labels for backends.
+
+    Parameters
+    ----------
+    order:
+        Optional iterable specifying the backends to include.  When omitted
+        the helper returns all known backends in their default ordering.
+    abbreviated:
+        When set, prefer compact identifiers such as ``"Tab"`` for Tableau in
+        place of the full backend names.  ``backend_labels`` falls back to the
+        full label if a backend does not define a short variant.
+    """
 
     if order is None:
         order = _DEFAULT_BACKEND_STYLES.keys()
     labels: dict[object, str] = {}
     for backend in order:
         style = _style_for_backend(backend)
-        if style is not None:
-            labels[backend] = style.label
+        if style is None:
+            continue
+        label = style.short_label if abbreviated and style.short_label else style.label
+        if label:
+            labels[backend] = label
     return labels
 
 


### PR DESCRIPTION
## Summary
- add short_label metadata to backend styles and extend backend_labels with an abbreviated option
- expose compact labels such as "SV" and "Tab" to generate_heatmap when building annotations and tables

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d13d1ec2d883218fd71cf696752583