### PR TITLE
Avoid redundant circuit simplification in planner

### DIFF
--- a/quasar/planner.py
+++ b/quasar/planner.py
@@ -1554,7 +1554,7 @@ class Planner:
             provided limits.
         """
 
-        gates = circuit.simplify_classical_controls()
+        gates = circuit.ensure_simplified()
         diagnostics = PlanDiagnostics() if explain else None
         names = [g.gate.upper() for g in gates]
         clifford_circuit = bool(names) and all(

--- a/tests/test_planner.py
+++ b/tests/test_planner.py
@@ -1,0 +1,35 @@
+"""Planner regression tests."""
+
+from __future__ import annotations
+
+from quasar.circuit import Circuit, Gate
+from quasar.planner import Planner
+
+
+def test_repeated_planning_does_not_rebuild_circuit_metadata(monkeypatch) -> None:
+    """Repeated planning should not trigger another metadata rebuild."""
+
+    circuit = Circuit(
+        [
+            Gate("H", [0]),
+            Gate("CX", [0, 1]),
+            Gate("T", [1]),
+        ],
+        use_classical_simplification=True,
+    )
+    planner = Planner()
+
+    call_count = 0
+    original_refresh = Circuit._refresh_metadata
+
+    def spy(self: Circuit) -> None:
+        nonlocal call_count
+        call_count += 1
+        original_refresh(self)
+
+    monkeypatch.setattr(Circuit, "_refresh_metadata", spy)
+
+    planner.plan(circuit)
+    planner.plan(circuit)
+
+    assert call_count == 0


### PR DESCRIPTION
## Summary
- track an is_simplified flag on Circuit and centralize metadata rebuilding
- expose ensure_simplified and reset the flag when toggling classical simplification
- teach Planner.plan to reuse simplified circuits and add a regression test

## Testing
- pytest tests/test_planner.py

------
https://chatgpt.com/codex/tasks/task_e_68db7578585c8321a55643c80e663858