### PR TITLE
Update documentation for quick-path configuration

### DIFF
--- a/docs/simulation_engine_api.md
+++ b/docs/simulation_engine_api.md
@@ -55,7 +55,7 @@ loudly.
 `SimulationEngine.simulate` accepts several optional parameters:
 
 - `backend` prefers a specific backend (for example
-  `Backend.STATEVECTOR` or `Backend.STIM_TABLEAU`).
+  `Backend.STATEVECTOR` or `Backend.TABLEAU`).
 - `memory_threshold` overrides the automatically detected memory ceiling for the
   dense statevector backend.
 - `target_accuracy`, `max_time` and `optimization_level` are forwarded to the

--- a/issues/quick_path_thresholds.md
+++ b/issues/quick_path_thresholds.md
@@ -2,8 +2,8 @@
 
 **Location:** `quasar/scheduler.py` and configuration defaults.
 
-**Context:** Quick-path heuristics determine when planning is bypassed. The repository includes `benchmarks/quick_analysis_benchmark.py` to guide tuning, but defaults may drift from optimal values.
+**Context:** Quick-path heuristics determine when planning is bypassed. The repository includes `benchmarks/bench_utils/quick_analysis_benchmark.py` to guide tuning, but defaults may drift from optimal values.
 
 **Impact:** Does not block system operation but may reduce performance if thresholds are poorly tuned.
 
-**Task:** Run `benchmarks/quick_analysis_benchmark.py` on representative circuits to validate or update `quick_max_qubits`, `quick_max_gates`, and `quick_max_depth` defaults. Document the chosen values.
+**Task:** Run `benchmarks/bench_utils/quick_analysis_benchmark.py` on representative circuits to validate or update `quick_max_qubits`, `quick_max_gates`, and `quick_max_depth` defaults. Document the chosen values and update configuration guidance if the heuristics are enabled (they default to `None`).


### PR DESCRIPTION
## Summary
- clarify that quick-path heuristics are disabled by default and point to the new calibration script path
- refresh the quick-path example in the README to show how to enable or disable the heuristics programmatically
- fix the simulation engine guide to reference the current Backend.TABLEAU enum value

## Testing
- not run (documentation changes only)

------
https://chatgpt.com/codex/tasks/task_e_68dc041cdbcc832183efacb5330707bd