### PR TITLE
Add fragment diagnostics exports

### DIFF
--- a/docs/backend_selection.md
+++ b/docs/backend_selection.md
@@ -199,6 +199,22 @@ cheaper than continuing with the current backend.  Additional reasons such as
 ``statevector_lock`` and ``single_qubit_preamble`` capture fast-path rejections
 for dense fragments and single-qubit prefixes respectively.【F:quasar/partitioner.py†L283-L399】【F:quasar/partitioner.py†L495-L508】【F:quasar/partitioner.py†L536-L547】
 
+### Fragment metrics
+
+Explaining backend choices also benefits from structural statistics about each
+planned fragment.  Enabling ``explain=True`` now attaches a
+``fragment_metrics`` list to :class:`~quasar.planner.PlanDiagnostics`.  Each
+entry tracks the span, backend, sparsity, rotation diversity, entanglement
+estimate and locality measures for the selected fragment, along with the
+heuristic values that influenced the decision.【F:quasar/planner.py†L215-L235】【F:quasar/planner.py†L465-L508】 The helper
+``PlanDiagnostics.fragments_as_dicts()`` converts the records into plain
+dictionaries, while :func:`~quasar.metrics.export_fragment_metrics_json` and
+:func:`~quasar.metrics.export_fragment_metrics_csv` persist the metrics for
+notebook analysis or post-processing pipelines.【F:quasar/planner.py†L238-L242】【F:quasar/metrics.py†L96-L172】 Each
+fragment metric entry mirrors the machine-readable diagnostics emitted by the
+method selector for individual selection calls, making the planner and the
+offline theoretical notebooks consume the same observables.【F:quasar/method_selector.py†L190-L262】【F:quasar/method_selector.py†L466-L520】
+
 Rank and frontier diagnostics in these traces come from the conversion helper
 inside the partitioner.  Boundaries fall back to ``2**|boundary|`` when no
 external rank model is supplied, and the estimator's chosen primitive plus its

--- a/quasar/__init__.py
+++ b/quasar/__init__.py
@@ -7,6 +7,11 @@ from .planner import Planner, PlanResult, PlanStep, DPEntry
 from .method_selector import MethodSelector, NoFeasibleBackendError
 from .scheduler import Scheduler
 from .simulation_engine import SimulationEngine, SimulationResult
+from .metrics import (
+    FragmentMetricRecord,
+    export_fragment_metrics_json,
+    export_fragment_metrics_csv,
+)
 from .ssd import SSD, SSDPartition, ConversionLayer, PartitionTraceEntry
 from .calibration import (
     run_calibration,
@@ -63,4 +68,7 @@ __all__ = [
     "DecisionDiagramBackend",
     "CircuitAnalyzer",
     "AnalysisResult",
+    "FragmentMetricRecord",
+    "export_fragment_metrics_json",
+    "export_fragment_metrics_csv",
 ]

--- a/tests/test_method_selector_diagnostics.py
+++ b/tests/test_method_selector_diagnostics.py
@@ -4,9 +4,15 @@ from __future__ import annotations
 
 import pytest
 
+import json
+
 from quasar.circuit import Circuit, Gate
 from quasar.cost import CostEstimator, Backend
 from quasar.method_selector import MethodSelector
+from quasar.metrics import (
+    export_fragment_metrics_csv,
+    export_fragment_metrics_json,
+)
 from quasar.planner import Planner
 
 
@@ -69,6 +75,14 @@ def test_method_selector_populates_diagnostics() -> None:
     assert metrics["mps_long_range_extent"] == pytest.approx(0.5)
     assert metrics["mps_max_interaction_distance"] == 2
     assert metrics["entanglement_entropy"] >= 0.0
+    fragments = metrics["fragments"]
+    assert fragments
+    fragment_entry = fragments[0]
+    assert fragment_entry["scope"] == "fragment"
+    assert fragment_entry["local"] is False
+    assert 0.0 <= fragment_entry["sparsity"] <= 1.0
+    assert fragment_entry["long_range_fraction"] == pytest.approx(1.0)
+    assert "rotation_density" in fragment_entry
 
     # The selected backend is marked accordingly in the diagnostics.
     assert backends[backend]["selected"] is True
@@ -97,3 +111,36 @@ def test_planner_explain_surfaces_selection_diagnostics() -> None:
     selector_diag = plan.diagnostics.backend_selection
     assert "single" in selector_diag
     assert selector_diag["single"]["selected_backend"] == plan.final_backend
+    fragment_records = plan.diagnostics.fragment_metrics
+    assert fragment_records
+    record_dict = fragment_records[0].to_mapping()
+    assert record_dict["backend"] == plan.final_backend.name
+    assert record_dict["scope"] == "plan"
+    assert "heuristic_sparsity" in record_dict
+    dicts = plan.diagnostics.fragments_as_dicts()
+    assert dicts[0]["scope"] == "plan"
+
+
+def test_fragment_metric_exporters(tmp_path) -> None:
+    estimator = CostEstimator()
+    planner = Planner(
+        estimator=estimator,
+        quick_max_qubits=32,
+        quick_max_gates=128,
+        quick_max_depth=128,
+    )
+    circuit = build_test_circuit()
+    plan = planner.plan(circuit, explain=True)
+    assert plan.diagnostics is not None
+    records = plan.diagnostics.fragment_metrics
+    json_path = tmp_path / "fragments.json"
+    csv_path = tmp_path / "fragments.csv"
+    export_fragment_metrics_json(records, json_path)
+    export_fragment_metrics_csv(records, csv_path)
+    data = json.loads(json_path.read_text())
+    assert data
+    assert data[0]["scope"] == "plan"
+    csv_lines = csv_path.read_text().strip().splitlines()
+    assert csv_lines
+    header = csv_lines[0].split(",")
+    assert "backend" in header


### PR DESCRIPTION
## Summary
- capture detailed fragment metrics in method selector diagnostics and propagate them through plan diagnostics
- expose fragment metric records with JSON/CSV exporters and re-export the helpers from the public API
- update the backend selection documentation and tests to cover the new diagnostics and exporters

## Testing
- pytest tests/test_method_selector_grover.py


------
https://chatgpt.com/codex/tasks/task_e_68dd2c3532388321adb03e567acefa0e