### PR TITLE
Add SQLite-backed benchmark storage and analysis tooling

### DIFF
--- a/benchmarks/analyse_database.py
+++ b/benchmarks/analyse_database.py
@@ -1,0 +1,347 @@
+"""Generate plots and tables from stored benchmark database results."""
+
+from __future__ import annotations
+
+import argparse
+import logging
+import sqlite3
+from pathlib import Path
+from typing import Iterable, Sequence
+
+import pandas as pd
+
+PACKAGE_ROOT = Path(__file__).resolve().parent
+
+try:  # package execution
+    from .bench_utils import showcase_benchmarks
+    from .bench_utils.plot_utils import compute_baseline_best
+    from .bench_utils.showcase_benchmarks import (
+        DATABASE_PATH as DEFAULT_DATABASE_PATH,
+        FIGURES_DIR as DEFAULT_FIGURES_DIR,
+        _export_plot,
+        _merge_results,
+        _write_markdown,
+        SHOWCASE_CIRCUITS,
+        SHOWCASE_GROUPS,
+    )
+    from .bench_utils.theoretical_estimation_utils import (
+        build_summary,
+        plot_memory_ratio,
+        plot_runtime_speedups,
+        write_tables,
+    )
+except ImportError:  # pragma: no cover - script execution fallback
+    from bench_utils import showcase_benchmarks  # type: ignore
+    from bench_utils.plot_utils import compute_baseline_best  # type: ignore
+    from bench_utils.showcase_benchmarks import (  # type: ignore
+        DATABASE_PATH as DEFAULT_DATABASE_PATH,
+        FIGURES_DIR as DEFAULT_FIGURES_DIR,
+        _export_plot,
+        _merge_results,
+        _write_markdown,
+        SHOWCASE_CIRCUITS,
+        SHOWCASE_GROUPS,
+    )
+    from bench_utils.theoretical_estimation_utils import (  # type: ignore
+        build_summary,
+        plot_memory_ratio,
+        plot_runtime_speedups,
+        write_tables,
+    )
+
+
+LOGGER = logging.getLogger(__name__)
+
+RESULTS_DIR = PACKAGE_ROOT / "results" / "showcase"
+
+
+def _resolve_circuits(explicit: Sequence[str] | None, groups: Sequence[str] | None) -> list[str]:
+    if explicit is None and groups is None:
+        return sorted(SHOWCASE_CIRCUITS)
+
+    selected: set[str] = set()
+    if explicit:
+        for name in explicit:
+            if name not in SHOWCASE_CIRCUITS:
+                raise ValueError(f"unknown circuit '{name}'")
+            selected.add(name)
+    if groups:
+        for group in groups:
+            if group not in SHOWCASE_GROUPS:
+                available = ", ".join(sorted(SHOWCASE_GROUPS))
+                raise ValueError(f"unknown group '{group}'. Available: {available}")
+            selected.update(SHOWCASE_GROUPS[group])
+    return sorted(selected)
+
+
+def _load_showcase_results(database: Path, circuits: Iterable[str]) -> pd.DataFrame:
+    placeholders = ",".join("?" for _ in circuits)
+    query = """
+        SELECT
+            b.circuit_id AS circuit,
+            b.circuit_display_name AS display_name,
+            sr.qubits,
+            sr.framework,
+            sr.backend,
+            sr.mode,
+            sr.repetitions,
+            sr.prepare_time_mean,
+            sr.prepare_time_std,
+            sr.run_time_mean,
+            sr.run_time_std,
+            sr.total_time_mean,
+            sr.total_time_std,
+            sr.prepare_peak_memory_mean,
+            sr.prepare_peak_memory_std,
+            sr.run_peak_memory_mean,
+            sr.run_peak_memory_std,
+            sr.unsupported,
+            sr.failed,
+            sr.timeout,
+            sr.comment,
+            sr.error,
+            sr.failed_runs,
+            sr.partition_count,
+            sr.partition_total_subsystems,
+            sr.partition_unique_backends,
+            sr.partition_max_multiplicity,
+            sr.partition_mean_multiplicity,
+            sr.partition_backend_breakdown,
+            sr.hierarchy_available,
+            sr.result_json,
+            b.repetitions AS benchmark_repetitions,
+            b.classical_simplification,
+            b.include_baselines,
+            b.quick,
+            b.run_timeout,
+            b.memory_bytes,
+            b.created_at AS benchmark_created_at,
+            br.id AS run_id,
+            br.description AS run_description,
+            br.parameters AS run_parameters,
+            br.created_at AS run_created_at
+        FROM simulation_run sr
+        JOIN benchmark b ON sr.benchmark_id = b.id
+        JOIN benchmark_run br ON b.run_id = br.id
+        {where_clause}
+    """
+    where_clause = ""
+    params: list[object] = []
+    circuit_list = list(circuits)
+    if circuit_list:
+        where_clause = f"WHERE b.circuit_id IN ({placeholders})"
+        params.extend(circuit_list)
+    query = query.format(where_clause=where_clause)
+    with sqlite3.connect(str(database)) as conn:
+        df = pd.read_sql_query(query, conn, params=params)
+    bool_columns = [
+        "unsupported",
+        "failed",
+        "timeout",
+        "hierarchy_available",
+        "classical_simplification",
+        "include_baselines",
+        "quick",
+    ]
+    for column in bool_columns:
+        if column in df.columns:
+            df[column] = df[column].astype(bool)
+    return df
+
+
+def _write_raw_tables(raw_df: pd.DataFrame, output_dir: Path, metric: str) -> None:
+    output_dir.mkdir(parents=True, exist_ok=True)
+    all_frames: list[pd.DataFrame] = []
+    all_summary_frames: list[pd.DataFrame] = []
+    all_speedups: list[pd.DataFrame] = []
+
+    for circuit, circuit_df in raw_df.groupby("circuit", sort=True):
+        circuit_df = circuit_df.copy()
+        circuit_df.sort_values(["qubits", "framework"], inplace=True)
+        display_name = circuit_df["display_name"].iloc[0] if not circuit_df.empty else circuit
+
+        raw_path = output_dir / f"{circuit}_raw.csv"
+        circuit_df.to_csv(raw_path, index=False)
+        _write_markdown(circuit_df, raw_path.with_suffix(".md"))
+        all_frames.append(circuit_df)
+
+        try:
+            baseline_best = compute_baseline_best(
+                circuit_df,
+                metrics=("run_time_mean", "total_time_mean", "run_peak_memory_mean"),
+            )
+        except ValueError:
+            LOGGER.warning("No feasible baseline measurements for %s", circuit)
+            baseline_best = pd.DataFrame()
+
+        quasar_df = circuit_df[circuit_df["framework"] == "quasar"].copy()
+        if not quasar_df.empty:
+            quasar_df["framework"] = "quasar"
+        summary_frames = [frame for frame in (baseline_best, quasar_df) if not frame.empty]
+        if not summary_frames:
+            LOGGER.warning("Skipping summary export for %s due to missing data", circuit)
+            continue
+
+        summary_df = pd.concat(summary_frames, ignore_index=True)
+        summary_df["circuit"] = circuit
+        summary_df["display_name"] = display_name
+        summary_path = output_dir / f"{circuit}_summary.csv"
+        summary_df.to_csv(summary_path, index=False)
+        _write_markdown(summary_df, summary_path.with_suffix(".md"))
+        all_summary_frames.append(summary_df)
+
+        speedups, figure_path = _export_plot(
+            summary_df,
+            showcase_benchmarks.SHOWCASE_CIRCUITS[circuit],
+            figures_dir=DEFAULT_FIGURES_DIR,
+            metric=metric,
+        )
+        if speedups is not None and not speedups.empty:
+            speedups["circuit"] = circuit
+            speedups["display_name"] = display_name
+            speedups_path = output_dir / f"{circuit}_speedups.csv"
+            speedups.to_csv(speedups_path, index=False)
+            _write_markdown(speedups, speedups_path.with_suffix(".md"))
+            all_speedups.append(speedups)
+        if figure_path is not None:
+            LOGGER.info("Saved figure for %s to %s", circuit, figure_path)
+
+    if all_frames:
+        combined_raw = pd.concat(all_frames, ignore_index=True)
+        combined_raw.sort_values(["circuit", "qubits", "framework"], inplace=True)
+        raw_path = output_dir / "showcase_raw.csv"
+        combined_raw = _merge_results(
+            raw_path,
+            combined_raw,
+            key_columns=("circuit", "framework", "qubits"),
+            sort_columns=("circuit", "qubits", "framework"),
+        )
+        combined_raw.to_csv(raw_path, index=False)
+        _write_markdown(combined_raw, raw_path.with_suffix(".md"))
+
+    if all_summary_frames:
+        combined_summary = pd.concat(all_summary_frames, ignore_index=True)
+        summary_path = output_dir / "showcase_summary.csv"
+        combined_summary = _merge_results(
+            summary_path,
+            combined_summary,
+            key_columns=("circuit", "framework", "qubits"),
+            sort_columns=("circuit", "qubits", "framework"),
+        )
+        combined_summary.to_csv(summary_path, index=False)
+        _write_markdown(combined_summary, summary_path.with_suffix(".md"))
+
+    if all_speedups:
+        combined_speedups = pd.concat(all_speedups, ignore_index=True)
+        speedups_path = output_dir / "showcase_speedups.csv"
+        combined_speedups = _merge_results(
+            speedups_path,
+            combined_speedups,
+            key_columns=("circuit", "baseline_backend", "qubits"),
+            sort_columns=("circuit", "qubits", "baseline_backend"),
+        )
+        combined_speedups.to_csv(speedups_path, index=False)
+        _write_markdown(combined_speedups, speedups_path.with_suffix(".md"))
+
+
+def _export_estimation_tables(database: Path) -> None:
+    with sqlite3.connect(str(database)) as conn:
+        df = pd.read_sql_query(
+            "SELECT circuit_id AS circuit, qubits, framework, backend, supported, time_ops,"
+            " approx_seconds, memory_bytes, note FROM estimation",
+            conn,
+        )
+    if df.empty:
+        LOGGER.warning("No estimation data found in %s", database)
+        return
+    df["supported"] = df["supported"].astype(bool)
+    df.sort_values(["circuit", "qubits", "framework"], inplace=True)
+    summary = build_summary(df)
+    write_tables(df, summary)
+    plot_runtime_speedups(summary)
+    plot_memory_ratio(summary)
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Generate plots and tables from a QuASAr benchmark database.",
+    )
+    parser.add_argument(
+        "--database",
+        type=Path,
+        default=DEFAULT_DATABASE_PATH,
+        help="SQLite database path (default: %(default)s)",
+    )
+    parser.add_argument(
+        "--circuit",
+        "--circuits",
+        dest="circuit_names",
+        action="append",
+        default=None,
+        help="Limit output to the specified circuit(s) (repeat flag to add more).",
+    )
+    parser.add_argument(
+        "--group",
+        dest="groups",
+        action="append",
+        default=None,
+        choices=sorted(SHOWCASE_GROUPS),
+        help="Include all circuits that belong to the named group(s).",
+    )
+    parser.add_argument(
+        "--metric",
+        default="run_time_mean",
+        help="Metric to use for the generated figures (default: run_time_mean).",
+    )
+    parser.add_argument(
+        "--output-dir",
+        type=Path,
+        default=RESULTS_DIR,
+        help="Directory for CSV/Markdown outputs (default: %(default)s)",
+    )
+    parser.add_argument(
+        "--estimation",
+        action="store_true",
+        help="Also export theoretical estimation tables and figures.",
+    )
+    parser.add_argument(
+        "-v",
+        "--verbose",
+        action="count",
+        default=0,
+        help="Increase logging verbosity (use twice for debug output).",
+    )
+    return parser
+
+
+def _configure_logging(verbosity: int) -> None:
+    level = logging.WARNING
+    if verbosity >= 2:
+        level = logging.DEBUG
+    elif verbosity == 1:
+        level = logging.INFO
+    logging.basicConfig(level=level, format="%(levelname)s: %(message)s")
+
+
+def main(argv: Sequence[str] | None = None) -> None:
+    parser = _build_parser()
+    args = parser.parse_args(argv)
+
+    circuits = _resolve_circuits(args.circuit_names, args.groups)
+    _configure_logging(args.verbose)
+
+    LOGGER.info("Loading showcase results for circuits: %s", ", ".join(circuits))
+    raw_df = _load_showcase_results(args.database, circuits)
+    if raw_df.empty:
+        LOGGER.warning("No simulation runs found for the requested selection")
+    else:
+        _write_raw_tables(raw_df, args.output_dir, args.metric)
+
+    if args.estimation:
+        LOGGER.info("Exporting estimation tables")
+        _export_estimation_tables(args.database)
+
+
+if __name__ == "__main__":  # pragma: no cover - CLI entry point
+    main()
+

--- a/benchmarks/bench_utils/database.py
+++ b/benchmarks/bench_utils/database.py
@@ -1,0 +1,374 @@
+"""SQLite storage for benchmark runs and theoretical estimates."""
+
+from __future__ import annotations
+
+import json
+import sqlite3
+import threading
+import uuid
+from contextlib import contextmanager
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Iterable, Iterator, Mapping
+
+
+def _bool(value: Any | None) -> int | None:
+    if value is None:
+        return None
+    return int(bool(value))
+
+
+def _json(value: Any | None) -> str | None:
+    if value is None:
+        return None
+    if isinstance(value, str):
+        return value
+    return json.dumps(value, sort_keys=True)
+
+
+@dataclass(frozen=True)
+class BenchmarkRun:
+    """Metadata describing a single benchmark invocation."""
+
+    id: str
+
+
+class BenchmarkDatabase:
+    """Persist benchmark results into a SQLite database."""
+
+    def __init__(self, path: Path):
+        self.path = Path(path)
+        self.path.parent.mkdir(parents=True, exist_ok=True)
+        self._connection = sqlite3.connect(
+            str(self.path), detect_types=sqlite3.PARSE_DECLTYPES, check_same_thread=False
+        )
+        self._connection.row_factory = sqlite3.Row
+        self._lock = threading.Lock()
+        with self._connection:
+            self._connection.execute("PRAGMA foreign_keys = ON")
+        self._initialise()
+
+    # ------------------------------------------------------------------
+    def close(self) -> None:
+        self._connection.close()
+
+    # ------------------------------------------------------------------
+    def _initialise(self) -> None:
+        with self._connection:
+            self._connection.executescript(
+                """
+                CREATE TABLE IF NOT EXISTS benchmark_run (
+                    id TEXT PRIMARY KEY,
+                    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+                    description TEXT,
+                    parameters TEXT
+                );
+
+                CREATE TABLE IF NOT EXISTS benchmark (
+                    id INTEGER PRIMARY KEY AUTOINCREMENT,
+                    run_id TEXT NOT NULL,
+                    circuit_id TEXT NOT NULL,
+                    circuit_display_name TEXT,
+                    repetitions INTEGER NOT NULL,
+                    qubits INTEGER NOT NULL,
+                    run_timeout REAL,
+                    memory_bytes INTEGER,
+                    classical_simplification INTEGER NOT NULL,
+                    include_baselines INTEGER NOT NULL,
+                    quick INTEGER NOT NULL,
+                    baseline_backends TEXT,
+                    workers INTEGER,
+                    metadata TEXT,
+                    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+                    FOREIGN KEY(run_id) REFERENCES benchmark_run(id) ON DELETE CASCADE
+                );
+
+                CREATE TABLE IF NOT EXISTS simulation_run (
+                    id INTEGER PRIMARY KEY AUTOINCREMENT,
+                    benchmark_id INTEGER NOT NULL,
+                    framework TEXT NOT NULL,
+                    backend TEXT,
+                    mode TEXT,
+                    repetitions INTEGER,
+                    qubits INTEGER,
+                    prepare_time_mean REAL,
+                    prepare_time_std REAL,
+                    run_time_mean REAL,
+                    run_time_std REAL,
+                    total_time_mean REAL,
+                    total_time_std REAL,
+                    prepare_peak_memory_mean REAL,
+                    prepare_peak_memory_std REAL,
+                    run_peak_memory_mean REAL,
+                    run_peak_memory_std REAL,
+                    unsupported INTEGER DEFAULT 0,
+                    failed INTEGER DEFAULT 0,
+                    timeout INTEGER,
+                    comment TEXT,
+                    error TEXT,
+                    failed_runs TEXT,
+                    partition_count INTEGER,
+                    partition_total_subsystems INTEGER,
+                    partition_unique_backends INTEGER,
+                    partition_max_multiplicity INTEGER,
+                    partition_mean_multiplicity REAL,
+                    partition_backend_breakdown TEXT,
+                    hierarchy_available INTEGER,
+                    result_json TEXT,
+                    extra TEXT,
+                    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+                    FOREIGN KEY(benchmark_id) REFERENCES benchmark(id) ON DELETE CASCADE
+                );
+
+                CREATE TABLE IF NOT EXISTS estimation (
+                    id INTEGER PRIMARY KEY AUTOINCREMENT,
+                    circuit_id TEXT NOT NULL,
+                    qubits INTEGER NOT NULL,
+                    framework TEXT NOT NULL,
+                    backend TEXT,
+                    supported INTEGER NOT NULL,
+                    time_ops REAL,
+                    approx_seconds REAL,
+                    memory_bytes REAL,
+                    note TEXT,
+                    method TEXT,
+                    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+                );
+                """
+            )
+
+    # ------------------------------------------------------------------
+    def start_run(
+        self, *, description: str | None = None, parameters: Mapping[str, Any] | None = None
+    ) -> BenchmarkRun:
+        run_id = str(uuid.uuid4())
+        with self._lock, self._connection:
+            self._connection.execute(
+                "INSERT INTO benchmark_run(id, description, parameters) VALUES (?, ?, ?)",
+                (run_id, description, _json(parameters)),
+            )
+        return BenchmarkRun(id=run_id)
+
+    # ------------------------------------------------------------------
+    def create_benchmark(
+        self,
+        run: BenchmarkRun,
+        *,
+        circuit_id: str,
+        circuit_display_name: str | None,
+        repetitions: int,
+        qubits: int,
+        run_timeout: float | None,
+        memory_bytes: int | None,
+        classical_simplification: bool,
+        include_baselines: bool,
+        quick: bool,
+        baseline_backends: Iterable[str] | None,
+        workers: int | None,
+        metadata: Mapping[str, Any] | None = None,
+    ) -> int:
+        backends_json = _json(list(baseline_backends) if baseline_backends else None)
+        with self._lock, self._connection:
+            cursor = self._connection.execute(
+                """
+                INSERT INTO benchmark (
+                    run_id,
+                    circuit_id,
+                    circuit_display_name,
+                    repetitions,
+                    qubits,
+                    run_timeout,
+                    memory_bytes,
+                    classical_simplification,
+                    include_baselines,
+                    quick,
+                    baseline_backends,
+                    workers,
+                    metadata
+                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                """,
+                (
+                    run.id,
+                    circuit_id,
+                    circuit_display_name,
+                    int(repetitions),
+                    int(qubits),
+                    float(run_timeout) if run_timeout is not None else None,
+                    int(memory_bytes) if memory_bytes is not None else None,
+                    _bool(classical_simplification),
+                    _bool(include_baselines),
+                    _bool(quick),
+                    backends_json,
+                    int(workers) if workers is not None else None,
+                    _json(metadata),
+                ),
+            )
+            return int(cursor.lastrowid)
+
+    # ------------------------------------------------------------------
+    def insert_simulation_run(
+        self, benchmark_id: int, record: Mapping[str, Any], *, qubits: int | None = None
+    ) -> None:
+        known_fields = {
+            "framework",
+            "backend",
+            "mode",
+            "repetitions",
+            "prepare_time_mean",
+            "prepare_time_std",
+            "run_time_mean",
+            "run_time_std",
+            "total_time_mean",
+            "total_time_std",
+            "prepare_peak_memory_mean",
+            "prepare_peak_memory_std",
+            "run_peak_memory_mean",
+            "run_peak_memory_std",
+            "unsupported",
+            "failed",
+            "timeout",
+            "comment",
+            "error",
+            "failed_runs",
+            "partition_count",
+            "partition_total_subsystems",
+            "partition_unique_backends",
+            "partition_max_multiplicity",
+            "partition_mean_multiplicity",
+            "partition_backend_breakdown",
+            "hierarchy_available",
+            "result_json",
+        }
+
+        extra = {
+            key: value
+            for key, value in record.items()
+            if key not in known_fields.union({"qubits"})
+        }
+        failed_runs = record.get("failed_runs")
+        if isinstance(failed_runs, list):
+            failed_runs_json = json.dumps(failed_runs)
+        elif isinstance(failed_runs, str) or failed_runs is None:
+            failed_runs_json = failed_runs
+        else:
+            failed_runs_json = json.dumps(failed_runs)
+        with self._lock, self._connection:
+            self._connection.execute(
+                """
+                INSERT INTO simulation_run (
+                    benchmark_id,
+                    framework,
+                    backend,
+                    mode,
+                    repetitions,
+                    qubits,
+                    prepare_time_mean,
+                    prepare_time_std,
+                    run_time_mean,
+                    run_time_std,
+                    total_time_mean,
+                    total_time_std,
+                    prepare_peak_memory_mean,
+                    prepare_peak_memory_std,
+                    run_peak_memory_mean,
+                    run_peak_memory_std,
+                    unsupported,
+                    failed,
+                    timeout,
+                    comment,
+                    error,
+                    failed_runs,
+                    partition_count,
+                    partition_total_subsystems,
+                    partition_unique_backends,
+                    partition_max_multiplicity,
+                    partition_mean_multiplicity,
+                    partition_backend_breakdown,
+                    hierarchy_available,
+                    result_json,
+                    extra
+                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                """,
+                (
+                    int(benchmark_id),
+                    record.get("framework"),
+                    record.get("backend"),
+                    record.get("mode"),
+                    record.get("repetitions"),
+                    qubits if qubits is not None else record.get("qubits"),
+                    record.get("prepare_time_mean"),
+                    record.get("prepare_time_std"),
+                    record.get("run_time_mean"),
+                    record.get("run_time_std"),
+                    record.get("total_time_mean"),
+                    record.get("total_time_std"),
+                    record.get("prepare_peak_memory_mean"),
+                    record.get("prepare_peak_memory_std"),
+                    record.get("run_peak_memory_mean"),
+                    record.get("run_peak_memory_std"),
+                    _bool(record.get("unsupported")),
+                    _bool(record.get("failed")),
+                    _bool(record.get("timeout")),
+                    record.get("comment"),
+                    record.get("error"),
+                    failed_runs_json,
+                    record.get("partition_count"),
+                    record.get("partition_total_subsystems"),
+                    record.get("partition_unique_backends"),
+                    record.get("partition_max_multiplicity"),
+                    record.get("partition_mean_multiplicity"),
+                    record.get("partition_backend_breakdown"),
+                    _bool(record.get("hierarchy_available")),
+                    record.get("result_json"),
+                    _json(extra) if extra else None,
+                ),
+            )
+
+    # ------------------------------------------------------------------
+    def insert_estimation(self, *, record: Mapping[str, Any], method: str | None = None) -> None:
+        with self._lock, self._connection:
+            self._connection.execute(
+                """
+                INSERT INTO estimation (
+                    circuit_id,
+                    qubits,
+                    framework,
+                    backend,
+                    supported,
+                    time_ops,
+                    approx_seconds,
+                    memory_bytes,
+                    note,
+                    method
+                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                """,
+                (
+                    record.get("circuit"),
+                    record.get("qubits"),
+                    record.get("framework"),
+                    record.get("backend"),
+                    _bool(record.get("supported")),
+                    record.get("time_ops"),
+                    record.get("approx_seconds"),
+                    record.get("memory_bytes"),
+                    record.get("note"),
+                    method,
+                ),
+            )
+
+    # ------------------------------------------------------------------
+    def connection(self) -> sqlite3.Connection:
+        return self._connection
+
+
+@contextmanager
+def open_database(path: Path) -> Iterator[BenchmarkDatabase]:
+    db = BenchmarkDatabase(path)
+    try:
+        yield db
+    finally:
+        db.close()
+
+
+__all__ = ["BenchmarkDatabase", "BenchmarkRun", "open_database"]
+


### PR DESCRIPTION
## Summary
- introduce a dedicated SQLite-backed storage layer for benchmarks and theoretical estimates
- update showcase benchmark execution and smoke tests to stream results into the database and expose a --database option
- add an analysis script that rebuilds publication tables and plots from the recorded database contents

## Testing
- pytest benchmarks/run_benchmark_test.py

------
https://chatgpt.com/codex/tasks/task_e_68d78e4c21088321aaf3a350a71c67d6