### PR TITLE
Add incremental showcase benchmark selections

### DIFF
--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -130,11 +130,29 @@ per-circuit summaries, derived speedup tables and comparative figures under
 python benchmarks/showcase_benchmarks.py --repetitions 3 --run-timeout 900
 ```
 
-Use `--circuits` to select a subset of workloads, `--qubits` to override the
-default width selections (e.g. `--qubits clustered_ghz_random=40:60:10`) and
-`--reuse-existing` to skip rerunning configurations with cached results.
-Pass `--workers <n>` to control how many threads execute circuit widths in
-parallel; omit the flag to let the runner auto-detect a sensible default.
+Use `--circuit <name>` (repeat the flag to add more) to benchmark individual
+workloads or `--group <name>` to run one of the curated circuit bundles.  Run
+`python benchmarks/showcase_benchmarks.py --list-groups` to discover the
+available groups.  The combined CSV/Markdown tables in
+`benchmarks/results/showcase/` are updated incrementally: re-running the helper
+with additional selections appends new measurements instead of overwriting the
+previous data.  This makes it practical to split long benchmark sessions across
+multiple invocations while keeping the aggregated tables up to date.
+
+For example, the commands below process the three predefined groups and yield
+the same combined results as a single full run:
+
+```bash
+python benchmarks/showcase_benchmarks.py --group clustered --repetitions 3 --run-timeout 900
+python benchmarks/showcase_benchmarks.py --group layered --repetitions 3 --run-timeout 900
+python benchmarks/showcase_benchmarks.py --group classical_control --repetitions 3 --run-timeout 900
+```
+
+The runner also accepts `--qubits` to override the default width selections
+(e.g. `--qubits clustered_ghz_random=40:60:10`), `--reuse-existing` to skip
+rerunning configurations with cached CSVs, and `--workers <n>` to control how
+many threads evaluate qubit widths in parallel.  Omitting `--workers` lets the
+script auto-detect a sensible default.
 
 ### Theoretical cost estimates
 


### PR DESCRIPTION
## Summary
- add grouped circuit selection and incremental result merging to the showcase benchmark runner
- document the new CLI options for splitting long benchmark sessions across multiple invocations
- cover the selection utilities with tests to keep the behaviour stable

## Testing
- pytest tests/test_showcase_benchmarks.py

------
https://chatgpt.com/codex/tasks/task_e_68d62ddbce908321b5acdb206768d3f4