### PR TITLE
Add stitched benchmark exports and CLI flags

### DIFF
--- a/benchmarks/run_benchmark.py
+++ b/benchmarks/run_benchmark.py
@@ -654,6 +654,8 @@ def parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
             parser.error("--suite cannot be combined with --circuit/--circuits")
         if getattr(args, "groups", None):
             parser.error("--suite cannot be combined with --group")
+    if getattr(args, "repetitions", None) is not None and args.repetitions <= 0:
+        parser.error("--repetitions must be a positive integer")
 
     return args
 


### PR DESCRIPTION
## Summary
- add optional JSON/CSV export helpers for stitched benchmark runs when an output directory is supplied
- expose --out, --repeats, and --choose-best-baseline flags on the showcase CLI and validate the repetitions count

## Testing
- python benchmarks/run_benchmark.py --circuit clustered_ghz_random --qubits clustered_ghz_random=2 --out out/test --repetitions 1 --workers 1 --choose-best-baseline --enable-classical-simplification

------
https://chatgpt.com/codex/tasks/task_e_68de43b6657c8321bd44ffd16222c28a