### PR TITLE
Record conversion window in native engine results

### DIFF
--- a/quasar_convert/__init__.py
+++ b/quasar_convert/__init__.py
@@ -270,6 +270,7 @@ except Exception:  # pragma: no cover - exercised when extension missing
         primitive: Primitive
         cost: float
         fidelity: float
+        window: int | None = None
 
     @dataclass
     class CompressionStats:
@@ -529,7 +530,13 @@ except Exception:  # pragma: no cover - exercised when extension missing
             if fidelity > 1.0:
                 fidelity = 1.0
 
-            return ConversionResult(primitive=primitive, cost=cost, fidelity=float(fidelity))
+            result_window = window_size if primitive == Primitive.LW else None
+            return ConversionResult(
+                primitive=primitive,
+                cost=cost,
+                fidelity=float(fidelity),
+                window=result_window,
+            )
 
         def convert_boundary_to_statevector(self, ssd: SSD) -> List[complex]:
             dim = 1 << len(ssd.boundary_qubits or [])

--- a/quasar_convert/binding.cpp
+++ b/quasar_convert/binding.cpp
@@ -59,7 +59,8 @@ PYBIND11_MODULE(_conversion_engine, m) {
     py::class_<quasar::ConversionResult>(m, "ConversionResult")
         .def_readonly("primitive", &quasar::ConversionResult::primitive)
         .def_readonly("cost", &quasar::ConversionResult::cost)
-        .def_readonly("fidelity", &quasar::ConversionResult::fidelity);
+        .def_readonly("fidelity", &quasar::ConversionResult::fidelity)
+        .def_readonly("window", &quasar::ConversionResult::window);
 
     py::class_<quasar::CompressionStats>(m, "CompressionStats")
         .def_readonly("original_terms", &quasar::CompressionStats::original_terms)

--- a/quasar_convert/conversion_engine.cpp
+++ b/quasar_convert/conversion_engine.cpp
@@ -317,6 +317,7 @@ ConversionResult ConversionEngine::convert(const SSD& ssd,
     Primitive chosen;
     double cost;
     double fidelity;
+    std::optional<std::size_t> result_window;
     if (rank <= 4 && boundary <= 6) {
         chosen = Primitive::B2B;
         cost = cost_b2b;
@@ -327,6 +328,7 @@ ConversionResult ConversionEngine::convert(const SSD& ssd,
         chosen = Primitive::LW;
         cost = cost_lw;
         fidelity = 1.0;  // dense extraction is exact
+        result_window = window;
     } else if (rank <= 16) {
         chosen = Primitive::ST;
         cost = cost_st;
@@ -342,7 +344,12 @@ ConversionResult ConversionEngine::convert(const SSD& ssd,
         fidelity = 1.0;
     }
 
-    return {chosen, cost, fidelity};
+    ConversionResult result;
+    result.primitive = chosen;
+    result.cost = cost;
+    result.fidelity = fidelity;
+    result.window = result_window;
+    return result;
 }
 
 std::vector<std::complex<double>> ConversionEngine::convert_boundary_to_statevector(const SSD& ssd) const {

--- a/quasar_convert/conversion_engine.hpp
+++ b/quasar_convert/conversion_engine.hpp
@@ -70,6 +70,7 @@ struct ConversionResult {
     Primitive primitive;   // primitive that was chosen
     double cost;           // estimated time cost
     double fidelity;       // crude fidelity estimate
+    std::optional<std::size_t> window;  // requested dense window for LW
 };
 
 struct CompressionStats {

--- a/quasar_convert/tests/test_engine.py
+++ b/quasar_convert/tests/test_engine.py
@@ -14,6 +14,7 @@ class ConversionPrimitiveTests(unittest.TestCase):
         res = self.eng.convert(ssd)
         self.assertEqual(res.primitive, qc.Primitive.B2B)
         self.assertGreater(res.cost, 0)
+        self.assertIsNone(res.window)
 
     def test_lw_selected(self):
         ssd = qc.SSD()
@@ -21,6 +22,7 @@ class ConversionPrimitiveTests(unittest.TestCase):
         ssd.top_s = 2
         res = self.eng.convert(ssd)
         self.assertEqual(res.primitive, qc.Primitive.LW)
+        self.assertEqual(res.window, 4)
 
     def test_lw_gate_counts_increase_cost(self):
         ssd = qc.SSD()
@@ -29,6 +31,8 @@ class ConversionPrimitiveTests(unittest.TestCase):
         base = self.eng.convert(ssd)
         with_gates = self.eng.convert(ssd, window_1q_gates=3, window_2q_gates=1)
         self.assertGreater(with_gates.cost, base.cost)
+        self.assertEqual(base.window, 4)
+        self.assertEqual(with_gates.window, 4)
 
     def test_window_override_expands_dense_region(self):
         ssd = qc.SSD()
@@ -37,6 +41,8 @@ class ConversionPrimitiveTests(unittest.TestCase):
         default = self.eng.convert(ssd)
         widened = self.eng.convert(ssd, window=6)
         self.assertGreater(widened.cost, default.cost)
+        self.assertEqual(default.window, 4)
+        self.assertEqual(widened.window, 6)
 
     def test_st_selected(self):
         ssd = qc.SSD()
@@ -44,6 +50,7 @@ class ConversionPrimitiveTests(unittest.TestCase):
         ssd.top_s = 8
         res = self.eng.convert(ssd)
         self.assertEqual(res.primitive, qc.Primitive.ST)
+        self.assertIsNone(res.window)
 
     def test_full_selected(self):
         ssd = qc.SSD()
@@ -51,6 +58,7 @@ class ConversionPrimitiveTests(unittest.TestCase):
         ssd.top_s = 32
         res = self.eng.convert(ssd)
         self.assertEqual(res.primitive, qc.Primitive.Full)
+        self.assertIsNone(res.window)
 
     def test_boundary_truncation_records_stats(self):
         eng = qc.ConversionEngine(truncation_tolerance=0.6)


### PR DESCRIPTION
## Summary
- capture the dense window chosen by `ConversionEngine::convert` and expose it via the bindings and Python stub
- extend conversion engine tests to assert the reported window, matching estimator diagnostics

## Testing
- `pytest quasar_convert/tests/test_engine.py tests/test_cost_estimator.py tests/test_planner.py tests/test_partitioner.py tests/test_partitioner_trace.py`


------
https://chatgpt.com/codex/tasks/task_e_68dce3f5d71483219cd3b99694ce7446