### PR TITLE
Ensure Scheduler forwards planned MPS chi

### DIFF
--- a/tests/test_scheduler_mps_load.py
+++ b/tests/test_scheduler_mps_load.py
@@ -1,0 +1,60 @@
+"""Tests for MPS initialisation in the scheduler."""
+
+from quasar.circuit import Circuit, Gate
+from quasar.cost import Backend, Cost, CostEstimator
+from quasar.planner import PlanResult, PlanStep, Planner
+from quasar.scheduler import Scheduler
+
+
+class RecordingMPSBackend:
+    """Minimal MPS backend capturing the ``chi`` argument passed to ``load``."""
+
+    backend = Backend.MPS
+    instances: list["RecordingMPSBackend"] = []
+
+    def __init__(self) -> None:
+        self.recorded_chi: int | None = None
+        self.num_qubits: int | None = None
+        RecordingMPSBackend.instances.append(self)
+
+    def load(self, num_qubits: int, **kwargs) -> None:  # pragma: no cover - trivial
+        self.num_qubits = num_qubits
+        self.recorded_chi = kwargs.get("chi")
+
+    def apply_gate(self, gate: str, qubits, params) -> None:  # pragma: no cover - stub
+        del gate, qubits, params
+
+    def extract_ssd(self):  # pragma: no cover - stub
+        return None
+
+
+def test_scheduler_initialises_mps_with_planned_chi() -> None:
+    """Scheduler should forward the planner's ``chi_max`` to MPS backends."""
+
+    chi_cap = 23
+    estimator = CostEstimator(chi_max=chi_cap)
+    planner = Planner(estimator=estimator)
+
+    RecordingMPSBackend.instances.clear()
+    scheduler = Scheduler(
+        planner=planner,
+        backends={Backend.MPS: RecordingMPSBackend()},
+    )
+
+    gate = Gate("H", [0])
+    circuit = Circuit([gate], use_classical_simplification=False)
+    gates = circuit.gates
+    plan = PlanResult(
+        table=[],
+        final_backend=Backend.MPS,
+        gates=gates,
+        explicit_steps=[PlanStep(start=0, end=1, backend=Backend.MPS)],
+        explicit_conversions=[],
+        step_costs=[Cost(time=0.0, memory=0.0)],
+    )
+
+    scheduler.run(circuit, plan=plan)
+
+    assert RecordingMPSBackend.instances, "Scheduler did not instantiate the backend"
+    recorded = RecordingMPSBackend.instances[-1].recorded_chi
+    assert recorded == planner.estimator.chi_max


### PR DESCRIPTION
## Summary
- add a Scheduler helper that forwards the planner's chi_max when initialising MPS backends
- route all scheduler load sites through the helper to keep bond dimensions consistent across execution paths
- add a scheduler regression test that checks an MPS backend receives the planner's chi value

## Testing
- pytest tests/test_scheduler_mps_load.py


------
https://chatgpt.com/codex/tasks/task_e_68da3e86fc8883218dfecc64b7692868