### PR TITLE
Use backend palette for plan-choice heatmap

### DIFF
--- a/benchmarks/plot_utils.py
+++ b/benchmarks/plot_utils.py
@@ -6,6 +6,7 @@ from dataclasses import dataclass
 from typing import Iterable, Mapping, Sequence, Literal, overload
 
 import matplotlib.pyplot as plt
+import matplotlib.colors as mcolors
 from matplotlib.legend import Legend
 import numpy as np
 import pandas as pd
@@ -614,8 +615,11 @@ def plot_heatmap(
     *,
     annot: bool = True,
     fmt: str = "",
-    cmap: str = "viridis",
+    cmap: mcolors.Colormap | str = "viridis",
+    norm: mcolors.Normalize | None = None,
+    cbar: bool = True,
     ax: plt.Axes | None = None,
+    **heatmap_kwargs,
 ) -> plt.Axes:
     """Render a heatmap with the shared style settings.
 
@@ -627,7 +631,16 @@ def plot_heatmap(
         raise RuntimeError("seaborn is required for plot_heatmap")
     if ax is None:
         ax = plt.gca()
-    sns.heatmap(pivot, annot=annot, fmt=fmt, cmap=cmap, ax=ax)
+    sns.heatmap(
+        pivot,
+        annot=annot,
+        fmt=fmt,
+        cmap=cmap,
+        norm=norm,
+        cbar=cbar,
+        ax=ax,
+        **heatmap_kwargs,
+    )
     return ax
 
 


### PR DESCRIPTION
## Summary
- build a ListedColormap from the backend palette when generating the plan-choice heatmap and add a legend for backend colors
- allow `plot_heatmap` to accept Matplotlib colormaps, normalisation, and passthrough keyword arguments so discrete palettes can be used

## Testing
- python -m benchmarks.paper_figures --reuse-existing


------
https://chatgpt.com/codex/tasks/task_e_68d248fe0fa483219047425a931b2fe0