### PR TITLE
Set benchmark repetition defaults to a single run

### DIFF
--- a/benchmarks/bench_utils/benchmark_cli.py
+++ b/benchmarks/bench_utils/benchmark_cli.py
@@ -178,8 +178,8 @@ def main() -> None:
     parser.add_argument(
         "--repetitions",
         type=int,
-        default=3,
-        help="Number of repetitions per configuration",
+        default=1,
+        help="Number of repetitions per configuration (default: %(default)s)",
     )
     parser.add_argument(
         "--output", required=True, type=Path, help="Output file path without extension"

--- a/benchmarks/bench_utils/estimate_paper_figures.py
+++ b/benchmarks/bench_utils/estimate_paper_figures.py
@@ -456,8 +456,8 @@ def parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
         "-r",
         "--repetitions",
         type=int,
-        default=3,
-        help="Number of repetitions used in paper_figures (default: 3).",
+        default=1,
+        help="Number of repetitions used in paper_figures (default: %(default)s).",
     )
     parser.add_argument(
         "--ops-per-second",

--- a/benchmarks/bench_utils/paper_figures.py
+++ b/benchmarks/bench_utils/paper_figures.py
@@ -762,7 +762,7 @@ def collect_backend_data(
     specs: Iterable[CircuitSpec],
     backends: Sequence[Backend],
     *,
-    repetitions: int = 3,
+    repetitions: int = 1,
     run_timeout: float | None = RUN_TIMEOUT_DEFAULT_SECONDS,
     max_workers: int | None = None,
 ) -> tuple[pd.DataFrame, pd.DataFrame]:
@@ -1092,7 +1092,7 @@ def _annotate_optimal_markers(
 
 def generate_backend_comparison(
     *,
-    repetitions: int = 3,
+    repetitions: int = 1,
     run_timeout: float | None = RUN_TIMEOUT_DEFAULT_SECONDS,
     reuse_existing: bool = False,
     max_workers: int | None = None,
@@ -1841,8 +1841,8 @@ def main(argv: Sequence[str] | None = None) -> None:
         "-r",
         "--repetitions",
         type=int,
-        default=3,
-        help="Number of repetitions per circuit/backend combination (default: 3).",
+        default=1,
+        help="Number of repetitions per circuit/backend combination (default: %(default)s).",
     )
     parser.add_argument(
         "-t",

--- a/benchmarks/bench_utils/showcase_benchmarks.py
+++ b/benchmarks/bench_utils/showcase_benchmarks.py
@@ -1017,8 +1017,8 @@ def build_arg_parser() -> argparse.ArgumentParser:
     parser.add_argument(
         "--repetitions",
         type=int,
-        default=3,
-        help="Number of repetitions per configuration (default: 3).",
+        default=1,
+        help="Number of repetitions per configuration (default: %(default)s).",
     )
     parser.add_argument(
         "--run-timeout",


### PR DESCRIPTION
## Summary
- set the benchmark CLI entry points to default to a single repetition unless overridden
- align the paper figure scripts and estimator with the new repetition default

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68da584439648321bd34a4b3650c4e3e