### PR TITLE
Teach planner to use entanglement-aware conversion windows

### DIFF
--- a/docs/conversion_primitives.md
+++ b/docs/conversion_primitives.md
@@ -9,7 +9,7 @@ Conversion estimates depend on the boundary descriptors emitted by the planner:
 - **Boundary size ``q``** – the number of qubits along the cut. Logged as ``boundary``/``boundary_size`` on :class:`~quasar.ssd.PartitionTraceEntry` and ``ConversionLayer.boundary`` on the SSD.【F:quasar/ssd.py†L18-L66】【F:quasar/ssd.py†L118-L160】
 - **Rank ``s``** – the Schmidt-rank bound used for SVD-based primitives. Stored as ``rank`` in planner traces and SSD conversion layers. When no upstream estimator supplies a refined value the partitioner defaults to ``2**q`` before scoring primitives.【F:quasar/ssd.py†L30-L66】【F:quasar/ssd.py†L118-L160】【F:quasar/partitioner.py†L143-L201】
 - **Frontier ``r``** – the decision-diagram frontier estimate recorded alongside ``rank`` to size DD-style conversions. The sequential backlog logic uses the boundary size as the default frontier when queuing pending conversions.【F:quasar/ssd.py†L30-L66】【F:quasar/ssd.py†L118-L160】【F:quasar/partitioner.py†L143-L201】
-- **Window ``w``** – the optional dense window size for LW extractions. When not specified by the planner the estimator defaults to ``min(q, 4)`` before scoring the primitives.【F:quasar/cost.py†L698-L739】
+- **Window ``w``** – the optional dense window size for LW extractions. When not specified by the planner the estimator derives an entanglement-aware window (clamped to at least ``min(q, 4)``) before scoring the primitives.【F:quasar/cost.py†L812-L881】
 
 The planner always threads ``q``, ``s`` and ``r`` into the cost estimator when emitting trace diagnostics. The LW window parameter remains implicit in the traces but can be reproduced analytically through the estimator helpers described below.
 
@@ -28,7 +28,7 @@ All primitives include a fixed ``conversion_base`` overhead and per-amplitude in
 
 The helper :func:`docs.utils.partitioning_analysis.build_conversion_primitive_examples` uses the calibrated estimator to tabulate per-primitive costs for small scenarios, matching the planner's ``debug=True`` traces.【F:docs/utils/partitioning_analysis.py†L188-L224】 Running the helper with ``calibration/coeff_v1.json`` yields the following illustrative tables.【7a22ef†L1-L20】
 
-Scenario 1 – statevector→tableau with default LW windows (``w = min(q, 4)``):
+Scenario 1 – statevector→tableau with heuristic LW windows (derived ``w``):
 
 | Boundary q | Rank s | Frontier r | Primitive | Time (a.u.) | Memory (a.u.) | Selected? |
 |---|---|---|---|---|---|---|

--- a/quasar/planner.py
+++ b/quasar/planner.py
@@ -230,6 +230,7 @@ class ConversionEstimate:
     primitive: str | None = None
     feasible: bool = True
     reason: str | None = None
+    window: int | None = None
 
 
 @dataclass
@@ -259,6 +260,7 @@ class PlanDiagnostics:
         primitive: str | None = None,
         feasible: bool = True,
         reason: str | None = None,
+        window: int | None = None,
     ) -> None:
         self.conversion_estimates.append(
             ConversionEstimate(
@@ -272,6 +274,7 @@ class PlanDiagnostics:
                 primitive=primitive,
                 feasible=feasible,
                 reason=reason,
+                window=window,
             )
         )
 
@@ -1514,12 +1517,18 @@ class Planner:
                                 compressed = _compressed_terms(j, len(boundary))
                                 rank = compressed
                                 frontier = len(boundary)
+                                window = self.estimator.derive_conversion_window(
+                                    len(boundary),
+                                    rank=rank,
+                                    compressed_terms=compressed,
+                                )
                                 conv_est = self.estimator.conversion(
                                     prev_backend,
                                     backend,
                                     num_qubits=len(boundary),
                                     rank=rank,
                                     frontier=frontier,
+                                    window=window,
                                     compressed_terms=compressed,
                                 )
                                 est_time = conv_est.cost.time
@@ -1551,6 +1560,7 @@ class Planner:
                                             primitive=primitive,
                                             feasible=False,
                                             reason="memory",
+                                            window=conv_est.window,
                                         )
                                     continue
                                 if diagnostics is not None and stage is not None:
@@ -1563,6 +1573,7 @@ class Planner:
                                         boundary=boundary,
                                         cost=conv_cost,
                                         primitive=primitive,
+                                        window=conv_est.window,
                                     )
                         total_cost = _add_cost(
                             _add_cost(prev_entry.cost, conv_cost), sim_cost
@@ -1696,12 +1707,18 @@ class Planner:
             compressed = compressed_for_cut(cut, len(boundary))
             rank = compressed
             frontier = len(boundary)
+            window = self.estimator.derive_conversion_window(
+                len(boundary),
+                rank=rank,
+                compressed_terms=compressed,
+            )
             conv_est = self.estimator.conversion(
                 prev.backend,
                 step.backend,
                 num_qubits=len(boundary),
                 rank=rank,
                 frontier=frontier,
+                window=window,
                 compressed_terms=compressed,
             )
             layers.append(
@@ -1713,6 +1730,7 @@ class Planner:
                     frontier=frontier,
                     primitive=conv_est.primitive,
                     cost=conv_est.cost,
+                    window=conv_est.window,
                 )
             )
         return layers

--- a/quasar/ssd.py
+++ b/quasar/ssd.py
@@ -44,6 +44,8 @@ class PartitionTraceEntry:
         Estimated Schmidt rank and decision diagram frontier across the cut.
     primitive, cost:
         Conversion primitive and estimated cost when a conversion is required.
+    window:
+        Dense window size requested for local-window conversions.
     applied:
         ``True`` when the backend change was accepted.
     reason:
@@ -58,6 +60,7 @@ class PartitionTraceEntry:
     boundary_size: int = 0
     rank: int | None = None
     frontier: int | None = None
+    window: int | None = None
     primitive: str | None = None
     cost: Cost | None = None
     applied: bool = False
@@ -1071,6 +1074,8 @@ class ConversionLayer:
         ``ST`` or ``Full``).
     cost:
         Estimated cost of performing the conversion.
+    window:
+        Dense window size used by local-window conversions (``None`` otherwise).
     """
 
     boundary: Tuple[int, ...]
@@ -1080,6 +1085,7 @@ class ConversionLayer:
     frontier: int
     primitive: str
     cost: Cost
+    window: int | None = None
 
 
 @dataclass

--- a/quasar_convert/__init__.py
+++ b/quasar_convert/__init__.py
@@ -489,12 +489,16 @@ except Exception:  # pragma: no cover - exercised when extension missing
             ssd: SSD,
             window_1q_gates: int = 0,
             window_2q_gates: int = 0,
+            window: int | None = None,
         ) -> ConversionResult:
             boundary = len(ssd.boundary_qubits or [])
             rank = ssd.top_s
 
-            window = min(boundary, 4)
-            dense = 1 << window
+            if window is None:
+                window_size = min(boundary, 4)
+            else:
+                window_size = min(boundary, max(window, 0))
+            dense = 1 << window_size
             chi_tilde = min(rank, self.st_chi_cap)
             full = 1 << min(boundary, 16)
 

--- a/quasar_convert/binding.cpp
+++ b/quasar_convert/binding.cpp
@@ -101,7 +101,8 @@ PYBIND11_MODULE(_conversion_engine, m) {
              &quasar::ConversionEngine::convert,
              py::arg("ssd"),
              py::arg("window_1q_gates") = 0,
-             py::arg("window_2q_gates") = 0)
+             py::arg("window_2q_gates") = 0,
+             py::arg("window") = py::none())
         .def("build_bridge_tensor", &quasar::ConversionEngine::build_bridge_tensor)
         .def("convert_boundary_to_statevector", &quasar::ConversionEngine::convert_boundary_to_statevector)
         .def("convert_boundary_to_stn", &quasar::ConversionEngine::convert_boundary_to_stn)

--- a/quasar_convert/conversion_engine.cpp
+++ b/quasar_convert/conversion_engine.cpp
@@ -283,14 +283,19 @@ std::vector<std::complex<double>> ConversionEngine::build_bridge_tensor(const SS
 
 ConversionResult ConversionEngine::convert(const SSD& ssd,
                                            std::size_t window_1q_gates,
-                                           std::size_t window_2q_gates) const {
+                                           std::size_t window_2q_gates,
+                                           std::optional<std::size_t> window_override) const {
     const std::size_t boundary = ssd.boundary_qubits.size();
     const std::size_t rank = ssd.top_s;
 
     // Cost estimates mirror the simple analytical models used by the Python
     // ``CostEstimator``.  We treat the returned ``cost`` as a time cost and
     // ignore memory for now since the conversion planner only compares runtime.
-    const std::size_t window = std::min<std::size_t>(boundary, 4);
+    std::size_t window_cap = 4;
+    if (window_override.has_value()) {
+        window_cap = window_override.value();
+    }
+    const std::size_t window = std::min<std::size_t>(boundary, window_cap);
     const std::size_t dense = 1ULL << window;  // dense window size for LW
     const std::size_t chi_tilde = std::min<std::size_t>(rank, st_chi_cap);  // staged cap
     const std::size_t full = 1ULL << std::min<std::size_t>(boundary, 16);

--- a/quasar_convert/conversion_engine.hpp
+++ b/quasar_convert/conversion_engine.hpp
@@ -121,7 +121,8 @@ class ConversionEngine {
     // for dense region depth when considering the LW primitive.
     ConversionResult convert(const SSD& ssd,
                              std::size_t window_1q_gates = 0,
-                             std::size_t window_2q_gates = 0) const;
+                             std::size_t window_2q_gates = 0,
+                             std::optional<std::size_t> window_override = std::nullopt) const;
 
     // Provide a concrete statevector representation for the boundary qubits.
     // A phase-factorable stabilizer state is synthesised from the leading

--- a/quasar_convert/tests/test_engine.py
+++ b/quasar_convert/tests/test_engine.py
@@ -30,6 +30,14 @@ class ConversionPrimitiveTests(unittest.TestCase):
         with_gates = self.eng.convert(ssd, window_1q_gates=3, window_2q_gates=1)
         self.assertGreater(with_gates.cost, base.cost)
 
+    def test_window_override_expands_dense_region(self):
+        ssd = qc.SSD()
+        ssd.boundary_qubits = list(range(8))
+        ssd.top_s = 2
+        default = self.eng.convert(ssd)
+        widened = self.eng.convert(ssd, window=6)
+        self.assertGreater(widened.cost, default.cost)
+
     def test_st_selected(self):
         ssd = qc.SSD()
         ssd.boundary_qubits = list(range(20))

--- a/tests/test_partitioner.py
+++ b/tests/test_partitioner.py
@@ -29,9 +29,14 @@ class SimpleEstimator:
         rank,
         frontier,
         compressed_terms=None,
+        window=None,
         **_kwargs,
     ) -> ConversionEstimate:
-        return ConversionEstimate("FAKE", Cost(time=0.0, memory=0.0, log_depth=float(frontier)))
+        return ConversionEstimate(
+            "FAKE",
+            Cost(time=0.0, memory=0.0, log_depth=float(frontier)),
+            window=window,
+        )
 
     def tableau(self, *_args, **_kwargs):  # type: ignore[no-untyped-def]
         return Cost(time=self.time, memory=self.memory)
@@ -47,6 +52,9 @@ class SimpleEstimator:
 
     def statevector(self, *_args, **_kwargs):  # type: ignore[no-untyped-def]
         return Cost(time=self.time, memory=self.memory)
+
+    def derive_conversion_window(self, num_qubits, *, rank, compressed_terms=None, bond_dimension=None):  # type: ignore[no-untyped-def]
+        return min(num_qubits, 4)
 
 
 class MetricsAssertingSelector:

--- a/tests/test_planner.py
+++ b/tests/test_planner.py
@@ -3,7 +3,8 @@
 from __future__ import annotations
 
 from quasar.circuit import Circuit, Gate
-from quasar.planner import Planner
+from quasar.cost import Backend
+from quasar.planner import PlanStep, Planner
 
 
 def test_repeated_planning_does_not_rebuild_circuit_metadata(monkeypatch) -> None:
@@ -33,3 +34,21 @@ def test_repeated_planning_does_not_rebuild_circuit_metadata(monkeypatch) -> Non
     planner.plan(circuit)
 
     assert call_count == 0
+
+
+def test_plan_records_wide_conversion_window() -> None:
+    gates = [Gate("H", [q]) for q in range(5)]
+    gates.append(Gate("CX", [4, 5]))
+    gates.extend(Gate("X", [q]) for q in range(6))
+    planner = Planner()
+    steps = [
+        PlanStep(start=0, end=6, backend=Backend.TABLEAU),
+        PlanStep(start=6, end=len(gates), backend=Backend.MPS),
+    ]
+
+    layers = planner._conversions_for_steps(gates, steps)
+
+    assert layers
+    layer = layers[0]
+    assert layer.primitive == "LW"
+    assert layer.window == 5


### PR DESCRIPTION
## Summary
- derive an entanglement-aware local window via `CostEstimator.derive_conversion_window` and surface it through `ConversionEstimate`
- thread the computed window through planner/partitioner diagnostics and the conversion engine binding so LW conversions can request larger windows
- update documentation and regression tests to exercise wider windows and confirm they are recorded

## Testing
- pytest tests/test_cost_estimator.py -k conversion_window
- pytest tests/test_planner.py tests/test_partitioner.py tests/test_partitioner_trace.py

------
https://chatgpt.com/codex/tasks/task_e_68dc8cde966883218b3e2a3614f4db56