### PR TITLE
Fix theoretical statevector baseline modeling fallback

### DIFF
--- a/benchmarks/bench_utils/showcase_benchmarks.py
+++ b/benchmarks/bench_utils/showcase_benchmarks.py
@@ -540,8 +540,8 @@ def _run_backend_suite_for_width(
     classical_simplification: bool,
     baseline_backends: Iterable[Backend],
     quasar_quick: bool,
-    include_theoretical_sv: bool,
-    theoretical_sv_options: Mapping[str, Any] | None,
+    include_theoretical_sv: bool = False,
+    theoretical_sv_options: Mapping[str, Any] | None = None,
     step_callback: Callable[[str], None] | None = None,
 ) -> tuple[list[dict[str, object]], list[str]]:
     baseline_backends = tuple(baseline_backends)
@@ -867,8 +867,8 @@ def _run_backend_suite_for_width_worker(
     classical_simplification: bool,
     baseline_backends: Iterable[Backend],
     quasar_quick: bool,
-    include_theoretical_sv: bool,
-    theoretical_sv_options: Mapping[str, Any] | None,
+    include_theoretical_sv: bool = False,
+    theoretical_sv_options: Mapping[str, Any] | None = None,
     step_callback: Callable[[str], None] | None = None,
 ) -> tuple[list[dict[str, object]], list[str]]:
     engine = thread_engine()

--- a/benchmarks/bench_utils/showcase_benchmarks.py
+++ b/benchmarks/bench_utils/showcase_benchmarks.py
@@ -911,6 +911,13 @@ def _run_backend_suite(
     if not width_list:
         return pd.DataFrame()
 
+    sv_options = dict(theoretical_sv_options or {})
+    mem_budget_bytes = sv_options.get("mem_budget_bytes")
+    dtype_bytes_opt = sv_options.get("dtype_bytes")
+    dtype_bytes = int(dtype_bytes_opt) if dtype_bytes_opt is not None else 16
+    scratch_factor_opt = sv_options.get("scratch_factor")
+    scratch_factor = float(scratch_factor_opt) if scratch_factor_opt is not None else 1.5
+
     baselines: tuple[Backend, ...]
     if not include_baselines:
         baselines = ()
@@ -964,7 +971,7 @@ def _run_backend_suite(
                             "description": spec.description,
                             "include_theoretical_sv": include_theoretical_sv,
                             "sv_mem_budget_bytes": mem_budget_bytes,
-                            "sv_scratch_factor": theoretical_sv_options["scratch_factor"],
+                            "sv_scratch_factor": scratch_factor,
                             "sv_dtype_bytes": dtype_bytes,
                         },
                     )
@@ -979,7 +986,7 @@ def _run_backend_suite(
                     baseline_backends=baselines,
                     quasar_quick=quasar_quick,
                     include_theoretical_sv=include_theoretical_sv,
-                    theoretical_sv_options=theoretical_sv_options,
+                    theoretical_sv_options=sv_options,
                     step_callback=progress.announce,
                 )
                 ordered[index] = recs
@@ -1012,7 +1019,7 @@ def _run_backend_suite(
                                 "description": spec.description,
                                 "include_theoretical_sv": include_theoretical_sv,
                                 "sv_mem_budget_bytes": mem_budget_bytes,
-                                "sv_scratch_factor": theoretical_sv_options["scratch_factor"],
+                                "sv_scratch_factor": scratch_factor,
                                 "sv_dtype_bytes": dtype_bytes,
                             },
                         )
@@ -1028,7 +1035,7 @@ def _run_backend_suite(
                         baseline_backends=baselines,
                         quasar_quick=quasar_quick,
                         include_theoretical_sv=include_theoretical_sv,
-                        theoretical_sv_options=theoretical_sv_options,
+                        theoretical_sv_options=sv_options,
                     )
                     futures[future] = index
 

--- a/benchmarks/bench_utils/theoretical_baselines.py
+++ b/benchmarks/bench_utils/theoretical_baselines.py
@@ -1,0 +1,127 @@
+"""Utilities for modelling dense statevector baselines.
+
+This module provides lightweight helpers that mirror the behaviour requested by
+QuASAr's stitched benchmark suite.  The helpers intentionally avoid any direct
+backend dependencies so they can be used for both offline estimation and at
+runtime when a dense simulator cannot be executed due to memory constraints.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Dict, Iterable
+
+# ---- Gate counting ---------------------------------------------------------
+ONE_Q = {
+    "x",
+    "y",
+    "z",
+    "h",
+    "s",
+    "sdg",
+    "t",
+    "tdg",
+    "rx",
+    "ry",
+    "rz",
+    "u",
+    "u1",
+    "u2",
+    "u3",
+    "p",
+}
+TWO_Q = {"cx", "cz", "swap", "crz", "cry", "crx", "cp", "cswap"}
+DIAG_2Q = {"cz", "crz", "cp"}
+THREE_Q = {"ccx", "ccz"}
+
+
+def _norm(name: str) -> str:
+    """Normalise a gate name for bucket classification."""
+
+    return name.lower().replace("-", "").replace("_", "")
+
+
+def count_gates(gates: Iterable[Any]) -> Dict[str, int]:
+    """Count gates grouped into coarse buckets for SV cost modelling."""
+
+    counts = {"1q": 0, "2q": 0, "diag2q": 0, "3q": 0, "other": 0, "total": 0}
+    for gate in gates:
+        name = _norm(getattr(gate, "name", getattr(gate, "gate", "other")))
+        targets = getattr(gate, "qubits", getattr(gate, "targets", None))
+        nq = len(targets or ())
+        counts["total"] += 1
+        if name in ONE_Q or nq == 1:
+            counts["1q"] += 1
+        elif name in THREE_Q or nq == 3:
+            counts["3q"] += 1
+        elif name in TWO_Q or nq == 2:
+            counts["2q"] += 1
+            if name in DIAG_2Q:
+                counts["diag2q"] += 1
+        else:
+            counts["other"] += 1
+    return counts
+
+
+# ---- Statevector memory model ----------------------------------------------
+def predict_sv_peak_bytes(
+    n: int,
+    *,
+    dtype_bytes: int = 16,
+    scratch_factor: float = 1.5,
+) -> int:
+    """Return the peak bytes required for an ``n`` qubit dense statevector."""
+
+    amplitudes = 1 << n
+    peak = amplitudes * dtype_bytes * scratch_factor
+    return int(peak)
+
+
+# ---- Statevector runtime model ---------------------------------------------
+def predict_sv_runtime_au(
+    n: int,
+    counts: Dict[str, int],
+    *,
+    c_1q: float = 1.0,
+    c_2q: float = 2.5,
+    c_diag2q: float = 0.8,
+    c_3q: float = 5.0,
+    c_other: float = 2.0,
+) -> float:
+    """Return the theoretical runtime in arbitrary units for dense SV."""
+
+    scale = float(1 << n)
+    non_diag_2q = counts.get("2q", 0) - counts.get("diag2q", 0)
+    value = (
+        c_1q * counts.get("1q", 0)
+        + c_2q * max(non_diag_2q, 0)
+        + c_diag2q * counts.get("diag2q", 0)
+        + c_3q * counts.get("3q", 0)
+        + c_other * counts.get("other", 0)
+    )
+    return scale * value
+
+
+# ---- Budget/OOM helpers ----------------------------------------------------
+def will_sv_oom(
+    n: int,
+    mem_budget_bytes: int | None,
+    *,
+    dtype_bytes: int = 16,
+    scratch_factor: float = 1.5,
+) -> bool:
+    """Return ``True`` when an ``n`` qubit SV would exceed ``mem_budget_bytes``."""
+
+    if mem_budget_bytes is None or mem_budget_bytes <= 0:
+        return False
+    required = predict_sv_peak_bytes(
+        n, dtype_bytes=dtype_bytes, scratch_factor=scratch_factor
+    )
+    return required > mem_budget_bytes
+
+
+__all__ = [
+    "count_gates",
+    "predict_sv_peak_bytes",
+    "predict_sv_runtime_au",
+    "will_sv_oom",
+]

--- a/benchmarks/run_benchmark.py
+++ b/benchmarks/run_benchmark.py
@@ -20,7 +20,7 @@ import argparse
 import logging
 import sys
 from pathlib import Path
-from typing import Iterable, Sequence
+from typing import Iterable, Mapping, Sequence
 
 import pandas as pd
 
@@ -175,6 +175,8 @@ def run_showcase_suite(
     database: BenchmarkDatabase | None = None,
     run: BenchmarkRun | None = None,
     database_path: Path | None = None,
+    include_theoretical_sv: bool = False,
+    theoretical_sv_options: Mapping[str, object] | None = None,
 ) -> pd.DataFrame:
     """Execute a subset of the showcase suite programmatically.
 
@@ -210,6 +212,8 @@ def run_showcase_suite(
             quasar_quick=quick,
             database=database,
             run=run,
+            include_theoretical_sv=include_theoretical_sv,
+            theoretical_sv_options=theoretical_sv_options,
         )
     finally:
         if managed_db is not None:
@@ -639,6 +643,12 @@ def parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
         value = getattr(args, opt, None)
         if value is not None and value <= 0:
             parser.error(f"--{opt.replace('_', '-')} must be positive")
+    if getattr(args, "sv_mem_budget_gib", None) is not None and args.sv_mem_budget_gib < 0:
+        parser.error("--sv-mem-budget-gib must be non-negative")
+    if getattr(args, "sv_scratch_factor", None) is not None and args.sv_scratch_factor <= 0:
+        parser.error("--sv-scratch-factor must be positive")
+    if getattr(args, "sv_dtype_bytes", None) is not None and args.sv_dtype_bytes <= 0:
+        parser.error("--sv-dtype-bytes must be positive")
     if getattr(args, "suite", None):
         if getattr(args, "circuit_names", None):
             parser.error("--suite cannot be combined with --circuit/--circuits")


### PR DESCRIPTION
## Summary
- add a theoretical statevector cost model helper module under bench_utils and integrate it with the showcase benchmark runner, CLI, and database metadata
- append predicted SV runtime/memory records when dense simulations are skipped or requested and render them as hatched grey bars in stitched plots
- ensure the showcase benchmark script paths include the repository root so the theoretical SV helper loads without triggering the memory_utils fallback

## Testing
- pytest benchmarks/run_benchmark_test.py

------
https://chatgpt.com/codex/tasks/task_e_68de196faf508321a72d1b6173ee7d5b