### PR TITLE
Fix memory metric labelling in backend timeseries

### DIFF
--- a/benchmarks/paper_figures.py
+++ b/benchmarks/paper_figures.py
@@ -764,9 +764,9 @@ def generate_backend_comparison(
                 frame["run_peak_memory_mib"] = frame.get("run_peak_memory_mean", 0) / (1024**2)
 
             grid_mem = plot_backend_timeseries(
-                forced.assign(run_peak_memory_mean=forced["run_peak_memory_mib"]),
-                auto.assign(run_peak_memory_mean=auto["run_peak_memory_mib"]),
-                metric="run_peak_memory_mean",
+                forced,
+                auto,
+                metric="run_peak_memory_mib",
                 annotate_auto=False,
                 col_wrap=2,
                 height=3.6,

--- a/benchmarks/plot_utils.py
+++ b/benchmarks/plot_utils.py
@@ -348,6 +348,12 @@ def _annotate_backends(
 
 
 def _metric_label(name: str) -> str:
+    specific = {
+        "run_peak_memory_mib": "Run peak memory (MiB)",
+    }
+    if name in specific:
+        return specific[name]
+
     pretty = name.replace("_", " ")
     return pretty.replace(" mean", "")
 


### PR DESCRIPTION
## Summary
- rename the derived backend memory metric to run_peak_memory_mib and pass it to the comparison plot
- add a specific metric label so memory plots display “Run peak memory (MiB)”

## Testing
- PYTHONPATH=. python benchmarks/paper_figures.py --reuse-existing

------
https://chatgpt.com/codex/tasks/task_e_68d2442a88d48321a7be7b9bc8c077f6