### PR TITLE
Add stitched SSD visualisation example

### DIFF
--- a/docs/examples/ssd_visualisation_stitched.py
+++ b/docs/examples/ssd_visualisation_stitched.py
@@ -1,0 +1,58 @@
+"""Visualise the SSD of a stitched benchmark circuit."""
+
+from __future__ import annotations
+
+import importlib
+from typing import Any, Sequence, cast
+
+from benchmarks.bench_utils import stitched_suite
+from quasar.circuit import Circuit
+
+
+def _require_module(module: str, package: str) -> Any:
+    """Import *module* or terminate with a helpful error message."""
+
+    try:
+        return importlib.import_module(module)
+    except ImportError as exc:  # pragma: no cover - exercised manually
+        raise SystemExit(
+            f"This example requires the '{package}' package. Install it to run the SSD visualisation."
+        ) from exc
+
+
+# Ensure the SSD helpers can be imported even when optional dependencies are missing.
+_require_module("networkx", "networkx")
+
+from tools.ssd_visualisation import HighlightOptions, compute_layout, draw_ssd_matplotlib, draw_ssd_plotly
+
+
+def render(width_index: int = 0) -> None:  # pragma: no cover - exercised manually in docs
+    """Render stitched SSD layouts with Matplotlib and Plotly."""
+
+    specs = stitched_suite.resolve_suite("stitched-big")
+    spec = specs[0]
+    widths: Sequence[int] = spec.widths
+    try:
+        width = widths[width_index]
+    except IndexError as exc:
+        raise ValueError(f"invalid width index {width_index!r}; available indices: 0..{len(widths) - 1}") from exc
+
+    circuit = cast(Circuit, spec.factory(width))
+    graph = circuit.to_networkx_ssd(include_conversions=True, include_backends=True)
+    layout = compute_layout(graph)
+    highlight = HighlightOptions(boundary_qubit_threshold=32, long_range_threshold=8, only_problematic=True)
+
+    plt = _require_module("matplotlib.pyplot", "matplotlib")
+    ax = draw_ssd_matplotlib(graph, layout=layout, highlight=highlight)
+    ax.set_title(f"{spec.display_name} (width={width})")
+    plt.tight_layout()
+    plt.show()
+
+    _require_module("plotly.graph_objects", "plotly")
+    fig = draw_ssd_plotly(graph, layout=layout, highlight=highlight)
+    fig.update_layout(title=f"{spec.display_name} (width={width})")
+    fig.show()
+
+
+if __name__ == "__main__":
+    render()

--- a/docs/ssd_visualisation.md
+++ b/docs/ssd_visualisation.md
@@ -59,6 +59,36 @@ An executable demonstration is provided in
 Running the script will open a Matplotlib window highlighting the
 long-range entanglement between distant qubits.
 
+## Stitched benchmark workflow
+
+Stitched benchmark circuits bundle several heterogeneous stages and
+produce substantially larger SSDs.  The helper script in
+[`docs/examples/ssd_visualisation_stitched.py`](examples/ssd_visualisation_stitched.py)
+illustrates the recommended workflow:
+
+1. Resolve the showcase definition with
+   ``stitched_suite.resolve_suite("stitched-big")`` and pick the desired
+   entry and width (e.g. ``spec.factory(spec.widths[0])``).
+2. Convert the resulting :class:`~quasar.circuit.Circuit` to a graph via
+   :meth:`Circuit.to_networkx_ssd`, keeping conversions and backend nodes
+   so that the stitched transitions remain visible.
+3. Derive a layout using :func:`compute_layout` and render either with
+   :func:`draw_ssd_matplotlib` for static figures or
+   :func:`draw_ssd_plotly` for interactive exploration.
+
+The stitched example guards all optional dependencies: ``networkx`` is
+required for the visualisation helpers, ``matplotlib`` powers the static
+plot and ``plotly`` enables the interactive view.  Install any missing
+packages before running the script.
+
+Large stitched graphs can overwhelm dense views.  Start with
+``HighlightOptions(only_problematic=True)`` and a generous
+``boundary_qubit_threshold`` to focus on bottlenecks, or increase the
+``partition_gap`` in :func:`compute_layout` to spread out the layout.
+When the figure still becomes cluttered, consider toggling
+``include_entanglement=False`` on :meth:`Circuit.to_networkx_ssd` to hide
+less critical edges and rely on the Plotly backend for targeted zooming.
+
 ## Filtering problematic regions
 
 Both rendering helpers accept :class:`HighlightOptions`.  Use the


### PR DESCRIPTION
## Summary
- add an executable SSD visualisation example for the stitched benchmark suite with guards for optional dependencies
- document the stitched workflow, required extras, and strategies for handling large SSD graphs

## Testing
- python -m compileall docs/examples/ssd_visualisation_stitched.py

------
https://chatgpt.com/codex/tasks/task_e_68de6b3b7e9883219ca2e2a480c48d4e