### PR TITLE
Optimize SSD construction and baseline circuit builds

### DIFF
--- a/tests/test_flat_ssd_mode.py
+++ b/tests/test_flat_ssd_mode.py
@@ -1,0 +1,45 @@
+import pytest
+
+from quasar.circuit import Circuit, Gate
+
+
+def _sample_gates():
+    return [
+        Gate("H", [0]),
+        Gate("CX", [0, 1]),
+        Gate("MEASURE", [1]),
+    ]
+
+
+def test_flat_ssd_single_partition():
+    circuit = Circuit(_sample_gates(), ssd_mode="flat")
+    ssd = circuit.ssd
+
+    assert len(ssd.partitions) == 1
+    partition = ssd.partitions[0]
+    assert partition.subsystems == ((0, 1),)
+    assert partition.dependencies == ()
+    assert partition.history == ("H", "CX", "MEASURE")
+
+
+def test_flat_ssd_serialization_roundtrip():
+    circuit = Circuit(_sample_gates(), ssd_mode="flat")
+    data = circuit.to_dict()
+
+    assert data["ssd_mode"] == "flat"
+
+    restored = Circuit.from_dict(data)
+    assert restored.ssd_mode == "flat"
+    assert len(restored.ssd.partitions) == 1
+
+
+def test_hierarchical_mode_remains_default():
+    circuit = Circuit(_sample_gates())
+    assert circuit.ssd_mode == "hierarchical"
+    # Hierarchy information should be populated in default mode.
+    assert circuit.ssd.hierarchy is not None
+
+
+def test_invalid_ssd_mode_raises():
+    with pytest.raises(ValueError):
+        Circuit(_sample_gates(), ssd_mode="invalid")


### PR DESCRIPTION
## Summary
- avoid re-running classical simplification when a circuit is already in the desired mode and add a disable helper so metadata can be rebuilt without simplification
- ensure forced benchmark circuits use the new flat SSD mode and skip redundant work when they already match the requested configuration
- streamline hierarchical SSD construction by removing per-node operation tuple copies and caching selector calls to keep large Grover circuits fast

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68d5047a164c83218fcae5a32161dd5c