### PR TITLE
Document deferred backend switch backlog

### DIFF
--- a/docs/backend_selection.md
+++ b/docs/backend_selection.md
@@ -191,8 +191,19 @@ When ``Planner.plan`` is invoked with ``explain=True`` the returned
 ``PlanDiagnostics`` object exposes a ``backend_selection`` mapping with the
 same diagnostic payload.  Each entry captures the heuristics, estimated costs
 and the reasons why candidates were accepted or rejected, making it easier to
-trace planning decisions without relying solely on console output. When a
-backend switch is applied, the planner also records the chosen conversion
-primitive together with ``boundary_size``, ``rank`` and ``frontier``; refer to
-[conversion_primitives.md](conversion_primitives.md) for the glossary and the
-helper utilities that reproduce these trace entries.【F:quasar/partitioner.py†L132-L201】【F:quasar/ssd.py†L18-L160】
+trace planning decisions without relying solely on console output.  The
+``reason`` field reflects the planner's backlog-aware workflow: repeated
+``deferred_switch_candidate`` entries track a pending backend change, while
+``deferred_backend_switch`` marks the point where the conversion becomes
+cheaper than continuing with the current backend.  Additional reasons such as
+``statevector_lock`` and ``single_qubit_preamble`` capture fast-path rejections
+for dense fragments and single-qubit prefixes respectively.【F:quasar/partitioner.py†L283-L399】【F:quasar/partitioner.py†L495-L508】【F:quasar/partitioner.py†L536-L547】
+
+Rank and frontier diagnostics in these traces come from the conversion helper
+inside the partitioner.  Boundaries fall back to ``2**|boundary|`` when no
+external rank model is supplied, and the estimator's chosen primitive plus its
+cost are carried over to any emitted `ConversionLayer`, keeping the diagnostic
+output aligned with the conversion glossary.【F:quasar/partitioner.py†L143-L201】【F:quasar/partitioner.py†L298-L308】 Refer to the
+[Partitioning Theory reference](partitioning_theory.md#single-method-backlog-and-deferred-conversions)
+for a narrative walkthrough of the backlog logic and how it interacts with the
+sequential fragment tracker.

--- a/docs/conversion_primitives.md
+++ b/docs/conversion_primitives.md
@@ -7,8 +7,8 @@ QuASAr evaluates four conversion primitives—boundary-to-boundary (B2B), local 
 Conversion estimates depend on the boundary descriptors emitted by the planner:
 
 - **Boundary size ``q``** – the number of qubits along the cut. Logged as ``boundary``/``boundary_size`` on :class:`~quasar.ssd.PartitionTraceEntry` and ``ConversionLayer.boundary`` on the SSD.【F:quasar/ssd.py†L18-L66】【F:quasar/ssd.py†L118-L160】
-- **Rank ``s``** – the Schmidt-rank bound used for SVD-based primitives. Stored as ``rank`` in planner traces and SSD conversion layers.【F:quasar/ssd.py†L30-L66】【F:quasar/ssd.py†L118-L160】
-- **Frontier ``r``** – the decision-diagram frontier estimate recorded alongside ``rank`` to size DD-style conversions.【F:quasar/ssd.py†L30-L66】【F:quasar/ssd.py†L118-L160】
+- **Rank ``s``** – the Schmidt-rank bound used for SVD-based primitives. Stored as ``rank`` in planner traces and SSD conversion layers. When no upstream estimator supplies a refined value the partitioner defaults to ``2**q`` before scoring primitives.【F:quasar/ssd.py†L30-L66】【F:quasar/ssd.py†L118-L160】【F:quasar/partitioner.py†L143-L201】
+- **Frontier ``r``** – the decision-diagram frontier estimate recorded alongside ``rank`` to size DD-style conversions. The sequential backlog logic uses the boundary size as the default frontier when queuing pending conversions.【F:quasar/ssd.py†L30-L66】【F:quasar/ssd.py†L118-L160】【F:quasar/partitioner.py†L143-L201】
 - **Window ``w``** – the optional dense window size for LW extractions. When not specified by the planner the estimator defaults to ``min(q, 4)`` before scoring the primitives.【F:quasar/cost.py†L698-L739】
 
 The planner always threads ``q``, ``s`` and ``r`` into the cost estimator when emitting trace diagnostics. The LW window parameter remains implicit in the traces but can be reproduced analytically through the estimator helpers described below.


### PR DESCRIPTION
## Summary
- extend the partitioning theory reference with the sequential fragment tracker, SSD hierarchy layers, and the deferred switch backlog flow
- clarify backend-selection telemetry reasons and default rank/frontier sourcing in the backend selection and conversion primitive guides

## Testing
- not run (documentation only)


------
https://chatgpt.com/codex/tasks/task_e_68db71032c7c8321b8e7ff52cf37d67b