### PR TITLE
Align theoretical estimation defaults with showcase circuits

### DIFF
--- a/benchmarks/bench_utils/estimate_theoretical_requirements.py
+++ b/benchmarks/bench_utils/estimate_theoretical_requirements.py
@@ -32,6 +32,7 @@ if __package__ in {None, ""}:  # pragma: no cover - script execution
         build_summary,
         load_estimator,
         plot_memory_ratio,
+        plot_relative_speedups,
         plot_runtime_speedups,
         report_totals,
         write_tables,
@@ -52,6 +53,7 @@ else:  # pragma: no cover - package import path
         build_summary,
         load_estimator,
         plot_memory_ratio,
+        plot_relative_speedups,
         plot_runtime_speedups,
         report_totals,
         write_tables,
@@ -137,7 +139,7 @@ def main(argv: Sequence[str] | None = None) -> None:
     ops_per_second = args.ops_per_second if args.ops_per_second > 0 else None
 
     estimator = load_estimator(args.calibration)
-    specs = resolve_requested_specs(args.circuits, args.groups)
+    specs = resolve_requested_specs(args.circuits, args.groups, default_group="showcase")
     records = collect_estimates(
         specs,
         paper_figures.BACKENDS,
@@ -154,6 +156,7 @@ def main(argv: Sequence[str] | None = None) -> None:
 
     if not summary.empty:
         plot_runtime_speedups(summary)
+        plot_relative_speedups(summary)
         plot_memory_ratio(summary)
     else:
         print("No supported configurations found for summary plots.")

--- a/benchmarks/bench_utils/theoretical_estimation_selection.py
+++ b/benchmarks/bench_utils/theoretical_estimation_selection.py
@@ -281,7 +281,7 @@ def resolve_requested_specs(
     circuits: Sequence[str] | None,
     groups: Sequence[str] | None,
     *,
-    default_to_paper: bool = True,
+    default_group: str = "showcase",
 ) -> tuple[paper_figures.CircuitSpec, ...]:
     """Return the circuit specifications requested via CLI arguments."""
 
@@ -322,7 +322,14 @@ def resolve_requested_specs(
                 selected.append(spec)
                 seen.add(key)
 
-    if not selected and default_to_paper:
-        return tuple(paper_figures.CIRCUITS)
+    if not selected:
+        if default_group == "paper":
+            return tuple(paper_figures.CIRCUITS)
+        if default_group not in GROUPS:
+            raise ValueError(
+                f"Unknown default estimation group '{default_group}'. Available groups: "
+                + ", ".join(sorted(GROUPS)),
+            )
+        return tuple(GROUPS[default_group])
 
     return tuple(selected)

--- a/benchmarks/run_benchmark.py
+++ b/benchmarks/run_benchmark.py
@@ -56,6 +56,7 @@ try:  # package execution
         build_summary,
         load_estimator,
         plot_memory_ratio,
+        plot_relative_speedups,
         plot_runtime_speedups,
         report_totals,
         write_tables,
@@ -80,6 +81,7 @@ except ImportError:  # pragma: no cover - script execution fallback
         build_summary,
         load_estimator,
         plot_memory_ratio,
+        plot_relative_speedups,
         plot_runtime_speedups,
         report_totals,
         write_tables,
@@ -199,7 +201,7 @@ def generate_theoretical_estimates(
 
     throughput = ops_per_second if ops_per_second and ops_per_second > 0 else None
     estimator = load_estimator(calibration)
-    specs = resolve_estimation_specs(circuits, groups)
+    specs = resolve_estimation_specs(circuits, groups, default_group="showcase")
     records = collect_estimates(
         specs,
         paper_figures.BACKENDS,
@@ -405,6 +407,7 @@ def _run_theoretical_estimation(
         report_totals(detail)
     if not summary.empty:
         plot_runtime_speedups(summary)
+        plot_relative_speedups(summary)
         plot_memory_ratio(summary)
     else:
         LOGGER.warning("No supported configurations found for summary plots.")

--- a/tests/test_theoretical_estimation_selection.py
+++ b/tests/test_theoretical_estimation_selection.py
@@ -6,8 +6,13 @@ from benchmarks.bench_utils import paper_figures
 from benchmarks.bench_utils import theoretical_estimation_selection as selection
 
 
-def test_defaults_fall_back_to_paper_circuits() -> None:
+def test_defaults_align_with_showcase_group() -> None:
     specs = selection.resolve_requested_specs(None, None)
+    assert specs == selection.GROUPS["showcase"]
+
+
+def test_explicit_paper_default_is_preserved() -> None:
+    specs = selection.resolve_requested_specs(None, None, default_group="paper")
     assert specs == paper_figures.CIRCUITS
 
 


### PR DESCRIPTION
## Summary
- default the theoretical estimation pipeline to the showcase circuit set used by the benchmarks while still allowing an explicit paper fallback
- export a relative speedup figure/CSV alongside existing runtime and memory plots with circuit-aware labels for clarity
- wire the new plot and defaults into both CLI entry points and extend the tests to cover the updated behaviour

## Testing
- `pytest tests/test_theoretical_estimation_selection.py`


------
https://chatgpt.com/codex/tasks/task_e_68d919e3b88883218a95e804eeabd71d