### PR TITLE
Penalise nonlocal MPS segments

### DIFF
--- a/quasar/planner.py
+++ b/quasar/planner.py
@@ -719,6 +719,21 @@ class Planner:
             ("amplitude_rotation_diversity", "amp_div", lambda v: str(int(v))),
             ("nnz", "nnz", lambda v: str(int(v))),
             ("local", "local", lambda v: "yes" if v else "no"),
+            (
+                "mps_long_range_fraction",
+                "mps_long",
+                lambda v: f"{float(v):.3f}",
+            ),
+            (
+                "mps_long_range_extent",
+                "mps_span",
+                lambda v: f"{float(v):.3f}",
+            ),
+            (
+                "mps_max_interaction_distance",
+                "mps_maxd",
+                lambda v: str(int(v)),
+            ),
         ]
         metric_parts: List[str] = []
         for key, label, fmt in metric_fields:

--- a/tests/benchmarks/test_random_clifford_mps.py
+++ b/tests/benchmarks/test_random_clifford_mps.py
@@ -1,0 +1,95 @@
+from __future__ import annotations
+
+import types
+
+import numpy as np
+
+from quasar.circuit import Circuit, Gate
+from quasar.cost import Backend, CostEstimator
+from quasar.planner import Planner
+
+
+def random_clifford_t_circuit(
+    num_qubits: int, *, depth_multiplier: int = 3, seed: int = 97
+) -> Circuit:
+    """Replica of the ``random_clifford_t`` workload used in benchmarks."""
+
+    depth = depth_multiplier * num_qubits
+    rng = np.random.default_rng(seed + num_qubits)
+    gates: list[Gate] = []
+
+    for _ in range(depth):
+        for qubit in range(num_qubits):
+            gate = rng.choice(["H", "S"])
+            gates.append(Gate(gate, [qubit]))
+        if num_qubits > 1:
+            a, b = rng.choice(num_qubits, 2, replace=False)
+            two_gate = "CX" if rng.random() < 0.5 else "CZ"
+            gates.append(Gate(two_gate, [int(a), int(b)]))
+        target = int(rng.integers(num_qubits)) if num_qubits else 0
+        gates.append(Gate("T", [target]))
+
+    return Circuit(gates, use_classical_simplification=False)
+
+
+def calibrated_estimator() -> CostEstimator:
+    """Return an estimator where MPS beats dense simulation for the workload."""
+
+    estimator = CostEstimator()
+    estimator.coeff.update(
+        {
+            "mps_gate_1q": 0.001,
+            "mps_gate_2q": 0.001,
+            "mps_trunc": 0.001,
+            "mps_base_time": 0.0,
+            "mps_long_range_weight": 0.05,
+            "mps_long_range_extent_weight": 0.05,
+            "sv_gate_1q": 1.0,
+            "sv_gate_2q": 1.0,
+            "sv_base_time": 0.5,
+        }
+    )
+    return estimator
+
+
+def test_planner_prefers_mps_for_random_clifford_when_faster() -> None:
+    circuit = random_clifford_t_circuit(8)
+    estimator = calibrated_estimator()
+
+    def fixed_chi_for_constraints(
+        self: CostEstimator,
+        num_qubits: int,
+        gates: list[Gate],
+        fidelity: float,
+        max_memory: float | None = None,
+    ) -> int:
+        return 8
+
+    estimator.chi_for_constraints = types.MethodType(
+        fixed_chi_for_constraints, estimator
+    )
+
+    planner = Planner(
+        estimator=estimator,
+        quick_max_qubits=64,
+        quick_max_gates=512,
+        quick_max_depth=512,
+    )
+
+    plan = planner.plan(circuit, explain=True, target_accuracy=0.8)
+    assert plan.final_backend == Backend.MPS
+    assert plan.diagnostics is not None
+
+    single = plan.diagnostics.backend_selection["single"]
+    assert single["selected_backend"] == Backend.MPS
+
+    metrics = single["metrics"]
+    assert metrics["mps_long_range_fraction"] > 0.0
+
+    backends = single["backends"]
+    assert backends[Backend.MPS]["feasible"] is True
+    assert backends[Backend.STATEVECTOR]["feasible"] is True
+
+    mps_time = backends[Backend.MPS]["cost"].time
+    sv_time = backends[Backend.STATEVECTOR]["cost"].time
+    assert mps_time < sv_time


### PR DESCRIPTION
## Summary
- replace the method selector's nearest-neighbour gate check with long-range locality metrics that feed the diagnostics
- extend the MPS cost model to penalise distant entanglers via new calibration coefficients
- add a regression under tests/benchmarks to ensure random_clifford_t workloads pick MPS when it is calibrated faster

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d2e1af52d08321a84558017bc676cd