### PR TITLE
Enhance calibration provenance and variance reporting

### DIFF
--- a/CALIBRATION.md
+++ b/CALIBRATION.md
@@ -58,7 +58,8 @@ Each invocation writes a new versioned JSON file under the top-level
 ``calibration/`` directory, e.g. ``calibration/coeff_v1.json``.  The
 latest available file is loaded automatically by
 :class:`~quasar.cost.CostEstimator` when instantiated with default
-arguments.
+arguments.  Calibration outputs now bundle provenance metadata alongside
+the coefficients to make measurements auditable and reproducible.
 
 Existing estimators can be updated in place using the calibration
 helpers:
@@ -67,10 +68,60 @@ helpers:
 from quasar import CostEstimator, latest_coefficients, apply_calibration
 
 estimator = CostEstimator()
-coeff = latest_coefficients()
-if coeff:
-    apply_calibration(estimator, coeff)
+record = latest_coefficients()
+if record:
+    apply_calibration(estimator, record)
+    print("Loaded calibration from", record["metadata"].get("date", "unknown"))
 ```
 
 These utilities allow coefficients to be tuned once and reused across
 runs on the same hardware.
+
+## Calibration provenance
+
+Calibration files follow a structured schema::
+
+    {
+      "coeff": {
+        "sv_gate_1q": 0.000123,
+        "mps_mem": 8.0,
+        ...
+      },
+      "variance": {
+        "sv_gate_1q": 1.2e-10,
+        "mps_mem": 0.0,
+        ...
+      },
+      "metadata": {
+        "hardware": {
+          "node": "quasar-dev",
+          "processor": "11th Gen Intel(R) Core(TM) i7-1185G7",
+          "system": "Linux",
+          "python": "3.11.7",
+          ...
+        },
+        "date": "2024-03-17T12:04:55Z",
+        "software_commit": "e3f3c0d6f5d54bcba30d1d756f81a1e7c2c92c3e"
+      }
+    }
+
+- ``coeff`` stores the mean value recorded across repeated benchmark
+  samples for each coefficient.
+- ``variance`` captures the (population) variance of the observed
+  samples.  Coefficients with deterministic microbenchmarks naturally
+  show a variance of ``0.0``.
+- ``metadata`` aggregates identifying information to ensure future runs
+  can be compared on the same hardware and software revision.  The
+  ``hardware`` block reports lightweight identifiers such as the host
+  name, CPU model and Python runtime, ``date`` is written in UTC using
+  ISO-8601 format and ``software_commit`` mirrors the repository commit
+  hash that produced the calibration.
+
+The provenance block is optional when loading historical calibration
+files that pre-date this schema; missing fields simply fall back to
+empty dictionaries.  Downstream utilities that only require the numeric
+coefficients can continue to call :func:`quasar.calibration.apply_calibration`
+with the complete record, which extracts the ``coeff`` mapping
+automatically.  Consumers that wish to inspect the measurement quality
+or trace calibration lineage should consult the ``variance`` and
+``metadata`` entries directly.

--- a/benchmarks/bench_utils/estimate_paper_figures.py
+++ b/benchmarks/bench_utils/estimate_paper_figures.py
@@ -142,13 +142,9 @@ def _load_estimator(calibration: Path | None) -> CostEstimator:
     """Return a cost estimator optionally initialised from calibration data."""
 
     estimator = CostEstimator()
-    coeff: dict[str, float] | None = None
-    if calibration is not None:
-        coeff = load_coefficients(calibration)
-    else:
-        coeff = latest_coefficients()
-    if coeff:
-        apply_calibration(estimator, coeff)
+    record = load_coefficients(calibration) if calibration is not None else latest_coefficients()
+    if record:
+        apply_calibration(estimator, record)
     return estimator
 
 

--- a/benchmarks/bench_utils/theoretical_estimation_utils.py
+++ b/benchmarks/bench_utils/theoretical_estimation_utils.py
@@ -139,13 +139,9 @@ def load_estimator(calibration: Path | None) -> CostEstimator:
     """Return a cost estimator optionally initialised from calibration data."""
 
     estimator = CostEstimator()
-    coeff: dict[str, float] | None
-    if calibration is not None:
-        coeff = load_coefficients(calibration)
-    else:
-        coeff = latest_coefficients()
-    if coeff:
-        apply_calibration(estimator, coeff)
+    record = load_coefficients(calibration) if calibration is not None else latest_coefficients()
+    if record:
+        apply_calibration(estimator, record)
     return estimator
 
 

--- a/docs/partitioning_theory.md
+++ b/docs/partitioning_theory.md
@@ -55,9 +55,9 @@ sync with runtime decisions::
     from quasar.cost import CostEstimator
 
     estimator = CostEstimator()
-    coeff = load_coefficients("calibration/coeff_dev.json")
-    coeff["sv_gate_2q"] *= 0.8   # pretend improved two-qubit fidelity
-    apply_calibration(estimator, coeff)
+    record = load_coefficients("calibration/coeff_dev.json")
+    record["coeff"]["sv_gate_2q"] *= 0.8   # pretend improved two-qubit fidelity
+    apply_calibration(estimator, record)
 
 The modified ``estimator`` exposes the adjusted parameters via
 ``estimator.coeff`` so notebook cells can reuse them when evaluating analytic

--- a/docs/utils/partitioning_analysis.py
+++ b/docs/utils/partitioning_analysis.py
@@ -49,8 +49,8 @@ def load_calibrated_estimator(
     else:
         path = _latest_calibration_path()
     if path is not None and path.exists():
-        coeff = load_coefficients(path)
-        apply_calibration(estimator, coeff)
+        record = load_coefficients(path)
+        apply_calibration(estimator, record)
     else:
         path = None
     return estimator, path

--- a/quasar/calibration.py
+++ b/quasar/calibration.py
@@ -13,18 +13,96 @@ performance on the current machine.
 
 from __future__ import annotations
 
+from datetime import datetime
+from statistics import fmean, pvariance
 from time import perf_counter
-from typing import Dict, TYPE_CHECKING
+from typing import Dict, TYPE_CHECKING, TypedDict, Mapping, Callable
 import argparse
 import json
 from pathlib import Path
 import math
+import os
+import platform
+import subprocess
 
 if TYPE_CHECKING:  # pragma: no cover - type hints only
     from .cost import CostEstimator
 
 
 CALIBRATION_DIR = Path(__file__).resolve().parent.parent / "calibration"
+
+
+class CalibrationMetadata(TypedDict, total=False):
+    """Descriptive information captured alongside calibration results."""
+
+    hardware: Dict[str, str]
+    date: str
+    software_commit: str
+
+
+class CalibrationRecord(TypedDict):
+    """Complete calibration payload including coefficients and metadata."""
+
+    coeff: Dict[str, float]
+    variance: Dict[str, float]
+    metadata: CalibrationMetadata
+
+
+def _current_commit() -> str:
+    """Return the git commit hash of the working tree or ``"unknown"``."""
+
+    repo_root = Path(__file__).resolve().parents[1]
+    try:
+        commit = subprocess.check_output(
+            ["git", "rev-parse", "HEAD"], cwd=repo_root, stderr=subprocess.DEVNULL
+        )
+    except (OSError, subprocess.CalledProcessError):  # pragma: no cover - best effort
+        return "unknown"
+    return commit.decode().strip()
+
+
+def _hardware_identifiers() -> Dict[str, str]:
+    """Gather lightweight identifiers describing the executing machine."""
+
+    identifiers = {
+        "node": platform.node(),
+        "system": platform.system(),
+        "release": platform.release(),
+        "machine": platform.machine(),
+        "processor": platform.processor(),
+        "python": platform.python_version(),
+        "cpu_count": str(os.cpu_count() or ""),
+    }
+    return {key: value for key, value in identifiers.items() if value}
+
+
+def _calibration_metadata() -> CalibrationMetadata:
+    """Construct metadata attached to every calibration run."""
+
+    metadata: CalibrationMetadata = {
+        "hardware": _hardware_identifiers(),
+        "date": datetime.utcnow().replace(microsecond=0).isoformat() + "Z",
+        "software_commit": _current_commit(),
+    }
+    return metadata
+
+
+def _run_with_variance(
+    func: "Callable[[], Dict[str, float]]", repeats: int
+) -> tuple[Dict[str, float], Dict[str, float]]:
+    """Execute ``func`` ``repeats`` times returning mean and variance."""
+
+    samples: list[Dict[str, float]] = []
+    for _ in range(max(1, repeats)):
+        samples.append(func())
+    keys = samples[0].keys()
+    mean_values: Dict[str, float] = {}
+    variance_values: Dict[str, float] = {}
+    for key in keys:
+        measurements = [float(sample[key]) for sample in samples]
+        mean_values[key] = float(fmean(measurements))
+        variance_values[key] = float(pvariance(measurements)) if len(measurements) > 1 else 0.0
+    return mean_values, variance_values
 
 
 def _bench_loop(iters: int) -> float:
@@ -194,38 +272,75 @@ def benchmark_full(q: int = 8) -> Dict[str, float]:
     return {"full_extract": coeff}
 
 
-def run_calibration() -> Dict[str, float]:
-    """Execute all benchmarks and return a coefficient dictionary."""
+def run_calibration(repeats: int = 3) -> CalibrationRecord:
+    """Execute all benchmarks, returning coefficients with metadata."""
+
+    repeats = max(1, int(repeats))
     coeff: Dict[str, float] = {}
-    coeff.update(benchmark_statevector())
-    coeff.update(benchmark_statevector_baseline())
-    coeff.update(benchmark_tableau())
-    coeff.update(benchmark_mps())
-    coeff.update(benchmark_mps_baseline())
-    coeff.update(benchmark_dd())
-    coeff.update(benchmark_dd_baseline())
-    coeff.update(benchmark_b2b())
-    coeff.update(benchmark_lw())
-    coeff.update(benchmark_st())
-    coeff.update(benchmark_full())
-    return coeff
+    variance: Dict[str, float] = {}
+
+    benchmarks: tuple[Callable[[], Dict[str, float]], ...] = (
+        benchmark_statevector,
+        benchmark_statevector_baseline,
+        benchmark_tableau,
+        benchmark_mps,
+        benchmark_mps_baseline,
+        benchmark_dd,
+        benchmark_dd_baseline,
+        benchmark_b2b,
+        benchmark_lw,
+        benchmark_st,
+        benchmark_full,
+    )
+
+    for bench in benchmarks:
+        mean_values, variance_values = _run_with_variance(bench, repeats)
+        coeff.update(mean_values)
+        variance.update(variance_values)
+
+    return {
+        "coeff": coeff,
+        "variance": variance,
+        "metadata": _calibration_metadata(),
+    }
 
 
-def save_coefficients(path: str | Path, coeff: Dict[str, float]) -> None:
+def save_coefficients(path: str | Path, coeff: CalibrationRecord) -> None:
     with Path(path).open("w") as fh:
         json.dump(coeff, fh, indent=2, sort_keys=True)
 
 
-def load_coefficients(path: str | Path) -> Dict[str, float]:
-    """Load calibration coefficients from ``path``."""
+def load_coefficients(path: str | Path) -> CalibrationRecord:
+    """Load calibration data from ``path`` with backward compatibility."""
 
     with Path(path).open() as fh:
         data = json.load(fh)
-    # Support files storing a top-level mapping or nested under ``coeff``
-    return data.get("coeff", data)
+    if isinstance(data, dict) and "coeff" in data:
+        coeff_data = data.get("coeff", {})
+        variance_data = data.get("variance", {})
+        metadata_raw = data.get("metadata", {})
+    else:
+        coeff_data = data if isinstance(data, dict) else {}
+        variance_data = {key: 0.0 for key in coeff_data}
+        metadata_raw = {}
+
+    coeff = {str(key): float(value) for key, value in coeff_data.items()}
+    variance = {str(key): float(value) for key, value in variance_data.items()}
+    metadata: CalibrationMetadata = {}
+    hardware = metadata_raw.get("hardware") if isinstance(metadata_raw, dict) else None
+    if isinstance(hardware, dict):
+        metadata["hardware"] = {str(k): str(v) for k, v in hardware.items()}
+    date = metadata_raw.get("date") if isinstance(metadata_raw, dict) else None
+    if isinstance(date, str) and date:
+        metadata["date"] = date
+    commit = metadata_raw.get("software_commit") if isinstance(metadata_raw, dict) else None
+    if isinstance(commit, str) and commit:
+        metadata["software_commit"] = commit
+
+    return {"coeff": coeff, "variance": variance, "metadata": metadata}
 
 
-def latest_coefficients() -> Dict[str, float] | None:
+def latest_coefficients() -> CalibrationRecord | None:
     """Return coefficients from the newest JSON file in ``CALIBRATION_DIR``.
 
     Files follow the ``coeff_v*.json`` naming convention.  ``None`` is
@@ -240,10 +355,16 @@ def latest_coefficients() -> Dict[str, float] | None:
     return load_coefficients(files[-1])
 
 
-def apply_calibration(estimator: "CostEstimator", coeff: Dict[str, float]) -> None:
+def apply_calibration(
+    estimator: "CostEstimator", coeff: Mapping[str, float] | CalibrationRecord
+) -> None:
     """Update ``estimator`` with calibrated ``coeff`` values."""
 
-    estimator.update_coefficients(coeff)
+    if isinstance(coeff, dict) and "coeff" in coeff and isinstance(coeff["coeff"], dict):
+        updates = coeff["coeff"]
+    else:
+        updates = coeff
+    estimator.update_coefficients(dict(updates))
 
 
 def main(argv: list[str] | None = None) -> None:

--- a/tools/benchmark_coefficients.py
+++ b/tools/benchmark_coefficients.py
@@ -10,8 +10,6 @@ measured coefficients are written to the next versioned JSON file under
 from __future__ import annotations
 
 from pathlib import Path
-from typing import Dict
-
 from quasar.calibration import run_calibration, save_coefficients
 
 
@@ -34,8 +32,8 @@ def main() -> None:
     """Run benchmarks and persist the resulting coefficients."""
 
     path = _next_version_path()
-    coeff: Dict[str, float] = run_calibration()
-    save_coefficients(path, coeff)
+    record = run_calibration()
+    save_coefficients(path, record)
     print(f"Saved calibration data to {path}")
 
 


### PR DESCRIPTION
## Summary
- extend the calibration payload to record hardware identifiers, run date, git commit, and per-coefficient variance
- surface the structured calibration record through latest_coefficients/apply_calibration and update dependent helpers and docs
- document the provenance schema and usage patterns for the enriched calibration files

## Testing
- `pytest` *(killed by environment watchdog after extended execution)*

------
https://chatgpt.com/codex/tasks/task_e_68dd2c1e552c832182c16ac3b79aa037