### PR TITLE
Add benchmark reuse flag and database caching support

### DIFF
--- a/tests/test_run_benchmark_cli.py
+++ b/tests/test_run_benchmark_cli.py
@@ -19,3 +19,8 @@ def test_parse_args_suite_conflicts_with_circuit() -> None:
 def test_parse_args_suite_conflicts_with_group() -> None:
     with pytest.raises(SystemExit):
         parse_args(["--suite", "stitched-big", "--group", "clustered"])
+
+
+def test_parse_args_accepts_reuse_flag() -> None:
+    args = parse_args(["--reuse-existing"])
+    assert args.reuse_existing is True


### PR DESCRIPTION
## Summary
- add a `--reuse-existing` flag to the showcase benchmark CLI and load cached measurements from the SQLite database when available
- expose the same reuse flow to `run_showcase_suite` so programmatic callers can skip reruns
- cover the new behaviour with targeted unit tests for the CLI argument parser and cache reuse helpers

## Testing
- pytest tests/test_run_benchmark_cli.py::test_parse_args_accepts_reuse_flag tests/test_showcase_benchmarks.py::test_run_showcase_benchmarks_reuses_existing tests/test_showcase_benchmarks.py::test_run_showcase_suite_reuses_existing

------
https://chatgpt.com/codex/tasks/task_e_68de7fed323c83219914edd750675b12