### PR TITLE
Handle parallel subsystem memory estimation in selector

### DIFF
--- a/tests/test_parallel_subsystems.py
+++ b/tests/test_parallel_subsystems.py
@@ -2,8 +2,11 @@
 
 from __future__ import annotations
 
+import pytest
+
 from benchmarks.parallel_circuits import many_ghz_subsystems
 from quasar.cost import Backend
+from quasar.method_selector import MethodSelector
 from quasar.planner import Planner
 
 
@@ -56,3 +59,53 @@ def test_parallel_groups_with_batched_planner() -> None:
     assert step.parallel == expected_groups
     assert step.start == 0
     assert step.end == len(circuit.gates)
+
+
+def test_method_selector_respects_parallel_memory_limits() -> None:
+    """Selector should base memory on the largest independent subsystem."""
+
+    num_groups = 6
+    group_size = 5
+    circuit = many_ghz_subsystems(num_groups=num_groups, group_size=group_size)
+    selector = MethodSelector()
+
+    def _counts(gates):
+        total = len(gates)
+        meas = sum(1 for gate in gates if gate.gate.upper() in {"MEASURE", "RESET"})
+        singles = sum(
+            1
+            for gate in gates
+            if len(gate.qubits) == 1 and gate.gate.upper() not in {"MEASURE", "RESET"}
+        )
+        return singles, total - singles - meas, meas
+
+    total_1q, total_2q, total_meas = _counts(circuit.gates)
+    combined_cost = selector.estimator.statevector(
+        circuit.num_qubits, total_1q, total_2q, total_meas
+    )
+
+    single_circuit = many_ghz_subsystems(num_groups=1, group_size=group_size)
+    single_1q, single_2q, single_meas = _counts(single_circuit.gates)
+    single_cost = selector.estimator.statevector(
+        single_circuit.num_qubits, single_1q, single_2q, single_meas
+    )
+
+    assert combined_cost.memory > single_cost.memory
+
+    memory_limit = single_cost.memory * 10
+    assert memory_limit < combined_cost.memory
+
+    diagnostics: dict[str, object] = {}
+    backend, cost = selector.select(
+        circuit.gates,
+        circuit.num_qubits,
+        max_memory=memory_limit,
+        allow_tableau=False,
+        diagnostics=diagnostics,
+    )
+
+    assert backend in {Backend.STATEVECTOR, Backend.MPS}
+    backends = diagnostics["backends"]
+    sv_entry = backends[Backend.STATEVECTOR]
+    assert sv_entry["feasible"] is True
+    assert sv_entry["cost"].memory == pytest.approx(single_cost.memory)


### PR DESCRIPTION
## Summary
- update `MethodSelector` to detect independent qubit groups and combine backend costs based on the largest subsystem
- enrich diagnostics with subsystem metadata and reuse sequential cost helpers for statevector, MPS, DD, and extended stabilizer estimates
- extend the parallel subsystem tests to verify that the selector honours memory limits for clustered circuits

## Testing
- pytest tests/test_parallel_subsystems.py tests/test_method_selector_grover.py

------
https://chatgpt.com/codex/tasks/task_e_68da620978148321be7f3d7e033003d5