### PR TITLE
Add stitched showcase suite and CLI support

### DIFF
--- a/benchmarks/bench_utils/stitched_suite.py
+++ b/benchmarks/bench_utils/stitched_suite.py
@@ -1,0 +1,133 @@
+"""Preconfigured showcase suites combining stitched circuit factories."""
+
+from __future__ import annotations
+
+import math
+from dataclasses import dataclass
+from typing import Callable, Mapping, Tuple
+
+from . import circuits as circuit_lib
+
+
+@dataclass(frozen=True)
+class StitchedCircuitSpec:
+    """Description of a stitched showcase circuit entry."""
+
+    name: str
+    display_name: str
+    description: str
+    factory: Callable[[int], object]
+    widths: Tuple[int, ...]
+
+
+def _stitched_clustered_factory(seed: int) -> Callable[[int], object]:
+    """Return a GHZ-cluster factory with stitched hybrid stages."""
+
+    def factory(width: int) -> object:
+        return circuit_lib.clustered_entanglement_circuit(
+            width,
+            block_size=6,
+            state="ghz",
+            entangler="random+diag+global_qft+random",
+            depth=(480, 180, 240),
+            seed=seed,
+        )
+
+    return factory
+
+
+def _stitched_layered_factory(seed: int) -> Callable[[int], object]:
+    """Return a layered Clifford factory with magic-state islands."""
+
+    def factory(width: int) -> object:
+        return circuit_lib.layered_clifford_magic_islands_circuit(
+            width,
+            depth=1800,
+            fraction_clifford=0.78,
+            islands=18,
+            island_len=5,
+            island_gap=12,
+            seed=seed,
+        )
+
+    return factory
+
+
+def _stitched_classical_factory(seed: int) -> Callable[[int], object]:
+    """Return a classical-control factory with stitched diagonal windows."""
+
+    def factory(width: int) -> object:
+        classical_qubits = max(10, width // 2)
+        if classical_qubits >= width:
+            classical_qubits = max(1, width - 2)
+        return circuit_lib.classical_controlled_circuit(
+            width,
+            depth=1800,
+            classical_qubits=classical_qubits,
+            toggle_period=80,
+            fanout=3,
+            seed=seed,
+            diag_fixed_phi=math.pi / 3,
+            diag_period=96,
+            cz_window_period=72,
+        )
+
+    return factory
+
+
+def build_stitched_big_suite() -> Tuple[StitchedCircuitSpec, ...]:
+    """Return the stitched-big showcase suite specification."""
+
+    return (
+        StitchedCircuitSpec(
+            name="stitched_clustered_hybrid",
+            display_name="Stitched clustered hybrid",
+            description="GHZ clusters with stitched random/diag/QFT/random stages.",
+            factory=_stitched_clustered_factory(seed=1337),
+            widths=(40, 48, 56),
+        ),
+        StitchedCircuitSpec(
+            name="stitched_layered_magic_islands",
+            display_name="Stitched layered magic islands",
+            description="Layered Clifford transition interleaving spaced magic windows.",
+            factory=_stitched_layered_factory(seed=2025),
+            widths=(28, 36, 44),
+        ),
+        StitchedCircuitSpec(
+            name="stitched_classical_diag_windows",
+            display_name="Stitched classical control windows",
+            description="Classical-control ladder stitched with diagonal and CZ windows.",
+            factory=_stitched_classical_factory(seed=424242),
+            widths=(32, 40, 48),
+        ),
+    )
+
+
+SUITES: Mapping[str, Callable[[], Tuple[StitchedCircuitSpec, ...]]] = {
+    "stitched-big": build_stitched_big_suite,
+}
+
+
+def available_suites() -> Tuple[str, ...]:
+    """Return the sorted tuple of available stitched suite names."""
+
+    return tuple(sorted(SUITES))
+
+
+def resolve_suite(name: str) -> Tuple[StitchedCircuitSpec, ...]:
+    """Return the stitched suite specification for ``name``."""
+
+    try:
+        builder = SUITES[name]
+    except KeyError as exc:  # pragma: no cover - defensive guard
+        raise ValueError(f"unknown suite '{name}'") from exc
+    return builder()
+
+
+__all__ = [
+    "StitchedCircuitSpec",
+    "available_suites",
+    "build_stitched_big_suite",
+    "resolve_suite",
+]
+

--- a/benchmarks/run_benchmark.py
+++ b/benchmarks/run_benchmark.py
@@ -464,6 +464,18 @@ def _build_parser() -> argparse.ArgumentParser:
     """Create the CLI argument parser."""
 
     parser = showcase_benchmarks.build_arg_parser()
+    suite_names: tuple[str, ...] = ()
+    if hasattr(showcase_benchmarks, "available_suite_names"):
+        suite_names = showcase_benchmarks.available_suite_names()
+    has_suite_arg = any(getattr(action, "dest", None) == "suite" for action in parser._actions)
+    if suite_names and not has_suite_arg:
+        parser.add_argument(
+            "--suite",
+            choices=sorted(suite_names),
+            metavar="SUITE",
+            default=None,
+            help="Run a preconfigured showcase suite (e.g. stitched-big).",
+        )
     parser.description = (
         "Run QuASAr showcase benchmarks and optionally compute theoretical"
         " resource estimates."
@@ -627,6 +639,11 @@ def parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
         value = getattr(args, opt, None)
         if value is not None and value <= 0:
             parser.error(f"--{opt.replace('_', '-')} must be positive")
+    if getattr(args, "suite", None):
+        if getattr(args, "circuit_names", None):
+            parser.error("--suite cannot be combined with --circuit/--circuits")
+        if getattr(args, "groups", None):
+            parser.error("--suite cannot be combined with --group")
 
     return args
 

--- a/tests/test_run_benchmark_cli.py
+++ b/tests/test_run_benchmark_cli.py
@@ -1,0 +1,21 @@
+import pytest
+
+from benchmarks.run_benchmark import parse_args
+
+
+def test_parse_args_accepts_stitched_suite() -> None:
+    args = parse_args(["--suite", "stitched-big"])
+    assert args.suite == "stitched-big"
+    assert args.circuit_names is None
+
+
+def test_parse_args_suite_conflicts_with_circuit() -> None:
+    with pytest.raises(SystemExit):
+        parse_args(
+            ["--suite", "stitched-big", "--circuit", "clustered_ghz_random"]
+        )
+
+
+def test_parse_args_suite_conflicts_with_group() -> None:
+    with pytest.raises(SystemExit):
+        parse_args(["--suite", "stitched-big", "--group", "clustered"])


### PR DESCRIPTION
## Summary
- add stitched suite factories and register the stitched-big configuration
- wire the --suite option through the showcase CLI and run_benchmark entrypoint
- exercise the stitched suite and parser interactions with targeted tests

## Testing
- pytest tests/test_showcase_benchmarks.py::test_stitched_suite_factories_metadata tests/test_showcase_benchmarks.py::test_run_showcase_benchmarks_suite_invokes_factories tests/test_run_benchmark_cli.py

------
https://chatgpt.com/codex/tasks/task_e_68dd223eea748321b52ac1fefb647a26