### PR TITLE
Add notebook to validate QuASAr simulation accuracy

### DIFF
--- a/docs/quasar_api_simulation_validation.ipynb
+++ b/docs/quasar_api_simulation_validation.ipynb
@@ -1,0 +1,394 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "bc636224",
+   "metadata": {},
+   "source": [
+    "# Validating QuASAr Simulation Correctness\n",
+    "\n",
+    "This notebook exercises the high-level QuASAr API to verify that the latest subsystem descriptor (SSD) structure still produces physically correct simulation outcomes.  Each circuit is simulated via the `SimulationEngine`, compared against an explicit statevector reference, and the resulting fidelity and amplitude deviations are reported."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "5778afa9",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2025-09-25T10:22:28.517171Z",
+     "iopub.status.busy": "2025-09-25T10:22:28.516942Z",
+     "iopub.status.idle": "2025-09-25T10:22:28.522547Z",
+     "shell.execute_reply": "2025-09-25T10:22:28.521986Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Using repository root: /workspace/QuASAr\n"
+     ]
+    }
+   ],
+   "source": [
+    "import sys\n",
+    "import pathlib\n",
+    "\n",
+    "# Ensure the repository root is on sys.path so `import quasar` succeeds during execution.\n",
+    "ROOT = pathlib.Path.cwd().resolve()\n",
+    "if not (ROOT / 'quasar').exists():\n",
+    "    for candidate in ROOT.parents:\n",
+    "        if (candidate / 'quasar').exists():\n",
+    "            ROOT = candidate\n",
+    "            break\n",
+    "if str(ROOT) not in sys.path:\n",
+    "    sys.path.insert(0, str(ROOT))\n",
+    "print('Using repository root:', ROOT)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "8045a5fb",
+   "metadata": {},
+   "source": [
+    "## Imports and Helpers\n",
+    "\n",
+    "The helper routine below evaluates a circuit with QuASAr's Aer-backed statevector simulator so that we can compare the engine's output against a dense reference state."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "9b7f0198",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2025-09-25T10:22:28.524550Z",
+     "iopub.status.busy": "2025-09-25T10:22:28.524349Z",
+     "iopub.status.idle": "2025-09-25T10:22:29.098001Z",
+     "shell.execute_reply": "2025-09-25T10:22:29.097268Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "import math\n",
+    "import numpy as np\n",
+    "\n",
+    "from quasar import Circuit, Gate, SimulationEngine, Backend, StatevectorBackend\n",
+    "\n",
+    "np.set_printoptions(precision=6, suppress=True)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "07416aba",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2025-09-25T10:22:29.100716Z",
+     "iopub.status.busy": "2025-09-25T10:22:29.100453Z",
+     "iopub.status.idle": "2025-09-25T10:22:29.104089Z",
+     "shell.execute_reply": "2025-09-25T10:22:29.103474Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "def reference_state(circuit: Circuit) -> np.ndarray:\n",
+    "    \"\"\"Return a dense statevector for `circuit` using Aer.\"\"\"\n",
+    "    backend = StatevectorBackend()\n",
+    "    backend.load(circuit.num_qubits)\n",
+    "    for gate in circuit.gates:\n",
+    "        backend.apply_gate(gate.gate, gate.qubits, gate.params)\n",
+    "    return np.asarray(backend.statevector(), dtype=complex)\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "43280e81",
+   "metadata": {},
+   "source": [
+    "## Benchmark Circuits\n",
+    "\n",
+    "We exercise a set of representative circuits that touch rotations, entanglement, controlled phase operations, and multi-qubit interactions."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "800b1554",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2025-09-25T10:22:29.106393Z",
+     "iopub.status.busy": "2025-09-25T10:22:29.106195Z",
+     "iopub.status.idle": "2025-09-25T10:22:29.119663Z",
+     "shell.execute_reply": "2025-09-25T10:22:29.119061Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "{'single_qubit_rotations': <quasar.circuit.Circuit at 0x7f349ea79ac0>,\n",
+       " 'bell_pair': <quasar.circuit.Circuit at 0x7f349ea7aed0>,\n",
+       " 'three_qubit_mixer': <quasar.circuit.Circuit at 0x7f349ea7bb60>}"
+      ]
+     },
+     "execution_count": 4,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "circuits = {\n",
+    "    \"single_qubit_rotations\": Circuit(\n",
+    "        [\n",
+    "            Gate(\"H\", [0]),\n",
+    "            Gate(\"RZ\", [0], {\"param0\": float(np.pi / 3)}),\n",
+    "            Gate(\"RX\", [0], {\"param0\": float(-np.pi / 5)}),\n",
+    "            Gate(\"RY\", [0], {\"param0\": float(np.pi / 7)}),\n",
+    "        ],\n",
+    "        use_classical_simplification=False,\n",
+    "    ),\n",
+    "    \"bell_pair\": Circuit(\n",
+    "        [\n",
+    "            Gate(\"H\", [0]),\n",
+    "            Gate(\"CX\", [0, 1]),\n",
+    "            Gate(\"RZ\", [1], {\"param0\": float(np.pi / 4)}),\n",
+    "            Gate(\"CX\", [0, 1]),\n",
+    "        ],\n",
+    "        use_classical_simplification=False,\n",
+    "    ),\n",
+    "    \"three_qubit_mixer\": Circuit(\n",
+    "        [\n",
+    "            Gate(\"H\", [0]),\n",
+    "            Gate(\"CX\", [0, 1]),\n",
+    "            Gate(\"RY\", [2], {\"param0\": float(np.pi / 5)}),\n",
+    "            Gate(\"CZ\", [1, 2]),\n",
+    "            Gate(\"T\", [0]),\n",
+    "            Gate(\"SX\", [1]),\n",
+    "            Gate(\"RZZ\", [0, 2], {\"param0\": float(-np.pi / 7)}),\n",
+    "            Gate(\"CP\", [0, 2], {\"k\": 3}),\n",
+    "        ],\n",
+    "        use_classical_simplification=False,\n",
+    "    ),\n",
+    "}\n",
+    "circuits\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "b5251d47",
+   "metadata": {},
+   "source": [
+    "## Simulation and Validation\n",
+    "\n",
+    "Each circuit is simulated via the `SimulationEngine`.  We request the dense statevector backend so that the final SSD contains an explicit amplitude vector.  The notebook reports the resulting fidelity against the reference, the maximum per-amplitude deviation, and the backends used for each partition in the SSD."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "af68b574",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2025-09-25T10:22:29.121399Z",
+     "iopub.status.busy": "2025-09-25T10:22:29.121229Z",
+     "iopub.status.idle": "2025-09-25T10:22:29.404742Z",
+     "shell.execute_reply": "2025-09-25T10:22:29.404064Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "single_qubit_rotations: fidelity=1.000000, max_error=0.000e+00, backends=['STATEVECTOR']\n",
+      "bell_pair: fidelity=1.000000, max_error=0.000e+00, backends=['STATEVECTOR']\n",
+      "three_qubit_mixer: fidelity=1.000000, max_error=0.000e+00, backends=['STATEVECTOR']\n"
+     ]
+    },
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>Circuit</th>\n",
+       "      <th>Qubits</th>\n",
+       "      <th>Partitions</th>\n",
+       "      <th>Backends</th>\n",
+       "      <th>Fidelity</th>\n",
+       "      <th>Max amplitude error</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>single_qubit_rotations</td>\n",
+       "      <td>1</td>\n",
+       "      <td>1</td>\n",
+       "      <td>[STATEVECTOR]</td>\n",
+       "      <td>1.0</td>\n",
+       "      <td>0.0</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>bell_pair</td>\n",
+       "      <td>2</td>\n",
+       "      <td>1</td>\n",
+       "      <td>[STATEVECTOR]</td>\n",
+       "      <td>1.0</td>\n",
+       "      <td>0.0</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2</th>\n",
+       "      <td>three_qubit_mixer</td>\n",
+       "      <td>3</td>\n",
+       "      <td>1</td>\n",
+       "      <td>[STATEVECTOR]</td>\n",
+       "      <td>1.0</td>\n",
+       "      <td>0.0</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "                  Circuit  Qubits  Partitions       Backends  Fidelity  \\\n",
+       "0  single_qubit_rotations       1           1  [STATEVECTOR]       1.0   \n",
+       "1               bell_pair       2           1  [STATEVECTOR]       1.0   \n",
+       "2       three_qubit_mixer       3           1  [STATEVECTOR]       1.0   \n",
+       "\n",
+       "   Max amplitude error  \n",
+       "0                  0.0  \n",
+       "1                  0.0  \n",
+       "2                  0.0  "
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "engine = SimulationEngine()\n",
+    "summary_rows = []\n",
+    "detailed_results = {}\n",
+    "\n",
+    "for name, circuit in circuits.items():\n",
+    "    ref = reference_state(circuit)\n",
+    "    result = engine.simulate(circuit, backend=Backend.STATEVECTOR, reference_state=ref)\n",
+    "    partition_backends = [part.backend.name for part in result.ssd.partitions]\n",
+    "    extracted = result.ssd.extract_state(0) if result.ssd.partitions else None\n",
+    "    final_state = np.asarray(extracted, dtype=complex) if extracted is not None else None\n",
+    "    max_error = float(np.max(np.abs(final_state - ref))) if final_state is not None else float('nan')\n",
+    "    summary_rows.append({\n",
+    "        \"Circuit\": name,\n",
+    "        \"Qubits\": circuit.num_qubits,\n",
+    "        \"Partitions\": len(result.ssd.partitions),\n",
+    "        \"Backends\": partition_backends,\n",
+    "        \"Fidelity\": result.fidelity,\n",
+    "        \"Max amplitude error\": max_error,\n",
+    "    })\n",
+    "    detailed_results[name] = {\n",
+    "        \"circuit\": circuit,\n",
+    "        \"result\": result,\n",
+    "        \"reference\": ref,\n",
+    "        \"final_state\": final_state,\n",
+    "    }\n",
+    "\n",
+    "    print(\"{}: fidelity={:.6f}, max_error={:.3e}, backends={}\".format(name, result.fidelity, max_error, partition_backends))\n",
+    "\n",
+    "try:\n",
+    "    import pandas as pd\n",
+    "except Exception:\n",
+    "    pd = None\n",
+    "\n",
+    "if pd is not None:\n",
+    "    display(pd.DataFrame(summary_rows))\n",
+    "else:\n",
+    "    summary_rows\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "de1ac9d9",
+   "metadata": {},
+   "source": [
+    "## Inspecting a Final State\n",
+    "\n",
+    "The following cell compares QuASAr's terminal amplitudes for the three-qubit mixer against the dense reference vector."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "1a47a23b",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2025-09-25T10:22:29.407085Z",
+     "iopub.status.busy": "2025-09-25T10:22:29.406722Z",
+     "iopub.status.idle": "2025-09-25T10:22:29.411399Z",
+     "shell.execute_reply": "2025-09-25T10:22:29.410819Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Reference amplitudes:\n",
+      "[ 0.252996+0.402641j  0.130826+0.082203j  0.402641-0.252996j\n",
+      "  0.082203-0.130826j  0.463606-0.105815j -0.082203-0.130826j\n",
+      "  0.105815+0.463606j  0.130826-0.082203j]\n",
+      "QuASAr amplitudes:\n",
+      "[ 0.252996+0.402641j  0.130826+0.082203j  0.402641-0.252996j\n",
+      "  0.082203-0.130826j  0.463606-0.105815j -0.082203-0.130826j\n",
+      "  0.105815+0.463606j  0.130826-0.082203j]\n",
+      "Max absolute deviation: 0.0\n"
+     ]
+    }
+   ],
+   "source": [
+    "target = detailed_results[\"three_qubit_mixer\"]\n",
+    "ref = target[\"reference\"]\n",
+    "state = target[\"final_state\"]\n",
+    "print(\"Reference amplitudes:\")\n",
+    "print(ref)\n",
+    "print(\"QuASAr amplitudes:\")\n",
+    "print(state)\n",
+    "print(\"Max absolute deviation:\", np.max(np.abs(ref - state)))\n"
+   ]
+  }
+ ],
+ "metadata": {
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.12.10"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
## Summary
- add an executed Jupyter notebook that compares SimulationEngine results against Aer statevector references for multiple circuits
- report fidelity, amplitude error, and backend assignments to confirm the new SSD representation preserves correct outputs

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d5166b12e483218952ffe9dbe39cb8