### PR TITLE
Introduce hierarchical SSD and provide demo notebook

### DIFF
--- a/benchmarks/notebooks/hierarchical_ssd_demo.ipynb
+++ b/benchmarks/notebooks/hierarchical_ssd_demo.ipynb
@@ -1,0 +1,188 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "d97107d3",
+   "metadata": {},
+   "source": [
+    "# Hierarchical SSD demonstration\n",
+    "\n",
+    "This notebook showcases the hierarchical subsystem descriptor (SSD) that\n",
+    "combines gate-level transitions, deduplicated gate-path nodes and qubit\n",
+    "subsystems.  The examples below build a descriptor for a few circuits,\n",
+    "inspect the automatically selected simulation methods and visualise the\n",
+    "resulting gate-path graph.  The final section runs a full simulation with\n",
+    ":class:`quasar.simulation_engine.SimulationEngine` to ensure the circuit can\n",
+    "still be executed end-to-end.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "4c44c9d7",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from quasar.circuit import Circuit\n",
+    "from quasar.ssd import build_hierarchical_ssd\n",
+    "from quasar.simulation_engine import SimulationEngine\n",
+    "\n",
+    "# Optional plotting helpers – the notebook works without these packages.\n",
+    "try:\n",
+    "    import matplotlib.pyplot as plt\n",
+    "    import networkx as nx\n",
+    "except ImportError:  # pragma: no cover - optional runtime dependency\n",
+    "    plt = nx = None\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "36e62483",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def describe_path_nodes(ssd):\n",
+    "    print(f\"SSD contains {len(ssd.partitions)} gate-path nodes\n",
+    "\")\n",
+    "    for idx, part in enumerate(ssd.partitions):\n",
+    "        qubits = [f\"{group}\" for group in part.subsystems]\n",
+    "        deps = part.dependencies if hasattr(part, \"dependencies\") else ()\n",
+    "        print(f\"Node {idx} -> backend={part.backend.name} qubits={qubits} history={part.history}\")\n",
+    "        if deps:\n",
+    "            print(f\"    depends on: {deps}\")\n",
+    "        if part.entangled_with:\n",
+    "            print(f\"    entangled with: {part.entangled_with}\")\n",
+    "    print()\n",
+    "\n",
+    "\n",
+    "def draw_path_graph(ssd, title=None):\n",
+    "    if nx is None or plt is None:\n",
+    "        print(\"Install networkx and matplotlib to visualise the gate-path graph.\")\n",
+    "        return\n",
+    "    graph = ssd.to_path_networkx()\n",
+    "    if not graph:\n",
+    "        print(\"Graph is empty.\")\n",
+    "        return\n",
+    "    labels = {}\n",
+    "    for node, data in graph.nodes(data=True):\n",
+    "        history = data.get(\"history\", ())\n",
+    "        if not history:\n",
+    "            label = \"INIT\"\n",
+    "        else:\n",
+    "            label = \"\n",
+    "\".join(history)\n",
+    "        backend = data.get(\"backend\")\n",
+    "        if backend:\n",
+    "            label += f\"\n",
+    "[{backend}]\"\n",
+    "        labels[node] = label\n",
+    "    pos = nx.spring_layout(graph, seed=42)\n",
+    "    plt.figure(figsize=(8, 5))\n",
+    "    nx.draw_networkx(graph, pos, labels=labels, node_color=\"#ffcc99\", node_size=1600)\n",
+    "    plt.title(title or \"Gate-path dependency graph\")\n",
+    "    plt.axis(\"off\")\n",
+    "    plt.show()\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "a5b33803",
+   "metadata": {},
+   "source": [
+    "## Example 1 – GHZ preparation\n",
+    "\n",
+    "Three qubits start in the zero state, undergo a Hadamard on qubit 0 and two\n",
+    "controlled-NOT gates.  The first two gates operate on disjoint subsystems and\n",
+    "are therefore deduplicated in the path graph before entanglement merges the\n",
+    "qubits.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "582730f9",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "ghz_gates = [\n",
+    "    {\"gate\": \"H\", \"qubits\": [0]},\n",
+    "    {\"gate\": \"H\", \"qubits\": [1]},\n",
+    "    {\"gate\": \"CX\", \"qubits\": [0, 2]},\n",
+    "    {\"gate\": \"CX\", \"qubits\": [1, 2]},\n",
+    "]\n",
+    "\n",
+    "ghz = Circuit(ghz_gates)\n",
+    "ssd_ghz = ghz.ssd  # already hierarchical thanks to the circuit helper\n",
+    "\n",
+    "describe_path_nodes(ssd_ghz)\n",
+    "draw_path_graph(ssd_ghz, title=\"GHZ gate-path graph\")\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "33170234",
+   "metadata": {},
+   "source": [
+    "## Example 2 – Reused single-qubit paths\n",
+    "\n",
+    "This circuit applies identical gate sequences on qubits 0 and 1 before\n",
+    "entangling them with a controlled-Z.  The SSD collapses both single-qubit\n",
+    "prefixes into a single gate-path node, demonstrating reuse of identical\n",
+    "sequences.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "5fb3544a",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "reused_gates = [\n",
+    "    {\"gate\": \"RX\", \"qubits\": [0], \"params\": {\"theta\": 1.5708}},\n",
+    "    {\"gate\": \"RY\", \"qubits\": [0], \"params\": {\"theta\": 0.7854}},\n",
+    "    {\"gate\": \"RX\", \"qubits\": [1], \"params\": {\"theta\": 1.5708}},\n",
+    "    {\"gate\": \"RY\", \"qubits\": [1], \"params\": {\"theta\": 0.7854}},\n",
+    "    {\"gate\": \"CZ\", \"qubits\": [0, 1]},\n",
+    "]\n",
+    "\n",
+    "reused = Circuit(reused_gates)\n",
+    "ssd_reused = reused.ssd\n",
+    "\n",
+    "describe_path_nodes(ssd_reused)\n",
+    "draw_path_graph(ssd_reused, title=\"Reused path graph\")\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "3e872681",
+   "metadata": {},
+   "source": [
+    "## Example 3 – Full simulation\n",
+    "\n",
+    "The final cell runs a dense statevector simulation.  The returned SSD comes\n",
+    "from the scheduler, while rebuilding the hierarchical descriptor afterwards\n",
+    "reveals the gate-path assignments used during analysis.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "c8c8a814",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "engine = SimulationEngine()\n",
+    "sim_result = engine.simulate(ghz)\n",
+    "print(f\"Simulation completed with {len(sim_result.ssd.partitions)} partitions.\")\n",
+    "\n",
+    "hierarchical_after_run = build_hierarchical_ssd(ghz)\n",
+    "describe_path_nodes(hierarchical_after_run)\n"
+   ]
+  }
+ ],
+ "metadata": {},
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/quasar/circuit.py
+++ b/quasar/circuit.py
@@ -11,7 +11,7 @@ import math
 from qiskit.circuit import QuantumCircuit
 from qiskit_qasm3_import import api as qasm3_api
 
-from .ssd import SSD, SSDPartition
+from .ssd import SSD, SSDPartition, build_hierarchical_ssd
 from .cost import Cost, CostEstimator, Backend
 from .decompositions import decompose_mcx, decompose_ccz, decompose_cswap
 
@@ -694,10 +694,7 @@ class Circuit:
         """Construct the initial subsystem descriptor."""
         if self._num_qubits == 0:
             return SSD([])
-        part = SSDPartition(subsystems=(tuple(range(self._num_qubits)),))
-        ssd = SSD([part])
-        ssd.build_metadata()
-        return ssd
+        return build_hierarchical_ssd(self)
 
     def _estimate_costs(self) -> Dict[str, Cost]:
         """Estimate simulation costs for standard backends."""


### PR DESCRIPTION
## Summary
- refactor the SSD module to expose a hierarchical descriptor with gate, path and qubit-map layers and cost-based backend assignment per path node
- update circuit initialisation to build the hierarchical SSD and add helpers for NetworkX visualisation of the gate-path graph
- add a `benchmarks/notebooks/hierarchical_ssd_demo.ipynb` notebook illustrating analysis, method selection and visualisation of the new SSD

## Testing
- `pytest tests/test_large_partitioned_circuit.py tests/test_mixed_method_partition.py`
- `pytest -q` *(execution aborted after ~8 minutes due to long-running hierarchical SSD construction; 49 tests completed before interruption)*

------
https://chatgpt.com/codex/tasks/task_e_68d4e993bdc08321b9c560be4e999d9b