### PR TITLE
Extend worker threading across benchmark scripts

### DIFF
--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -29,6 +29,9 @@ python benchmarks/run_benchmarks.py --circuit ghz --qubits 4:12:2 --repetitions 
 - `--qubits` specifies a `start:end[:step]` range.
 - `--repetitions` repeats each configuration to compute a mean and variance.
 - `--output` is the base path for the generated `.json` and `.csv` files.
+- `--workers` bounds the number of worker threads used to benchmark qubit
+  widths and scenarios in parallel.  When omitted the script auto-detects a
+  suitable level of concurrency based on the available CPU cores.
 - Circuit families composed solely of Clifford gates (`H`, `S`, `CX`, `CZ`, etc.)
   are skipped to avoid benchmarking workloads that are trivial for stabiliser
   simulators.
@@ -108,12 +111,16 @@ python benchmarks/showcase_benchmarks.py --repetitions 3 --run-timeout 900
 Use `--circuits` to select a subset of workloads, `--qubits` to override the
 default width selections (e.g. `--qubits clustered_ghz_random=40:60:10`) and
 `--reuse-existing` to skip rerunning configurations with cached results.
+Pass `--workers <n>` to control how many threads execute circuit widths in
+parallel; omit the flag to let the runner auto-detect a sensible default.
 
 ### Reproducing paper figures
 
 Execute the commands below in order to rebuild every artefact used by
 [`paper_figures.py`](paper_figures.py). Check that each step produces the
 described files before moving to the next command.
+The `--workers` flag mirrors the benchmark runner and enables threaded circuit
+execution for the forced/automatic comparisons.
 
 1. **Partitioning sweeps** – regenerate the benchmark tables that back the
    mainline runtime and memory figures:

--- a/benchmarks/threading_utils.py
+++ b/benchmarks/threading_utils.py
@@ -1,0 +1,58 @@
+from __future__ import annotations
+
+"""Shared concurrency helpers for benchmark scripts."""
+
+import os
+import threading
+from typing import Any, Callable, TypeVar
+
+from quasar import SimulationEngine
+
+__all__ = ["resolve_worker_count", "thread_engine", "with_thread_engine"]
+
+
+_THREAD_LOCAL = threading.local()
+
+_T = TypeVar("_T")
+
+
+def resolve_worker_count(max_workers: int | None, task_count: int) -> int:
+    """Return an appropriate worker count bounded by ``task_count``."""
+
+    if task_count <= 0:
+        return 0
+    if max_workers is not None:
+        try:
+            workers = int(max_workers)
+        except (TypeError, ValueError):
+            workers = 0
+        else:
+            if workers < 0:
+                workers = 0
+        if workers:
+            return min(workers, task_count)
+        return 1 if task_count else 0
+    cpu_count = os.cpu_count() or 1
+    return min(cpu_count, task_count)
+
+
+def thread_engine(factory: Callable[[], SimulationEngine] | None = None) -> SimulationEngine:
+    """Return a thread-local :class:`~quasar.SimulationEngine` instance."""
+
+    engine = getattr(_THREAD_LOCAL, "engine", None)
+    if engine is None:
+        if factory is None:
+            factory = SimulationEngine
+        engine = factory()
+        _THREAD_LOCAL.engine = engine
+    return engine
+
+
+def with_thread_engine(func: Callable[[SimulationEngine, _T], Any]) -> Callable[[_T], Any]:
+    """Wrap ``func`` so it receives a thread-local engine as the first argument."""
+
+    def _wrapper(arg: _T) -> Any:
+        engine = thread_engine()
+        return func(engine, arg)
+
+    return _wrapper


### PR DESCRIPTION
## Summary
- extract shared threading helpers for benchmark scripts
- enable configurable worker pools in paper figures, showcase, and table generators
- add concurrent estimate generation and document the new `--workers` options in the README

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d5663d85088321a23f936ec8a2f1ea