### PR TITLE
Add conversion telemetry instrumentation

### DIFF
--- a/quasar/config.py
+++ b/quasar/config.py
@@ -163,6 +163,7 @@ class Config:
     backend_selection_log: str | None = os.getenv("QUASAR_BACKEND_SELECTION_LOG")
     verbose_selection: bool = _bool_from_env("QUASAR_VERBOSE_SELECTION", False)
     coeff_ema_decay: float = _float_from_env("QUASAR_COEFF_EMA_DECAY", 0.5)
+    conversion_telemetry_path: str | None = os.getenv("QUASAR_CONVERSION_TELEMETRY")
     st_chi_cap: int | None = _int_from_env("QUASAR_ST_CHI_CAP", 16)
     graph_cut_candidate_limit: int | None = _int_from_env(
         "QUASAR_GRAPH_CUT_CANDIDATES", 4

--- a/quasar/simulation_engine.py
+++ b/quasar/simulation_engine.py
@@ -25,7 +25,7 @@ from .circuit import Circuit
 from .analyzer import CircuitAnalyzer, AnalysisResult
 from .planner import Planner, PlanResult
 from .method_selector import NoFeasibleBackendError
-from .scheduler import Scheduler
+from .scheduler import Scheduler, ConversionProfile
 from .ssd import SSD, SSDPartition
 from .cost import CostEstimator, Backend
 from . import config
@@ -99,6 +99,9 @@ class SimulationResult:
         Number of times execution changed between backends.
     conversion_durations:
         Wall-clock durations for each state conversion.
+    conversion_profiles:
+        Detailed telemetry for each conversion primitive executed during the
+        run.  Entries mirror :class:`quasar.scheduler.ConversionProfile`.
     plan_cache_hits:
         Number of times a plan was reused from the planner cache.
     fidelity:
@@ -113,6 +116,7 @@ class SimulationResult:
     execution_time: float = 0.0
     backend_switches: int = 0
     conversion_durations: List[float] = field(default_factory=list)
+    conversion_profiles: List[ConversionProfile] = field(default_factory=list)
     plan_cache_hits: int = 0
     fidelity: float | None = None
 
@@ -341,6 +345,7 @@ class SimulationEngine:
             execution_time=execution_time,
             backend_switches=metrics.backend_switches,
             conversion_durations=metrics.conversion_durations,
+            conversion_profiles=metrics.conversion_profiles,
             plan_cache_hits=total_cache_hits,
             fidelity=metrics.fidelity,
         )


### PR DESCRIPTION
## Summary
- add detailed conversion telemetry collection to the scheduler and conversion wrappers
- expose conversion profiles via simulation results and optional telemetry log path
- update configuration to support exporting collected telemetry

## Testing
- pytest tests/test_scheduler.py -q

------
https://chatgpt.com/codex/tasks/task_e_68dd2b3662308321a4c0e4d223dd83d6