### PR TITLE
Add final_state helper and document simulation API

### DIFF
--- a/docs/quasar_api_simulation_validation.ipynb
+++ b/docs/quasar_api_simulation_validation.ipynb
@@ -177,6 +177,39 @@
   },
   {
    "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Quick Start: Running the Engine\n",
+    "\n",
+    "The planner normally selects the most appropriate backend on its own.\n",
+    "The example below constructs a simple GHZ-style circuit, executes it\n",
+    "with :class:`~quasar.simulation_engine.SimulationEngine`, and then\n",
+    "inspects the terminal state via the\n",
+    "``SimulationResult.final_state`` convenience helper."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "engine = SimulationEngine()\n",
+    "\n",
+    "circuit = Circuit([\n",
+    "    Gate(\"H\", [0]),\n",
+    "    Gate(\"CX\", [0, 1]),\n",
+    "    Gate(\"CX\", [1, 2]),\n",
+    "])\n",
+    "\n",
+    "result = engine.simulate(circuit)\n",
+    "print(\"Chosen backend(s):\", [part.backend.name for part in result.ssd.partitions])\n",
+    "print(\"Native state representation:\", result.final_state())\n",
+    "print(\"Dense statevector:\", result.final_state(as_numpy=True))\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "b5251d47",
    "metadata": {},
    "source": [
@@ -293,8 +326,7 @@
     "    ref = reference_state(circuit)\n",
     "    result = engine.simulate(circuit, backend=Backend.STATEVECTOR, reference_state=ref)\n",
     "    partition_backends = [part.backend.name for part in result.ssd.partitions]\n",
-    "    extracted = result.ssd.extract_state(0) if result.ssd.partitions else None\n",
-    "    final_state = np.asarray(extracted, dtype=complex) if extracted is not None else None\n",
+    "    final_state = result.final_state(as_numpy=True)\n",
     "    max_error = float(np.max(np.abs(final_state - ref))) if final_state is not None else float('nan')\n",
     "    summary_rows.append({\n",
     "        \"Circuit\": name,\n",
@@ -366,7 +398,7 @@
    "source": [
     "target = detailed_results[\"three_qubit_mixer\"]\n",
     "ref = target[\"reference\"]\n",
-    "state = target[\"final_state\"]\n",
+    "state = target[\"result\"].final_state(as_numpy=True)\n",
     "print(\"Reference amplitudes:\")\n",
     "print(ref)\n",
     "print(\"QuASAr amplitudes:\")\n",

--- a/docs/simulation_engine_api.md
+++ b/docs/simulation_engine_api.md
@@ -1,0 +1,76 @@
+# QuASAr Simulation Engine API
+
+This guide summarises the public surface of `quasar.simulation_engine` and
+demonstrates how to execute circuits, inspect the resulting subsystem
+descriptor (SSD), and customise the planner.
+
+## Quick start
+
+```python
+from quasar import Circuit, Gate
+from quasar.simulation_engine import SimulationEngine
+
+engine = SimulationEngine()
+
+circuit = Circuit([
+    Gate("H", [0]),
+    Gate("CX", [0, 1]),
+    Gate("CX", [1, 2]),
+])
+
+result = engine.simulate(circuit)
+print("Backends:", [part.backend.name for part in result.ssd.partitions])
+print("Final amplitudes:", result.final_state(as_numpy=True))
+```
+
+The planner automatically selects a suitable backend for each partition.  For
+small GHZ-style circuits like the example above a dense statevector backend is
+typically chosen, but larger circuits may trigger tensor-network or tableau
+simulators instead.  The :class:`SimulationResult` returned by
+:meth:`SimulationEngine.simulate` always provides access to the full SSD so that
+advanced users can inspect individual partitions, conversions and cost
+estimates.
+
+## Retrieving terminal states
+
+`SimulationResult.final_state()` retrieves the state stored on the last SSD
+partition.  When `as_numpy=True` the helper converts the state into a dense
+`numpy.ndarray` (if the backend supports it).  Passing a specific partition
+index returns intermediate states, and setting `as_numpy=False` exposes the
+backend-native representation such as stabiliser tableaux or decision diagram
+nodes.
+
+```python
+native = result.final_state()
+amplitudes = result.final_state(as_numpy=True)
+```
+
+If the SSD does not contain the requested state the method returns `None`.  In
+addition, attempting to use `as_numpy=True` without NumPy installed raises a
+`RuntimeError` so that environments without the optional dependency fail
+loudly.
+
+## Guiding the planner
+
+`SimulationEngine.simulate` accepts several optional parameters:
+
+- `backend` prefers a specific backend (for example
+  `Backend.STATEVECTOR` or `Backend.STIM_TABLEAU`).
+- `memory_threshold` overrides the automatically detected memory ceiling for the
+  dense statevector backend.
+- `target_accuracy`, `max_time` and `optimization_level` are forwarded to the
+  planner and scheduler to tune trade-offs between accuracy and runtime.
+
+The returned :class:`SimulationResult` also exposes per-phase timings (`analysis_time`,
+`planning_time`, `execution_time`), backend switch counts, conversion durations
+and optional fidelity metrics computed against a reference state.
+
+## Inspecting the SSD
+
+The SSD attached to `SimulationResult.ssd` stores each partition together with
+its backend, qubits, dependencies, entanglement relations and recorded state.
+Utility methods such as :meth:`SSD.by_backend` and :meth:`SSD.to_networkx`
+provide convenient entry points for visualisation and deeper analysis.
+
+When you need to persist SSDs for later inspection, consider serialising them
+with `quasar.ssd.SSDCache` from the same module.


### PR DESCRIPTION
## Summary
- add SimulationResult.final_state() helper to simplify state extraction from SSDs
- extend the API validation notebook with a backend-agnostic quick start example using the new helper
- document the SimulationEngine API surface and workflow in a dedicated markdown guide

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d53b1964908321ba7ea497fc0b96c1