### PR TITLE
Optimize supported backend metrics reuse

### DIFF
--- a/quasar/analyzer.py
+++ b/quasar/analyzer.py
@@ -271,12 +271,16 @@ class CircuitAnalyzer:
     def method_compatibility(self) -> List[List[str]]:
         """Return compatible simulation backends for each gate."""
 
-        from .planner import _supported_backends
+        from .planner import SupportedBackendMetrics, _supported_backends
 
         compat: List[List[str]] = []
         for gate in self._topological_order():
+            metrics = SupportedBackendMetrics.from_gate(gate)
             backends = _supported_backends(
-                [gate], circuit=self.circuit, estimator=self.estimator
+                [gate],
+                metrics=metrics,
+                circuit=self.circuit,
+                estimator=self.estimator,
             )
             methods = [b.name.lower() for b in backends]
             gate.compatible_methods = methods

--- a/quasar/circuit.py
+++ b/quasar/circuit.py
@@ -331,7 +331,7 @@ class Circuit:
     def _annotate_gates(self) -> None:
         """Attach per-gate metadata such as entanglement and costs."""
 
-        from .planner import _supported_backends
+        from .planner import SupportedBackendMetrics, _supported_backends
 
         estimator = CostEstimator()
         max_index = max((q for g in self.gates for q in g.qubits), default=-1)
@@ -362,7 +362,10 @@ class Circuit:
                 else:
                     gate.entanglement = "modifies"
 
-            backends = _supported_backends([gate], circuit=self, estimator=estimator)
+            metrics = SupportedBackendMetrics.from_gate(gate)
+            backends = _supported_backends(
+                [gate], metrics=metrics, circuit=self, estimator=estimator
+            )
             gate.compatible_methods = [b.name.lower() for b in backends]
             resources: Dict[str, Cost] = {}
             num_qubits = (max(qubits) + 1) if qubits else 0


### PR DESCRIPTION
## Summary
- add a reusable `SupportedBackendMetrics` dataclass and allow `_supported_backends` to consume pre-computed counts and locality flags
- feed dynamic-programming segments and gate annotations with cached metrics to avoid recomputing gate statistics
- update analyzer and circuit helpers to reuse the shared metrics when querying supported backends

## Testing
- pytest tests/test_planner_cost_table.py tests/test_planner_cost_gap_cdf.py

------
https://chatgpt.com/codex/tasks/task_e_68db84e16d44832180e39584cca78b16