### PR TITLE
Add stitched clustered entanglement and classical-control variants

### DIFF
--- a/benchmarks/bench_utils/circuits.py
+++ b/benchmarks/bench_utils/circuits.py
@@ -1361,6 +1361,30 @@ def clustered_w_qft_circuit(
     )
 
 
+def clustered_w_random_xburst_random_circuit(
+    num_qubits: int,
+    *,
+    block_size: int = 5,
+    depth: int | Sequence[int] | None = None,
+    seed: int | None = 1337,
+) -> Circuit:
+    """Prepare W clusters with random, cross-block burst and random stages."""
+
+    stage_depths: int | Sequence[int]
+    if depth is None:
+        stage_depths = (360, 240)
+    else:
+        stage_depths = depth
+    return clustered_entanglement_circuit(
+        num_qubits,
+        block_size=block_size,
+        state="w",
+        entangler="random+xblock_random+random",
+        depth=stage_depths,
+        seed=seed,
+    )
+
+
 def clustered_ghz_random_qft_circuit(
     num_qubits: int,
     *,
@@ -1377,6 +1401,54 @@ def clustered_ghz_random_qft_circuit(
         state="ghz",
         entangler="random+qft",
         depth=random_depth,
+        seed=seed,
+    )
+
+
+def clustered_ghz_random_globalqft_random_circuit(
+    num_qubits: int,
+    *,
+    block_size: int = 5,
+    depth: int | Sequence[int] | None = None,
+    seed: int | None = 1337,
+) -> Circuit:
+    """Prepare GHZ clusters with random, global-QFT and random stages."""
+
+    stage_depths: int | Sequence[int]
+    if depth is None:
+        stage_depths = (400, 200)
+    else:
+        stage_depths = depth
+    return clustered_entanglement_circuit(
+        num_qubits,
+        block_size=block_size,
+        state="ghz",
+        entangler="random+global_qft+random",
+        depth=stage_depths,
+        seed=seed,
+    )
+
+
+def clustered_ghz_diag_globalqft_diag_circuit(
+    num_qubits: int,
+    *,
+    block_size: int = 5,
+    depth: int | Sequence[int] | None = None,
+    seed: int | None = 1337,
+) -> Circuit:
+    """Prepare GHZ clusters with diagonal slabs around a global QFT."""
+
+    stage_depths: int | Sequence[int]
+    if depth is None:
+        stage_depths = (320, 320)
+    else:
+        stage_depths = depth
+    return clustered_entanglement_circuit(
+        num_qubits,
+        block_size=block_size,
+        state="ghz",
+        entangler="diag+global_qft+diag",
+        depth=stage_depths,
         seed=seed,
     )
 
@@ -1690,6 +1762,33 @@ def classical_controlled_circuit(
     setattr(circuit, "classical_qubits", tuple(classical))
     setattr(circuit, "quantum_qubits", tuple(quantum))
     return circuit
+
+
+def classical_controlled_dd_sandwich_circuit(
+    num_qubits: int,
+    *,
+    depth: int = 1800,
+    classical_qubits: int | Iterable[int] = 10,
+    toggle_period: int = 48,
+    fanout: int = 3,
+    seed: int | None = 424242,
+    diag_fixed_phi: float = math.pi / 2,
+    diag_period: int = 96,
+    cz_window_period: int = 64,
+) -> Circuit:
+    """Classical-control variant sandwiching a DD-friendly diagonal slab."""
+
+    return classical_controlled_circuit(
+        num_qubits,
+        depth=depth,
+        classical_qubits=classical_qubits,
+        toggle_period=toggle_period,
+        fanout=fanout,
+        seed=seed,
+        diag_fixed_phi=diag_fixed_phi,
+        diag_period=diag_period,
+        cz_window_period=cz_window_period,
+    )
 
 
 def dynamic_classical_control_circuit(num_qubits: int) -> Circuit:

--- a/benchmarks/bench_utils/showcase_benchmarks.py
+++ b/benchmarks/bench_utils/showcase_benchmarks.py
@@ -250,6 +250,33 @@ SHOWCASE_CIRCUITS: Mapping[str, ShowcaseCircuit] = {
         default_qubits=(24, 32, 36),
         description="GHZ clusters, random evolution and a final QFT.",
     ),
+    "clustered_ghz_random_globalqft_random": ShowcaseCircuit(
+        name="clustered_ghz_random_globalqft_random",
+        display_name="Clustered GHZ random-QFT-random",
+        constructor=circuit_lib.clustered_ghz_random_globalqft_random_circuit,
+        default_qubits=(24, 32, 36),
+        description=(
+            "GHZ clusters with a random prefix, global QFT interlude and random tail."
+        ),
+    ),
+    "clustered_ghz_diag_globalqft_diag": ShowcaseCircuit(
+        name="clustered_ghz_diag_globalqft_diag",
+        display_name="Clustered GHZ diag-QFT-diag",
+        constructor=circuit_lib.clustered_ghz_diag_globalqft_diag_circuit,
+        default_qubits=(24, 32, 36),
+        description=(
+            "GHZ clusters with diagonal CRZ/CCZ slabs bracketing a global QFT."
+        ),
+    ),
+    "clustered_w_random_xburst_random": ShowcaseCircuit(
+        name="clustered_w_random_xburst_random",
+        display_name="Clustered W random-X-burst-random",
+        constructor=circuit_lib.clustered_w_random_xburst_random_circuit,
+        default_qubits=(24, 32, 36),
+        description=(
+            "W-state clusters with a random prelude, cross-block burst and random tail."
+        ),
+    ),
     "layered_clifford_delayed_magic": ShowcaseCircuit(
         name="layered_clifford_delayed_magic",
         display_name="Layered Clifford (delayed magic)",
@@ -292,6 +319,15 @@ SHOWCASE_CIRCUITS: Mapping[str, ShowcaseCircuit] = {
         default_qubits=(16, 22, 24),
         description="Classical controls with wide fan-out.",
     ),
+    "classical_controlled_dd_sandwich": ShowcaseCircuit(
+        name="classical_controlled_dd_sandwich",
+        display_name="Classical control DD sandwich",
+        constructor=circuit_lib.classical_controlled_dd_sandwich_circuit,
+        default_qubits=(16, 22, 24),
+        description=(
+            "Diagonal CRZ/CCZ slab sandwiched between classical-control toggles."
+        ),
+    ),
 }
 
 
@@ -302,6 +338,9 @@ SHOWCASE_GROUPS: Mapping[str, tuple[str, ...]] = {
         "clustered_ghz_qft",
         "clustered_w_qft",
         "clustered_ghz_random_qft",
+        "clustered_ghz_random_globalqft_random",
+        "clustered_ghz_diag_globalqft_diag",
+        "clustered_w_random_xburst_random",
     ),
     "layered": (
         "layered_clifford_delayed_magic",
@@ -312,6 +351,7 @@ SHOWCASE_GROUPS: Mapping[str, tuple[str, ...]] = {
         "classical_controlled",
         "dynamic_classical_control",
         "classical_controlled_fanout",
+        "classical_controlled_dd_sandwich",
     ),
 }
 


### PR DESCRIPTION
## Summary
- add clustered GHZ and W circuit factories that stitch random, diagonal, and global-QFT stages using deterministic depths
- introduce a classical-control DD sandwich helper and expose all new builders through the showcase registry

## Testing
- pytest tests/test_showcase_benchmarks.py

------
https://chatgpt.com/codex/tasks/task_e_68dd1da72e7c832191494a147311213d