### PR TITLE
Avoid MPS-heavy paper figure runs

### DIFF
--- a/benchmarks/paper_figures.py
+++ b/benchmarks/paper_figures.py
@@ -569,6 +569,34 @@ def collect_backend_data(
                 spec.name,
                 n,
             )
+            auto_skip_reason = _mps_skip_reason(
+                circuit_auto,
+                n,
+                forced_width=auto_width,
+            )
+            if auto_skip_reason:
+                LOGGER.info(
+                    "Skipping automatic run: circuit=%s qubits=%s reason=%s",
+                    spec.name,
+                    n,
+                    auto_skip_reason,
+                )
+                auto_records.append(
+                    {
+                        "circuit": spec.name,
+                        "qubits": n,
+                        "actual_qubits": auto_width,
+                        "framework": "quasar",
+                        "backend": Backend.MPS.name,
+                        "mode": "auto",
+                        "unsupported": True,
+                        "failed": False,
+                        "error": auto_skip_reason,
+                        "comment": auto_skip_reason,
+                        "repetitions": 0,
+                    }
+                )
+                continue
             try:
                 rec = runner.run_quasar_multiple(
                     circuit_auto,

--- a/tests/test_paper_figures.py
+++ b/tests/test_paper_figures.py
@@ -69,10 +69,14 @@ def test_collect_backend_data_marks_statevector_unsupported(monkeypatch, recwarn
     assert row["actual_qubits"] > paper_figures.STATEVECTOR_MAX_QUBITS
     assert "exceeding statevector limit" in row["error"]
     assert Backend.STATEVECTOR not in calls
-    assert calls == [None]
+    assert calls == []
 
     assert auto.shape[0] == 1
-    assert auto.iloc[0]["mode"] == "auto"
+    row_auto = auto.iloc[0]
+    assert row_auto["mode"] == "auto"
+    assert row_auto["backend"] == Backend.MPS.name
+    assert row_auto["unsupported"]
+    assert "ancilla expansion" in row_auto["error"]
 
     assert not recwarn.list
     assert not [record for record in caplog.records if record.levelno >= logging.WARNING]
@@ -127,7 +131,7 @@ def test_collect_backend_data_marks_mps_ancilla_unsupported(monkeypatch, recwarn
     assert "exceeds statevector limit" in row["comment"]
     assert "dense memory" in row["comment"]
     assert Backend.MPS not in calls
-    assert calls == [None]
+    assert calls == []
 
     assert auto.shape[0] == 1
     assert auto.iloc[0]["mode"] == "auto"


### PR DESCRIPTION
## Summary
- skip automatic scheduler executions for paper_figures circuits whose ancilla-expanded width would exceed the statevector limit and blow up the Aer MPS backend
- record the skip in the backend CSV with an unsupported entry so downstream tooling still sees the circuit
- update the paper_figures tests to assert the new skip behaviour

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68d26c789860832185935e639e4b645e