### PR TITLE
Add backlog look-ahead projections and break-even diagnostics

### DIFF
--- a/quasar/config.py
+++ b/quasar/config.py
@@ -180,6 +180,10 @@ class Config:
     graph_cut_cost_weight: float = _float_from_env(
         "QUASAR_GRAPH_CUT_COST_WEIGHT", 0.25
     )
+    backlog_projection_window: int = max(
+        0,
+        _int_from_env("QUASAR_BACKLOG_WINDOW", 8) or 0,
+    )
 
 
 # Global configuration instance used when modules import ``quasar.config``.

--- a/quasar/ssd.py
+++ b/quasar/ssd.py
@@ -50,6 +50,9 @@ class PartitionTraceEntry:
         ``True`` when the backend change was accepted.
     reason:
         Short textual explanation for the decision.
+    break_even_horizon:
+        Number of gates from the backlog origin required to amortise a pending
+        conversion. ``None`` when no break-even is predicted.
     """
 
     gate_index: int
@@ -65,6 +68,7 @@ class PartitionTraceEntry:
     cost: Cost | None = None
     applied: bool = False
     reason: str = ""
+    break_even_horizon: int | None = None
 
 
 @dataclass


### PR DESCRIPTION
## Summary
- add a configuration knob for backlog projection window sizing
- extend the partitioner backlog to track look-ahead metrics and compute break-even horizons for deferred switches, surfacing the value in trace output
- update trace diagnostics/data structures and expand tests to cover the new look-ahead behaviour

## Testing
- pytest tests/test_partitioner_trace.py

------
https://chatgpt.com/codex/tasks/task_e_68dd1da2e3a48321a9d5ade2eab8cf52