### PR TITLE
Handle missing baseline metrics and remap sparse qubits

### DIFF
--- a/tests/test_plot_utils.py
+++ b/tests/test_plot_utils.py
@@ -88,11 +88,12 @@ def test_compute_baseline_best_handles_all_nan_metrics():
     result = compute_baseline_best(df, metrics=["run_time_mean"])
 
     assert isinstance(result, pd.DataFrame)
-    assert result.empty
-    assert isinstance(result.index, pd.RangeIndex)
-    assert "run_time_mean" in result.columns
-    assert "framework" in result.columns
-    assert "backend" in result.columns
+    assert len(result) == 1
+    row = result.iloc[0]
+    assert row["framework"] == "baseline_best"
+    assert np.isnan(row["run_time_mean"])
+    assert row["backend"] == "unavailable"
+    assert row["status"]
 
 
 def test_compute_baseline_best_records_unavailable_baselines():
@@ -156,6 +157,27 @@ def test_compute_baseline_best_handles_missing_baseline_with_quasar_runs():
     assert row["status"] == "no baseline measurement available"
     assert bool(row["failed"]) is False
     assert bool(row["unsupported"]) is True
+
+
+def test_compute_baseline_best_fills_missing_metric_columns():
+    df = pd.DataFrame(
+        [
+            {
+                "framework": "STATEVECTOR",
+                "backend": "STATEVECTOR",
+                "circuit": "qft",
+                "qubits": 4,
+            }
+        ]
+    )
+
+    result = compute_baseline_best(df, metrics=["run_time_mean"])
+
+    assert len(result) == 1
+    row = result.iloc[0]
+    assert row["framework"] == "baseline_best"
+    assert np.isnan(row["run_time_mean"])
+    assert row["backend"] == "unavailable"
 
 
 def test_plot_quasar_vs_baseline_best_handles_missing_baseline():


### PR DESCRIPTION
## Summary
- prevent compute_baseline_best from raising when baseline metrics are missing by inserting NaN placeholders and emitting warnings
- remap gate qubits to dense indices before cost estimation so planner and selector handle sparse numbering and update supported backend heuristics
- extend tests to cover missing-metric placeholders, parallel clusters, and sparse-qubit planning

## Testing
- pytest tests/test_plot_utils.py tests/test_no_feasible_backend.py

------
https://chatgpt.com/codex/tasks/task_e_68d933b08dfc8321a9007e880b40d7d0