### PR TITLE
Add work-register QFT circuit variant and stitched suite

### DIFF
--- a/benchmarks/bench_utils/showcase_benchmarks.py
+++ b/benchmarks/bench_utils/showcase_benchmarks.py
@@ -261,6 +261,15 @@ SHOWCASE_CIRCUITS: Mapping[str, ShowcaseCircuit] = {
             "GHZ clusters with a random prefix, global QFT interlude and random tail."
         ),
     ),
+    "clustered_ghz_random_workqft_random": ShowcaseCircuit(
+        name="clustered_ghz_random_workqft_random",
+        display_name="Clustered GHZ random-workQFT-random",
+        constructor=circuit_lib.clustered_ghz_random_workqft_random_circuit,
+        default_qubits=(128, 160, 192),
+        description=(
+            "Random layers stitched with a bounded work-register QFT window."
+        ),
+    ),
     "clustered_ghz_diag_globalqft_diag": ShowcaseCircuit(
         name="clustered_ghz_diag_globalqft_diag",
         display_name="Clustered GHZ diag-QFT-diag",

--- a/benchmarks/bench_utils/stitched_suite.py
+++ b/benchmarks/bench_utils/stitched_suite.py
@@ -200,10 +200,27 @@ def build_stitched_disjoint_suite() -> Tuple[StitchedCircuitSpec, ...]:
     )
 
 
+def build_stitched_workqft_suite() -> Tuple[StitchedCircuitSpec, ...]:
+    """Return the stitched-workQFT showcase suite specification."""
+
+    return (
+        StitchedCircuitSpec(
+            name="stitched_rand_workqft_rand",
+            display_name="Random – Work-QFT – Random",
+            description="Random layers stitched with a bounded work-register QFT window.",
+            factory=lambda width: circuit_lib.clustered_ghz_random_workqft_random_circuit(
+                width, block_size=8, work_qubits=24
+            ),
+            widths=(128, 160, 192),
+        ),
+    )
+
+
 SUITES: Mapping[str, Callable[[], Tuple[StitchedCircuitSpec, ...]]] = {
     "stitched-big": build_stitched_big_suite,
     "stitched-2x": build_stitched_2x_suite,
     "stitched-disjoint": build_stitched_disjoint_suite,
+    "stitched-workqft": build_stitched_workqft_suite,
 }
 
 

--- a/configs/benchmark_config.stitched-workqft.json
+++ b/configs/benchmark_config.stitched-workqft.json
@@ -1,0 +1,14 @@
+{
+  "suite": [
+    {
+      "name": "rand-workqft-rand",
+      "builder": "clustered_ghz_random_workqft_random_circuit",
+      "params": [
+        { "num_qubits": 128, "block_size": 8, "work_qubits": 24 },
+        { "num_qubits": 160, "block_size": 8, "work_qubits": 24 },
+        { "num_qubits": 192, "block_size": 8, "work_qubits": 24 }
+      ],
+      "baselines": ["mps", "sv"]
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- allow the work_qft stage to target a configurable window and add a wrapper that stitches random-workQFT-random layers
- expose the new circuit through the showcase catalog and a dedicated stitched-workqft suite
- provide a ready-to-run benchmark configuration for the stitched work-register QFT suite

## Testing
- pytest tests/test_showcase_benchmarks.py

------
https://chatgpt.com/codex/tasks/task_e_68dddbe064188321b16f88e70927569d