### PR TITLE
Refine SSD hierarchy fragment tracking

### DIFF
--- a/tests/test_ssd_sequential.py
+++ b/tests/test_ssd_sequential.py
@@ -1,0 +1,34 @@
+from quasar.circuit import Circuit, Gate
+from quasar.cost import Backend
+from quasar.ssd import build_hierarchical_ssd
+
+
+def build_circuit(*gates: Gate) -> Circuit:
+    return Circuit(list(gates), use_classical_simplification=False)
+
+
+def test_first_fragment_prefers_tableau_for_initial_clifford() -> None:
+    circuit = build_circuit(Gate("H", [0]), Gate("X", [1]))
+
+    ssd = build_hierarchical_ssd(circuit)
+
+    assert ssd.partitions
+    first = ssd.partitions[0]
+    assert first.backend == Backend.TABLEAU
+    assert first.history == ("H",)
+
+
+def test_disjoint_qubits_form_independent_partitions() -> None:
+    circuit = build_circuit(Gate("H", [0]), Gate("X", [1]))
+
+    ssd = build_hierarchical_ssd(circuit)
+
+    assert len(ssd.partitions) == 2
+    first, second = ssd.partitions
+
+    assert set(first.qubits) == {0}
+    assert set(second.qubits) == {1}
+    assert first.history == ("H",)
+    assert second.history == ("X",)
+    assert first.backend == Backend.TABLEAU
+    assert second.backend == Backend.TABLEAU


### PR DESCRIPTION
## Summary
- track incremental gate metrics and backend assignments while building SSD hierarchy fragments
- finalise fragments when gates become disjoint and honour their sequential order in SSD partitions
- add tests covering initial Clifford backend choice and disjoint-qubit partitioning

## Testing
- pytest tests/test_ssd_sequential.py

------
https://chatgpt.com/codex/tasks/task_e_68dab8a1cea08321abfc758578dd4ea6