### PR TITLE
Add showcase benchmark circuits and tests

### DIFF
--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -72,6 +72,27 @@ You can override the ceiling via the environment variable, the global
 ``SimulationEngine(memory_threshold=...)`` and ``simulate(memory_threshold=...)``
 APIs. Supplying a non-positive threshold disables the guard for that call.
 
+### Showcase benchmark suites
+
+The following circuit families were added to highlight situations where QuASAr
+delivers large wins over single-method simulators. Each generator exposes rich
+metadata on the returned :class:`~quasar.circuit.Circuit` objects under the
+``metadata`` attribute so downstream scripts can recover the layer structure,
+transition depths and control layouts.
+
+| Circuit family | Key characteristics | When to use |
+| -------------- | ------------------- | ----------- |
+| `clustered_ghz_random_circuit`, `clustered_w_random_circuit` | 50-qubit (configurable) circuits that prepare GHZ or W states on disjoint blocks of five qubits before applying ~1000 layers of random hybrid gates. The metadata records the block size, number of blocks, and random-layer offsets. | Stress QuASAr's ability to keep subsystems independent during deep hybrid evolution. |
+| `clustered_ghz_qft_circuit`, `clustered_w_qft_circuit`, `clustered_ghz_random_qft_circuit` | Reuse the clustered preparation but follow it with a global QFT or a QFT after the random evolution. | Demonstrate QuASAr's ability to switch between sparse subsystem handling and dense global transforms. |
+| `layered_clifford_delayed_magic_circuit`, `layered_clifford_midpoint_circuit` | Depth-5000 workloads with configurable Clifford-only prefixes (80% and 60% respectively) before transitioning to non-Clifford layers. | Measure QuASAr's planning decisions when only part of the circuit demands non-Clifford simulation techniques. |
+| `layered_clifford_ramp_circuit` | Similar to the layered transition circuits but gradually increases the non-Clifford density between two fractions. Metadata lists the per-layer Clifford/non-Clifford flag. | Evaluate how quickly QuASAr reacts to gradual changes in gate character. |
+| `classical_controlled_circuit`, `dynamic_classical_control_circuit`, `classical_controlled_fanout_circuit` | 28-qubit (configurable) circuits that initialise subsets of qubits into classical basis states and reuse them as controls across thousands of layers. `dynamic_classical_control_circuit` flips controls frequently while `classical_controlled_fanout_circuit` increases fan-out. The generators default to `use_classical_simplification=False` so benchmarks can toggle the optimisation on demand. | Quantify the savings from QuASAr's classical-control simplification pass and stress the planner's handling of mixed classical/quantum regions. |
+
+All of the showcase circuits adhere to the `<name>_circuit` naming convention
+and are available through the benchmarking CLI via `--circuit <name>`. They use
+fixed seeds by default to keep gate patterns reproducible; override the seed
+argument when exploring stochastic behaviour.
+
 ### Reproducing paper figures
 
 Execute the commands below in order to rebuild every artefact used by

--- a/tests/test_showcase_benchmarks.py
+++ b/tests/test_showcase_benchmarks.py
@@ -1,0 +1,107 @@
+"""Tests for the high-impact benchmark circuits."""
+
+from __future__ import annotations
+
+from typing import List
+
+from benchmarks.circuits import (
+    CLIFFORD_GATES,
+    classical_controlled_circuit,
+    clustered_entanglement_circuit,
+    layered_clifford_nonclifford_circuit,
+    layered_clifford_ramp_circuit,
+)
+
+
+def _layer_gates(circuit, layer_offsets: List[int], layer: int):
+    start = layer_offsets[layer]
+    end = layer_offsets[layer + 1] if layer + 1 < len(layer_offsets) else len(circuit.gates)
+    return circuit.gates[start:end]
+
+
+def test_clustered_entanglement_prep_blocks():
+    circuit = clustered_entanglement_circuit(
+        10, block_size=5, state="ghz", entangler="qft", depth=0
+    )
+    metadata = circuit.metadata
+    assert metadata["num_blocks"] == 2
+    prep_gates = circuit.gates[: metadata["prep_gate_count"]]
+    first_block = {0, 1, 2, 3, 4}
+    second_block = {5, 6, 7, 8, 9}
+    fb_gates = [g for g in prep_gates if set(g.qubits) <= first_block]
+    sb_gates = [g for g in prep_gates if set(g.qubits) <= second_block]
+    assert any(g.gate == "H" and g.qubits == [0] for g in fb_gates)
+    assert any(g.gate == "H" and g.qubits == [5] for g in sb_gates)
+    for idx in range(1, 5):
+        assert any(g.gate == "CX" and g.qubits == [idx - 1, idx] for g in fb_gates)
+        offset = idx + 5 - 1
+        assert any(g.gate == "CX" and g.qubits == [offset, offset + 1] for g in sb_gates)
+
+
+def test_clustered_entanglement_random_layer_metadata():
+    circuit = clustered_entanglement_circuit(
+        10,
+        block_size=5,
+        state="w",
+        entangler="random",
+        depth=3,
+        seed=123,
+    )
+    metadata = circuit.metadata
+    assert metadata["state"] == "w"
+    assert len(metadata["layer_offsets"]) == 3
+    random_section = circuit.gates[metadata["prep_gate_count"] :]
+    assert any(g.gate not in CLIFFORD_GATES for g in random_section)
+    # Each W preparation ends with an X gate on the first qubit of the block.
+    for block in range(metadata["num_blocks"]):
+        qubit = block * metadata["block_size"]
+        assert any(g.gate == "X" and g.qubits == [qubit] for g in circuit.gates)
+
+
+def test_layered_clifford_transition_delays_magic():
+    circuit = layered_clifford_nonclifford_circuit(
+        6, depth=12, fraction_clifford=0.5, seed=1
+    )
+    metadata = circuit.metadata
+    offsets = metadata["layer_offsets"]
+    assert len(offsets) == 12
+    for layer in range(metadata["clifford_layers"]):
+        gates = _layer_gates(circuit, offsets, layer)
+        assert all(g.gate in CLIFFORD_GATES for g in gates)
+    for layer in range(metadata["clifford_layers"], metadata["depth"]):
+        gates = _layer_gates(circuit, offsets, layer)
+        assert any(g.gate not in CLIFFORD_GATES for g in gates)
+
+
+def test_layered_clifford_ramp_metadata():
+    circuit = layered_clifford_ramp_circuit(
+        5, depth=10, ramp_start_fraction=0.3, ramp_end_fraction=0.6, seed=2
+    )
+    metadata = circuit.metadata
+    flags = metadata["non_clifford_layer_flags"]
+    assert len(flags) == metadata["depth"]
+    assert not any(flags[: metadata["ramp_start_layer"]])
+    assert any(flags[metadata["ramp_end_layer"] :])
+
+
+def test_classical_controlled_circuit_enables_simplification():
+    circuit = classical_controlled_circuit(
+        12, depth=5, classical_qubits=4, toggle_period=2, fanout=2, seed=7
+    )
+    metadata = circuit.metadata
+    assert circuit.use_classical_simplification is False
+    assert metadata["classical_qubits"] == [0, 1, 2, 3]
+    assert metadata["prep_gate_count"] == len(metadata["classical_qubits"]) // 2
+    # Ensure classical qubits only appear as controls or are flipped by X gates.
+    classical_set = set(metadata["classical_qubits"])
+    for gate in circuit.gates:
+        control_gates = {"CX", "CZ", "CRZ"}
+        if gate.qubits[0] in classical_set and gate.gate in control_gates:
+            continue
+        if gate.gate == "X" and gate.qubits[0] in classical_set:
+            continue
+        assert not classical_set.intersection(gate.qubits)
+    before = len(circuit.gates)
+    circuit.enable_classical_simplification()
+    after = len(circuit.gates)
+    assert after <= before


### PR DESCRIPTION
## Summary
- add clustered entanglement generators that prepare GHZ/W blocks and chain them with random, QFT and hybrid workloads
- introduce layered Clifford-to-non-Clifford transition circuits plus classical-control heavy workloads, all with rich metadata
- document the new showcase suites in the benchmarking README and cover them with regression tests

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d395bba1a8832185f7de30b2848247