### PR TITLE
Add minimal SSD visualisation example

### DIFF
--- a/docs/data/ssd_visualisation_minimal.svg
+++ b/docs/data/ssd_visualisation_minimal.svg
@@ -1,0 +1,438 @@
+<?xml version="1.0" encoding="utf-8" standalone="no"?>
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN"
+  "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg xmlns:xlink="http://www.w3.org/1999/xlink" width="424.8pt" height="279.838125pt" viewBox="0 0 424.8 279.838125" xmlns="http://www.w3.org/2000/svg" version="1.1">
+ <metadata>
+  <rdf:RDF xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:cc="http://creativecommons.org/ns#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+   <cc:Work>
+    <dc:type rdf:resource="http://purl.org/dc/dcmitype/StillImage"/>
+    <dc:date>2025-10-02T12:10:29.977360</dc:date>
+    <dc:format>image/svg+xml</dc:format>
+    <dc:creator>
+     <cc:Agent>
+      <dc:title>Matplotlib v3.10.6, https://matplotlib.org/</dc:title>
+     </cc:Agent>
+    </dc:creator>
+   </cc:Work>
+  </rdf:RDF>
+ </metadata>
+ <defs>
+  <style type="text/css">*{stroke-linejoin: round; stroke-linecap: butt}</style>
+ </defs>
+ <g id="figure_1">
+  <g id="patch_1">
+   <path d="M 0 279.838125 
+L 424.8 279.838125 
+L 424.8 0 
+L 0 0 
+z
+" style="fill: #ffffff"/>
+  </g>
+  <g id="axes_1">
+   <g id="patch_2">
+    <path d="M 51.474218 147.478125 
+Q 212.399631 147.478125 371.647993 147.478125 
+" clip-path="url(#p18c191fc43)" style="fill: none; stroke: #9e9e9e; stroke-width: 1.5; stroke-linecap: round"/>
+    <path d="M 367.647993 145.478125 
+L 371.647993 147.478125 
+L 367.647993 149.478125 
+z
+" clip-path="url(#p18c191fc43)" style="fill: #9e9e9e; stroke: #9e9e9e; stroke-width: 1.5; stroke-linecap: round"/>
+   </g>
+   <g id="PathCollection_1">
+    <defs>
+     <path id="C0_0_f1da49c695" d="M 0 13.228757 
+C 3.508307 13.228757 6.873396 11.834891 9.354143 9.354143 
+C 11.834891 6.873396 13.228757 3.508307 13.228757 -0 
+C 13.228757 -3.508307 11.834891 -6.873396 9.354143 -9.354143 
+C 6.873396 -11.834891 3.508307 -13.228757 0 -13.228757 
+C -3.508307 -13.228757 -6.873396 -11.834891 -9.354143 -9.354143 
+C -11.834891 -6.873396 -13.228757 -3.508307 -13.228757 0 
+C -13.228757 3.508307 -11.834891 6.873396 -9.354143 9.354143 
+C -6.873396 11.834891 -3.508307 13.228757 0 13.228757 
+z
+"/>
+    </defs>
+    <g clip-path="url(#p18c191fc43)">
+     <use xlink:href="#C0_0_f1da49c695" x="42.813223" y="147.478125" style="fill: #4c78a8; stroke: #4c78a8"/>
+    </g>
+    <g clip-path="url(#p18c191fc43)">
+     <use xlink:href="#C0_0_f1da49c695" x="212.4" y="147.478125" style="fill: #4c78a8; stroke: #4c78a8"/>
+    </g>
+    <g clip-path="url(#p18c191fc43)">
+     <use xlink:href="#C0_0_f1da49c695" x="381.986777" y="147.478125" style="fill: #4c78a8; stroke: #4c78a8"/>
+    </g>
+   </g>
+   <g id="text_1">
+    <g clip-path="url(#p18c191fc43)">
+     <!-- P0 -->
+     <g transform="translate(36.617129 150.2375) scale(0.1 -0.1)">
+      <defs>
+       <path id="DejaVuSans-50" d="M 1259 4147 
+L 1259 2394 
+L 2053 2394 
+Q 2494 2394 2734 2622 
+Q 2975 2850 2975 3272 
+Q 2975 3691 2734 3919 
+Q 2494 4147 2053 4147 
+L 1259 4147 
+z
+M 628 4666 
+L 2053 4666 
+Q 2838 4666 3239 4311 
+Q 3641 3956 3641 3272 
+Q 3641 2581 3239 2228 
+Q 2838 1875 2053 1875 
+L 1259 1875 
+L 1259 0 
+L 628 0 
+L 628 4666 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-30" d="M 2034 4250 
+Q 1547 4250 1301 3770 
+Q 1056 3291 1056 2328 
+Q 1056 1369 1301 889 
+Q 1547 409 2034 409 
+Q 2525 409 2770 889 
+Q 3016 1369 3016 2328 
+Q 3016 3291 2770 3770 
+Q 2525 4250 2034 4250 
+z
+M 2034 4750 
+Q 2819 4750 3233 4129 
+Q 3647 3509 3647 2328 
+Q 3647 1150 3233 529 
+Q 2819 -91 2034 -91 
+Q 1250 -91 836 529 
+Q 422 1150 422 2328 
+Q 422 3509 836 4129 
+Q 1250 4750 2034 4750 
+z
+" transform="scale(0.015625)"/>
+      </defs>
+      <use xlink:href="#DejaVuSans-50"/>
+      <use xlink:href="#DejaVuSans-30" transform="translate(60.302734 0)"/>
+     </g>
+    </g>
+   </g>
+   <g id="text_2">
+    <g clip-path="url(#p18c191fc43)">
+     <!-- P1 -->
+     <g transform="translate(206.203906 150.2375) scale(0.1 -0.1)">
+      <defs>
+       <path id="DejaVuSans-31" d="M 794 531 
+L 1825 531 
+L 1825 4091 
+L 703 3866 
+L 703 4441 
+L 1819 4666 
+L 2450 4666 
+L 2450 531 
+L 3481 531 
+L 3481 0 
+L 794 0 
+L 794 531 
+z
+" transform="scale(0.015625)"/>
+      </defs>
+      <use xlink:href="#DejaVuSans-50"/>
+      <use xlink:href="#DejaVuSans-31" transform="translate(60.302734 0)"/>
+     </g>
+    </g>
+   </g>
+   <g id="text_3">
+    <g clip-path="url(#p18c191fc43)">
+     <!-- P2 -->
+     <g transform="translate(375.790683 150.2375) scale(0.1 -0.1)">
+      <defs>
+       <path id="DejaVuSans-32" d="M 1228 531 
+L 3431 531 
+L 3431 0 
+L 469 0 
+L 469 531 
+Q 828 903 1448 1529 
+Q 2069 2156 2228 2338 
+Q 2531 2678 2651 2914 
+Q 2772 3150 2772 3378 
+Q 2772 3750 2511 3984 
+Q 2250 4219 1831 4219 
+Q 1534 4219 1204 4116 
+Q 875 4013 500 3803 
+L 500 4441 
+Q 881 4594 1212 4672 
+Q 1544 4750 1819 4750 
+Q 2544 4750 2975 4387 
+Q 3406 4025 3406 3419 
+Q 3406 3131 3298 2873 
+Q 3191 2616 2906 2266 
+Q 2828 2175 2409 1742 
+Q 1991 1309 1228 531 
+z
+" transform="scale(0.015625)"/>
+      </defs>
+      <use xlink:href="#DejaVuSans-50"/>
+      <use xlink:href="#DejaVuSans-32" transform="translate(60.302734 0)"/>
+     </g>
+    </g>
+   </g>
+   <g id="text_4">
+    <!-- SSD visualisation -->
+    <g transform="translate(160.802812 16.318125) scale(0.12 -0.12)">
+     <defs>
+      <path id="DejaVuSans-53" d="M 3425 4513 
+L 3425 3897 
+Q 3066 4069 2747 4153 
+Q 2428 4238 2131 4238 
+Q 1616 4238 1336 4038 
+Q 1056 3838 1056 3469 
+Q 1056 3159 1242 3001 
+Q 1428 2844 1947 2747 
+L 2328 2669 
+Q 3034 2534 3370 2195 
+Q 3706 1856 3706 1288 
+Q 3706 609 3251 259 
+Q 2797 -91 1919 -91 
+Q 1588 -91 1214 -16 
+Q 841 59 441 206 
+L 441 856 
+Q 825 641 1194 531 
+Q 1563 422 1919 422 
+Q 2459 422 2753 634 
+Q 3047 847 3047 1241 
+Q 3047 1584 2836 1778 
+Q 2625 1972 2144 2069 
+L 1759 2144 
+Q 1053 2284 737 2584 
+Q 422 2884 422 3419 
+Q 422 4038 858 4394 
+Q 1294 4750 2059 4750 
+Q 2388 4750 2728 4690 
+Q 3069 4631 3425 4513 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-44" d="M 1259 4147 
+L 1259 519 
+L 2022 519 
+Q 2988 519 3436 956 
+Q 3884 1394 3884 2338 
+Q 3884 3275 3436 3711 
+Q 2988 4147 2022 4147 
+L 1259 4147 
+z
+M 628 4666 
+L 1925 4666 
+Q 3281 4666 3915 4102 
+Q 4550 3538 4550 2338 
+Q 4550 1131 3912 565 
+Q 3275 0 1925 0 
+L 628 0 
+L 628 4666 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-20" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-76" d="M 191 3500 
+L 800 3500 
+L 1894 563 
+L 2988 3500 
+L 3597 3500 
+L 2284 0 
+L 1503 0 
+L 191 3500 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-69" d="M 603 3500 
+L 1178 3500 
+L 1178 0 
+L 603 0 
+L 603 3500 
+z
+M 603 4863 
+L 1178 4863 
+L 1178 4134 
+L 603 4134 
+L 603 4863 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-73" d="M 2834 3397 
+L 2834 2853 
+Q 2591 2978 2328 3040 
+Q 2066 3103 1784 3103 
+Q 1356 3103 1142 2972 
+Q 928 2841 928 2578 
+Q 928 2378 1081 2264 
+Q 1234 2150 1697 2047 
+L 1894 2003 
+Q 2506 1872 2764 1633 
+Q 3022 1394 3022 966 
+Q 3022 478 2636 193 
+Q 2250 -91 1575 -91 
+Q 1294 -91 989 -36 
+Q 684 19 347 128 
+L 347 722 
+Q 666 556 975 473 
+Q 1284 391 1588 391 
+Q 1994 391 2212 530 
+Q 2431 669 2431 922 
+Q 2431 1156 2273 1281 
+Q 2116 1406 1581 1522 
+L 1381 1569 
+Q 847 1681 609 1914 
+Q 372 2147 372 2553 
+Q 372 3047 722 3315 
+Q 1072 3584 1716 3584 
+Q 2034 3584 2315 3537 
+Q 2597 3491 2834 3397 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-75" d="M 544 1381 
+L 544 3500 
+L 1119 3500 
+L 1119 1403 
+Q 1119 906 1312 657 
+Q 1506 409 1894 409 
+Q 2359 409 2629 706 
+Q 2900 1003 2900 1516 
+L 2900 3500 
+L 3475 3500 
+L 3475 0 
+L 2900 0 
+L 2900 538 
+Q 2691 219 2414 64 
+Q 2138 -91 1772 -91 
+Q 1169 -91 856 284 
+Q 544 659 544 1381 
+z
+M 1991 3584 
+L 1991 3584 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-61" d="M 2194 1759 
+Q 1497 1759 1228 1600 
+Q 959 1441 959 1056 
+Q 959 750 1161 570 
+Q 1363 391 1709 391 
+Q 2188 391 2477 730 
+Q 2766 1069 2766 1631 
+L 2766 1759 
+L 2194 1759 
+z
+M 3341 1997 
+L 3341 0 
+L 2766 0 
+L 2766 531 
+Q 2569 213 2275 61 
+Q 1981 -91 1556 -91 
+Q 1019 -91 701 211 
+Q 384 513 384 1019 
+Q 384 1609 779 1909 
+Q 1175 2209 1959 2209 
+L 2766 2209 
+L 2766 2266 
+Q 2766 2663 2505 2880 
+Q 2244 3097 1772 3097 
+Q 1472 3097 1187 3025 
+Q 903 2953 641 2809 
+L 641 3341 
+Q 956 3463 1253 3523 
+Q 1550 3584 1831 3584 
+Q 2591 3584 2966 3190 
+Q 3341 2797 3341 1997 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-6c" d="M 603 4863 
+L 1178 4863 
+L 1178 0 
+L 603 0 
+L 603 4863 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-74" d="M 1172 4494 
+L 1172 3500 
+L 2356 3500 
+L 2356 3053 
+L 1172 3053 
+L 1172 1153 
+Q 1172 725 1289 603 
+Q 1406 481 1766 481 
+L 2356 481 
+L 2356 0 
+L 1766 0 
+Q 1100 0 847 248 
+Q 594 497 594 1153 
+L 594 3053 
+L 172 3053 
+L 172 3500 
+L 594 3500 
+L 594 4494 
+L 1172 4494 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-6f" d="M 1959 3097 
+Q 1497 3097 1228 2736 
+Q 959 2375 959 1747 
+Q 959 1119 1226 758 
+Q 1494 397 1959 397 
+Q 2419 397 2687 759 
+Q 2956 1122 2956 1747 
+Q 2956 2369 2687 2733 
+Q 2419 3097 1959 3097 
+z
+M 1959 3584 
+Q 2709 3584 3137 3096 
+Q 3566 2609 3566 1747 
+Q 3566 888 3137 398 
+Q 2709 -91 1959 -91 
+Q 1206 -91 779 398 
+Q 353 888 353 1747 
+Q 353 2609 779 3096 
+Q 1206 3584 1959 3584 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-6e" d="M 3513 2113 
+L 3513 0 
+L 2938 0 
+L 2938 2094 
+Q 2938 2591 2744 2837 
+Q 2550 3084 2163 3084 
+Q 1697 3084 1428 2787 
+Q 1159 2491 1159 1978 
+L 1159 0 
+L 581 0 
+L 581 3500 
+L 1159 3500 
+L 1159 2956 
+Q 1366 3272 1645 3428 
+Q 1925 3584 2291 3584 
+Q 2894 3584 3203 3211 
+Q 3513 2838 3513 2113 
+z
+" transform="scale(0.015625)"/>
+     </defs>
+     <use xlink:href="#DejaVuSans-53"/>
+     <use xlink:href="#DejaVuSans-53" transform="translate(63.476562 0)"/>
+     <use xlink:href="#DejaVuSans-44" transform="translate(126.953125 0)"/>
+     <use xlink:href="#DejaVuSans-20" transform="translate(203.955078 0)"/>
+     <use xlink:href="#DejaVuSans-76" transform="translate(235.742188 0)"/>
+     <use xlink:href="#DejaVuSans-69" transform="translate(294.921875 0)"/>
+     <use xlink:href="#DejaVuSans-73" transform="translate(322.705078 0)"/>
+     <use xlink:href="#DejaVuSans-75" transform="translate(374.804688 0)"/>
+     <use xlink:href="#DejaVuSans-61" transform="translate(438.183594 0)"/>
+     <use xlink:href="#DejaVuSans-6c" transform="translate(499.462891 0)"/>
+     <use xlink:href="#DejaVuSans-69" transform="translate(527.246094 0)"/>
+     <use xlink:href="#DejaVuSans-73" transform="translate(555.029297 0)"/>
+     <use xlink:href="#DejaVuSans-61" transform="translate(607.128906 0)"/>
+     <use xlink:href="#DejaVuSans-74" transform="translate(668.408203 0)"/>
+     <use xlink:href="#DejaVuSans-69" transform="translate(707.617188 0)"/>
+     <use xlink:href="#DejaVuSans-6f" transform="translate(735.400391 0)"/>
+     <use xlink:href="#DejaVuSans-6e" transform="translate(796.582031 0)"/>
+    </g>
+   </g>
+  </g>
+ </g>
+ <defs>
+  <clipPath id="p18c191fc43">
+   <rect x="7.2" y="22.318125" width="410.4" height="250.32"/>
+  </clipPath>
+ </defs>
+</svg>

--- a/docs/examples/ssd_visualisation_minimal.py
+++ b/docs/examples/ssd_visualisation_minimal.py
@@ -1,0 +1,72 @@
+"""Minimal SSD partition visualisation focusing on partition structure."""
+
+from __future__ import annotations
+
+from argparse import ArgumentParser, Namespace
+from pathlib import Path
+from typing import Optional
+
+from quasar.circuit import Circuit
+from quasar.ssd import SSD
+
+from tools.ssd_visualisation import HighlightOptions, compute_layout, draw_ssd_matplotlib
+
+
+def build_minimal_ssd() -> SSD:
+    """Return a compact SSD with a few clearly separated partitions."""
+
+    circuit = Circuit(
+        [
+            {"gate": "H", "qubits": [0]},  # isolated single-qubit fragment
+            {"gate": "RX", "qubits": [2], "params": {"theta": 0.5}},  # non-Clifford fragment
+            {"gate": "CX", "qubits": [0, 1]},  # entangling bridge between partitions
+        ],
+        use_classical_simplification=False,
+    )
+    return circuit.ssd
+
+
+def _parse_args() -> Namespace:
+    parser = ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--output",
+        type=Path,
+        help="Optional path to save the rendered figure (format inferred from extension).",
+    )
+    return parser.parse_args()
+
+
+def render(output: Optional[Path]) -> None:  # pragma: no cover - exercised manually
+    """Render the SSD diagram, optionally writing it to disk."""
+
+    import matplotlib.pyplot as plt
+
+    ssd = build_minimal_ssd()
+    graph = ssd.to_networkx(include_conversions=False, include_backends=False)
+    layout = compute_layout(graph)
+
+    fig, ax = plt.subplots(figsize=(6, 4))
+    draw_ssd_matplotlib(
+        graph,
+        layout=layout,
+        highlight=HighlightOptions(long_range_threshold=None, boundary_qubit_threshold=None),
+        ax=ax,
+        node_size=700,
+    )
+    fig.tight_layout()
+
+    if output is not None:
+        output.parent.mkdir(parents=True, exist_ok=True)
+        fig.savefig(output, bbox_inches="tight")
+        plt.close(fig)
+    else:
+        plt.show()
+
+
+def main() -> None:  # pragma: no cover - exercised manually
+    args = _parse_args()
+    render(args.output)
+
+
+if __name__ == "__main__":  # pragma: no cover - module intended for manual execution
+    main()

--- a/docs/ssd_visualisation.md
+++ b/docs/ssd_visualisation.md
@@ -59,6 +59,33 @@ An executable demonstration is provided in
 Running the script will open a Matplotlib window highlighting the
 long-range entanglement between distant qubits.
 
+## Minimal partition-only layout
+
+For a compact example that focuses purely on partition structure, the
+[`docs/examples/ssd_visualisation_minimal.py`](examples/ssd_visualisation_minimal.py)
+script constructs a three-gate circuit consisting of two disjoint
+single-qubit fragments (`H` on qubit 0 and `RX` on qubit 2) and a single
+entangling `CX` acting on qubits 0 and 1.  Invoking
+``Circuit.ssd.to_networkx(include_conversions=False, include_backends=False)``
+removes conversion layers and backend nodes so the resulting SSD clearly
+shows how partitions connect.
+
+![Minimal SSD partition layout](data/ssd_visualisation_minimal.svg)
+
+In the rendered graph, partition ``P0`` represents the `H` gate on qubit 0
+and feeds into partition ``P2`` that contains the `CX` gate on qubits 0 and
+1, encoding the execution dependency introduced by the entangling
+operation.  Partition ``P1`` captures the `RX` rotation on qubit 2 and
+remains isolated because it manipulates a qubit that does not interact
+with the other fragments.
+
+Recreate the diagram with::
+
+    PYTHONPATH=. python docs/examples/ssd_visualisation_minimal.py --output docs/data/ssd_visualisation_minimal.svg
+
+The command emits the SVG used above, letting readers modify the circuit
+or plotting parameters to explore other partitioning outcomes.
+
 ## Filtering problematic regions
 
 Both rendering helpers accept :class:`HighlightOptions`.  Use the


### PR DESCRIPTION
## Summary
- add a compact SSD visualisation example that omits conversion edges
- generate and check in the corresponding SVG so the documentation can embed it
- expand the SSD visualisation guide with the simplified partition walkthrough

## Testing
- PYTHONPATH=. python docs/examples/ssd_visualisation_minimal.py --output docs/data/ssd_visualisation_minimal.svg

------
https://chatgpt.com/codex/tasks/task_e_68de6b402fd48321b2147a9c2daaa3b1