### PR TITLE
Add stitched-disjoint suite with bounded stitched circuit stages

### DIFF
--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -79,6 +79,13 @@ For example, the stitched-big suite covers nine circuits split across
 ``stitched_classical_diag_windows`` (32/40/48 qubits).  The CLI advertises the
 available suite names in ``--help`` and accepts the usual overrides:
 
+``stitched-disjoint`` complements the existing options with banded, region-
+aware stitched circuits.  Each entry keeps the stitched regions disjoint so the
+planner can distribute workloads across workers without spiking the statevector
+width.  The preconfigured JSON file
+``configs/benchmark_config.stitched-disjoint.json`` mirrors the CLI suite and
+lets automation trigger the same runs via ``--config``.
+
 ```bash
 python benchmarks/run_benchmark.py --suite stitched-big --workers 16 \
   --reuse-existing

--- a/benchmarks/bench_utils/stitched_suite.py
+++ b/benchmarks/bench_utils/stitched_suite.py
@@ -166,9 +166,44 @@ def build_stitched_2x_suite() -> Tuple[StitchedCircuitSpec, ...]:
     )
 
 
+def build_stitched_disjoint_suite() -> Tuple[StitchedCircuitSpec, ...]:
+    """Return the stitched-disjoint showcase suite specification."""
+
+    return (
+        StitchedCircuitSpec(
+            name="stitched_rand_bandedqft_rand",
+            display_name="Random – Banded QFT – Random",
+            description="Random layers stitched with bounded QFT regions per cluster.",
+            factory=lambda width: circuit_lib.clustered_ghz_random_bandedqft_random_circuit(
+                width, block_size=8, region_blocks=3
+            ),
+            widths=(128, 160, 192),
+        ),
+        StitchedCircuitSpec(
+            name="stitched_diag_bandedqft_diag",
+            display_name="Diag – Banded QFT – Diag",
+            description="Diagonal slabs surrounding bounded banded QFT windows.",
+            factory=lambda width: circuit_lib.clustered_ghz_diag_bandedqft_diag_circuit(
+                width, block_size=8, region_blocks=3
+            ),
+            widths=(128, 160),
+        ),
+        StitchedCircuitSpec(
+            name="stitched_rand_bridge_rand",
+            display_name="Random – Bridge – Random",
+            description="W clusters with neighbour bridges confined to local regions.",
+            factory=lambda width: circuit_lib.clustered_w_random_neighborbridge_random_circuit(
+                width, block_size=8, region_blocks=3, bridge_layers=2
+            ),
+            widths=(192, 256),
+        ),
+    )
+
+
 SUITES: Mapping[str, Callable[[], Tuple[StitchedCircuitSpec, ...]]] = {
     "stitched-big": build_stitched_big_suite,
     "stitched-2x": build_stitched_2x_suite,
+    "stitched-disjoint": build_stitched_disjoint_suite,
 }
 
 

--- a/configs/benchmark_config.stitched-disjoint.json
+++ b/configs/benchmark_config.stitched-disjoint.json
@@ -1,0 +1,32 @@
+{
+  "suite": [
+    {
+      "name": "rand-bandedqft-rand",
+      "builder": "clustered_ghz_random_bandedqft_random_circuit",
+      "params": [
+        {"num_qubits": 128, "block_size": 8, "region_blocks": 3},
+        {"num_qubits": 160, "block_size": 8, "region_blocks": 3},
+        {"num_qubits": 192, "block_size": 8, "region_blocks": 3}
+      ],
+      "baselines": ["mps", "sv"]
+    },
+    {
+      "name": "diag-bandedqft-diag",
+      "builder": "clustered_ghz_diag_bandedqft_diag_circuit",
+      "params": [
+        {"num_qubits": 128, "block_size": 8, "region_blocks": 3},
+        {"num_qubits": 160, "block_size": 8, "region_blocks": 3}
+      ],
+      "baselines": ["sv", "dd"]
+    },
+    {
+      "name": "rand-bridge-rand",
+      "builder": "clustered_w_random_neighborbridge_random_circuit",
+      "params": [
+        {"num_qubits": 192, "block_size": 8, "region_blocks": 3, "bridge_layers": 2},
+        {"num_qubits": 256, "block_size": 8, "region_blocks": 3, "bridge_layers": 2}
+      ],
+      "baselines": ["mps", "sv"]
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- add optional stage parameters and bounded stage implementations to clustered entanglement circuits, including banded QFT, diagonal windows, and neighbour bridges
- expose convenience builders and a stitched-disjoint showcase suite together with automation config
- update benchmark documentation to describe the new suite entry point

## Testing
- pytest tests/test_showcase_benchmarks.py

------
https://chatgpt.com/codex/tasks/task_e_68ddd618b46083218e8e19e9e7e567d0