### PR TITLE
Fix Stim target detection in cutoff suite

### DIFF
--- a/test_suite/cutoff_suite.py
+++ b/test_suite/cutoff_suite.py
@@ -136,7 +136,7 @@ def build_qiskit_from_stim(circ: "stim.Circuit") -> "QuantumCircuit":
     if QuantumCircuit is None:
         raise RuntimeError("qiskit-aer not installed. pip install qiskit qiskit-aer")
     max_qubit = max(
-        (t.qubit_value for inst in circ for t in inst.targets_copy() if t.is_qubit_target()),
+        (t.qubit_value for inst in circ for t in inst.targets_copy() if t.is_qubit_target),
         default=-1,
     )
     qc = QuantumCircuit(max_qubit + 1)


### PR DESCRIPTION
## Summary
- fix the Stim circuit conversion helper in the cutoff suite to use the `is_qubit_target` attribute correctly
- ensure Stim-generated circuits are converted to Qiskit without raising a `TypeError`

## Testing
- PYTHONPATH=. python test_suite/cutoff_suite.py --out /tmp/out --ns 4 --depth-min 2 --depth-max 4 --target-speedup 2 --sv-timeout-sec 1

------
https://chatgpt.com/codex/tasks/task_e_68de2663b328832191f99161ee4eebaf