### PR TITLE
Add networkx SSD visualisation helpers

### DIFF
--- a/docs/partitioning_theory.md
+++ b/docs/partitioning_theory.md
@@ -396,3 +396,31 @@ documented assumptions with the concrete heuristics above provides clear targets
 for the calculator implementation: expose the selector metrics, replace coarse
 rank defaults, and thread calibration metadata through the partition trace so
 theoretical analyses stay aligned with runtime behaviour.
+
+### Visualising subsystem descriptors
+
+QuASAr now exposes a lightweight network representation of subsystem
+descriptors that can be rendered with the optional :mod:`networkx` package.
+Every :class:`~quasar.ssd.SSD` instance provides
+``SSD.to_networkx(...)`` while :class:`~quasar.circuit.Circuit` offers the
+convenience wrapper ``Circuit.to_networkx_ssd(...)`` for direct use on parsed
+circuits.【F:quasar/ssd.py†L151-L277】【F:quasar/circuit.py†L123-L164】 The methods
+return a :class:`networkx.MultiDiGraph` encoding partitions, conversion layers
+and backend assignments as labelled nodes.  Edges highlight execution
+dependencies, entanglement and conversion boundaries.  The optional parameters
+allow toggling each category so plots can focus on a subset of the metadata.
+
+Example usage:
+
+.. code-block:: python
+
+    from quasar.circuit import Circuit
+    import networkx as nx
+
+    circuit = Circuit([...], use_classical_simplification=False)
+    graph = circuit.to_networkx_ssd()
+
+    nx.draw_networkx(graph)
+
+If :mod:`networkx` is not installed the helpers raise a ``RuntimeError`` with a
+clear installation hint, leaving core simulation dependencies untouched.【F:quasar/ssd.py†L24-L38】【F:tests/test_ssd_visualization.py†L12-L32】

--- a/tests/test_ssd_visualization.py
+++ b/tests/test_ssd_visualization.py
@@ -1,0 +1,95 @@
+"""Tests for networkx visualisation helpers on SSD objects."""
+
+from __future__ import annotations
+
+import pytest
+
+from quasar.circuit import Circuit
+from quasar.cost import Backend, Cost
+from quasar.ssd import ConversionLayer, SSD, SSDPartition
+
+
+def test_to_networkx_requires_optional_dependency(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Attempting to visualise without networkx should raise a helpful error."""
+
+    partition = SSDPartition(subsystems=((0,),))
+    ssd = SSD([partition])
+
+    def _missing_package(name: str):  # pragma: no cover - behaviour verified in test
+        raise ModuleNotFoundError(name)
+
+    monkeypatch.setattr("quasar.ssd.importlib.import_module", _missing_package)
+
+    with pytest.raises(RuntimeError) as excinfo:
+        ssd.to_networkx()
+
+    assert "networkx" in str(excinfo.value)
+
+
+def test_ssd_to_networkx_structure() -> None:
+    """The generated graph should expose partitions, backends and conversions."""
+
+    nx = pytest.importorskip("networkx")
+
+    partitions = [
+        SSDPartition(subsystems=((0,),), backend=Backend.STATEVECTOR),
+        SSDPartition(subsystems=((1,),), backend=Backend.MPS),
+    ]
+    conversion = ConversionLayer(
+        boundary=(0, 1),
+        source=Backend.STATEVECTOR,
+        target=Backend.MPS,
+        rank=4,
+        frontier=2,
+        primitive="B2B",
+        cost=Cost(time=1.0, memory=2.0),
+    )
+    ssd = SSD(partitions, conversions=[conversion])
+
+    graph = ssd.to_networkx()
+
+    assert isinstance(graph, nx.MultiDiGraph)
+
+    part0 = ("partition", 0)
+    part1 = ("partition", 1)
+    conv_node = ("conversion", 0)
+    backend_sv = ("backend", Backend.STATEVECTOR.name)
+    backend_mps = ("backend", Backend.MPS.name)
+
+    assert part0 in graph.nodes
+    assert graph.nodes[part0]["backend"] == Backend.STATEVECTOR.name
+    assert conv_node in graph.nodes
+    assert graph.nodes[conv_node]["source"] == Backend.STATEVECTOR.name
+
+    # Partition 0 should depend on partition 1 via conversion metadata.
+    edge_data = graph.get_edge_data(part0, part1)
+    assert edge_data is not None
+    assert any(data.get("kind") == "dependency" for data in edge_data.values())
+    assert any(data.get("kind") == "entanglement" for data in edge_data.values())
+
+    # Backend assignment and conversion edges should be present.
+    assert graph.has_edge(part0, backend_sv)
+    assert graph.has_edge(part1, backend_mps)
+    assert graph.has_edge(part0, conv_node)
+    assert graph.has_edge(backend_sv, conv_node)
+    assert graph.has_edge(conv_node, backend_mps)
+
+
+def test_circuit_to_networkx_ssd_proxy() -> None:
+    """Circuit helper should delegate to the underlying SSD instance."""
+
+    nx = pytest.importorskip("networkx")
+
+    circuit = Circuit(
+        [
+            {"gate": "H", "qubits": [0]},
+            {"gate": "CX", "qubits": [0, 1]},
+        ],
+        use_classical_simplification=False,
+    )
+
+    graph = circuit.to_networkx_ssd()
+
+    assert isinstance(graph, nx.MultiDiGraph)
+    assert graph.graph["fingerprint"] == circuit.ssd.fingerprint
+    assert ("partition", 0) in graph.nodes


### PR DESCRIPTION
## Summary
- add `SSD.to_networkx` to expose subsystem descriptors as NetworkX graphs with optional metadata toggles
- expose a `Circuit.to_networkx_ssd` wrapper and document how to render SSDs from circuits
- cover the new helpers with tests, including the optional dependency failure path

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d39107fba0832192970e5da00edfe2