### PR TITLE
Tune theoretical estimates planner for large circuits

### DIFF
--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -109,6 +109,20 @@ selections:
 * ``--ops-per-second`` – set the conversion factor from model operations to
   seconds (use ``0`` to omit runtime conversion).
 * ``--calibration`` – provide a JSON file with calibrated cost coefficients.
+* ``--estimate-large-planner`` / ``--no-estimate-large-planner`` – toggle the
+  tuned planner configuration that accelerates estimates for very large
+  classically simplified circuits.
+* ``--estimate-large-threshold`` – gate-count threshold for enabling the tuned
+  planner (``0`` disables the heuristic).
+* ``--estimate-large-batch-size`` / ``--estimate-large-horizon`` /
+  ``--estimate-large-quick-max-*`` – override the coarse planner parameters used
+  once the threshold is exceeded.
+
+When enabled (the default) the runner inspects the simplified circuit and, for
+gate counts above the threshold, instantiates a planner with a wider batch size,
+a finite DP horizon and explicit quick-path limits.  This keeps small and
+medium-sized circuits on the exhaustive search while ensuring that the
+highly-clustered showcase variants complete promptly.
 
 The standalone helper ``benchmarks/bench_utils/estimate_theoretical_requirements.py``
 offers the same flags when you only need analytical estimates.  For example:

--- a/tests/benchmarks/test_theoretical_estimation_runner.py
+++ b/tests/benchmarks/test_theoretical_estimation_runner.py
@@ -1,0 +1,124 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+
+from benchmarks.bench_utils.paper_figures import CircuitSpec
+from benchmarks.bench_utils import theoretical_estimation_runner as runner
+from benchmarks.bench_utils.theoretical_estimation_utils import EstimateRecord
+from quasar.cost import CostEstimator
+from quasar.planner import Planner
+
+
+class FakeCircuit:
+    def __init__(self, gate_count: int):
+        self.gates = [SimpleNamespace(gate="H", qubits=(0,)) for _ in range(gate_count)]
+        self.num_qubits = 1
+        self.use_classical_simplification = False
+
+    def enable_classical_simplification(self) -> None:
+        self.use_classical_simplification = True
+
+    def disable_classical_simplification(self) -> None:
+        self.use_classical_simplification = False
+
+
+class FakeAnalyzer:
+    def __init__(self, circuit, estimator):  # noqa: D401 - mimic real signature
+        self.circuit = circuit
+        self.estimator = estimator
+
+    def resource_estimates(self):  # noqa: D401 - mimic real method
+        return {}
+
+
+def _make_spec(name: str, gate_count: int) -> CircuitSpec:
+    def builder(_n_qubits: int, *, gate_count: int = gate_count) -> FakeCircuit:
+        return FakeCircuit(gate_count)
+
+    return CircuitSpec(name, builder, (1,), {"gate_count": gate_count})
+
+
+def _run_estimate(
+    monkeypatch: pytest.MonkeyPatch,
+    gate_count: int,
+    *,
+    enable_large_planner: bool = True,
+    threshold: int = 50,
+    overrides: dict[str, object] | None = None,
+):
+    spec = _make_spec("fake", gate_count)
+    estimator = CostEstimator()
+    base_planner = Planner(estimator=estimator, perf_prio="time")
+
+    captured: dict[str, object] = {}
+
+    def fake_quasar_record(**kwargs):
+        planner = kwargs["planner"]
+        captured["planner"] = planner
+        return EstimateRecord(
+            circuit=spec.name,
+            qubits=1,
+            framework="quasar",
+            backend="stub",
+            supported=True,
+            time_ops=1.0,
+            memory_bytes=1.0,
+            note="base",
+        )
+
+    monkeypatch.setattr(runner, "CircuitAnalyzer", FakeAnalyzer)
+    monkeypatch.setattr(runner, "_estimate_quasar_record", fake_quasar_record)
+
+    records = runner.estimate_circuit(
+        spec,
+        1,
+        estimator,
+        (),
+        base_planner,
+        enable_large_planner=enable_large_planner,
+        large_gate_threshold=threshold,
+        large_planner_kwargs=overrides,
+    )
+    return records, captured, base_planner
+
+
+def test_large_circuit_uses_tuned_planner(monkeypatch: pytest.MonkeyPatch) -> None:
+    overrides = {"batch_size": 16, "horizon": 256, "quick_max_gates": 500}
+    records, captured, base_planner = _run_estimate(
+        monkeypatch,
+        gate_count=100,
+        threshold=50,
+        overrides=overrides,
+    )
+    planner = captured["planner"]
+    assert planner is not base_planner
+    assert planner.batch_size == overrides["batch_size"]
+    assert planner.horizon == overrides["horizon"]
+    assert planner.quick_max_gates == overrides["quick_max_gates"]
+    quasar_note = next(rec.note for rec in records if rec.framework == "quasar")
+    assert quasar_note and "tuned planner" in quasar_note
+
+
+def test_small_circuit_retains_full_planner(monkeypatch: pytest.MonkeyPatch) -> None:
+    records, captured, base_planner = _run_estimate(
+        monkeypatch,
+        gate_count=20,
+        threshold=50,
+    )
+    assert captured["planner"] is base_planner
+    quasar_note = next(rec.note for rec in records if rec.framework == "quasar")
+    assert quasar_note == "base"
+
+
+def test_large_planner_can_be_disabled(monkeypatch: pytest.MonkeyPatch) -> None:
+    records, captured, base_planner = _run_estimate(
+        monkeypatch,
+        gate_count=100,
+        threshold=50,
+        enable_large_planner=False,
+    )
+    assert captured["planner"] is base_planner
+    quasar_note = next(rec.note for rec in records if rec.framework == "quasar")
+    assert quasar_note == "base"


### PR DESCRIPTION
## Summary
- detect large simplified circuits in the theoretical estimation runner and reuse a tuned planner configuration when the gate count exceeds a configurable threshold
- expose CLI flags in both `run_benchmark.py` and `estimate_theoretical_requirements.py` to toggle the tuned planner and override batch size, horizon and quick-path limits
- document the new options in the benchmarks README and add regression tests covering tuned, default and disabled planner flows

## Testing
- pytest tests/benchmarks/test_theoretical_estimation_runner.py

------
https://chatgpt.com/codex/tasks/task_e_68da4e4de8408321a109c532c8afc4dc